### PR TITLE
feat(engine): implement M1 deterministic directive engine

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,5 @@ repos:
     hooks:
       - id: mypy
         args: [--pretty]
-        additional_dependencies: []
+        additional_dependencies:
+          - hypothesis

--- a/docs/M1Design.md
+++ b/docs/M1Design.md
@@ -97,11 +97,18 @@ Accepted patterns:
 - "do not X"
 - "never X"
 - "avoid X"
+- "refrain from X"
 - "please don't X"
 
 Produces:
 
     POLICY_ADD(normalize(X))
+
+`"refrain from X"` is treated as a hard-negative directive and adds
+`normalize(X)` to `policies.prohibit`.
+
+For hard-negative directives, `normalize(X)` is applied to each policy
+payload item before storage.
 
 #### 5.2 Hard Positive Directives
 
@@ -117,6 +124,8 @@ Produces:
     FACT_SET(key="focus.device", value=X)
 
 “Using” statements set the current discussion focus, not inventory.
+Hard-positive directives store fact values as opaque strings and do not
+apply `normalize(X)` to the stored fact value.
 
 #### 5.3 Correction Markers
 
@@ -143,6 +152,8 @@ Produces:
     POLICY_REMOVE(normalize(X))
 
 If X not present → no-op.
+For allow/removal directives, `normalize(X)` is applied to each policy
+payload item used for removal matching.
 
 #### 5.5 List Handling
 
@@ -166,6 +177,17 @@ For exclusive predicates:
 5. Normalize apostrophes (`dont` → `don't`)
 
 No stemming, synonym mapping, ontology, or semantic interpretation.
+
+Policy payloads (add/remove) use `normalize(X)` exactly as defined above.
+
+Fact values do not use `normalize(X)`. They may receive minimal input
+sanitation only:
+
+1. Unicode normalization
+2. Apostrophe normalization
+3. Whitespace collapse
+
+Fact sanitation does not include lowercasing or leading-article removal.
 
 ### 7. Ambiguity Handling
 

--- a/src/context_compiler/__init__.py
+++ b/src/context_compiler/__init__.py
@@ -1,0 +1,3 @@
+from .engine import Decision, Engine, State, create_engine
+
+__all__ = ["Decision", "Engine", "State", "create_engine"]

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -1,0 +1,374 @@
+"""Deterministic M1 state engine for explicit user directive handling.
+
+This module provides a small, model-independent state machine that parses
+high-confidence directives and emits host decisions without invoking an LLM.
+Only explicit user directives can mutate authoritative state.
+"""
+
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Literal, TypedDict
+from unicodedata import normalize as unicode_normalize
+
+FactsState = TypedDict("FactsState", {"focus.device": str | None})
+
+
+class PoliciesState(TypedDict):
+    prohibit: list[str]
+
+
+class State(TypedDict):
+    """Versioned authoritative state; future versions may add new fields."""
+
+    facts: FactsState
+    policies: PoliciesState
+    version: Literal[1]
+
+
+class Decision(TypedDict):
+    kind: Literal["passthrough", "update", "clarify"]
+    state: State | None
+    prompt_to_user: str | None
+
+
+@dataclass(frozen=True)
+class PendingEvent:
+    kind: Literal["policy_add", "policy_remove", "fact_set", "reset_policies", "clear_state"]
+    values: tuple[str, ...] = ()
+    fact_value: str | None = None
+    requires_confirmation: bool = False
+
+
+@dataclass(frozen=True)
+class NegativeDirectiveRule:
+    starter: str
+    kind: Literal["policy_add"]
+    strip_leading_use: bool
+
+
+_RESET_POLICY = {"reset policies", "clear constraints"}
+_CLEAR_STATE = {"clear state"}
+
+_CORRECTION_RE = re.compile(r"^\s*(actually|i meant|correction:|no,)\s*(.*?)\s*$", re.IGNORECASE)
+_POSITIVE_RE = re.compile(
+    r"^\s*(?:use|set|i\s+am\s+using|i['’]m\s+using)\s+(.+?)\s*$", re.IGNORECASE
+)
+_ALLOW_PREFIX_RE = re.compile(r"^\s*(?:allow|you\s+can)\s+(.+?)\s*$", re.IGNORECASE)
+_ALLOW_SUFFIX_RE = re.compile(r"^\s*(.+?)\s+is\s+fine\s*$", re.IGNORECASE)
+
+_AMBIGUOUS_NEGATIVE_RE = re.compile(r"^\s*(?:don\s+use|no\s+use)\s+(.+?)\s*$", re.IGNORECASE)
+_SPLIT_RE = re.compile(r",|\s+and\s+", re.IGNORECASE)
+
+_PASSTHROUGH: Decision = {
+    "kind": "passthrough",
+    "state": None,
+    "prompt_to_user": None,
+}
+
+_NEGATIVE_DIRECTIVE_RULES: tuple[NegativeDirectiveRule, ...] = (
+    NegativeDirectiveRule(starter="please don't ", kind="policy_add", strip_leading_use=True),
+    NegativeDirectiveRule(starter="don't ", kind="policy_add", strip_leading_use=True),
+    NegativeDirectiveRule(starter="do not ", kind="policy_add", strip_leading_use=True),
+    NegativeDirectiveRule(starter="never ", kind="policy_add", strip_leading_use=True),
+    NegativeDirectiveRule(starter="refrain from ", kind="policy_add", strip_leading_use=False),
+    NegativeDirectiveRule(starter="avoid ", kind="policy_add", strip_leading_use=False),
+)
+
+
+def create_engine() -> "Engine":
+    """Create a new deterministic Engine instance with initial M1 state."""
+    return Engine()
+
+
+class Engine:
+    """Deterministic state engine implementing M1 directive semantics."""
+
+    def __init__(self) -> None:
+        self._state: State = _initial_state()
+        self._pending: PendingEvent | None = None
+        self._pending_prompt: str | None = None
+        self._last_exclusive_fact_key: str | None = None
+
+    @property
+    def state(self) -> State:
+        """Return a defensive copy of the current authoritative state snapshot."""
+        return deepcopy(self._state)
+
+    def step(self, user_input: str) -> Decision:
+        """Process one user input and return a deterministic Decision."""
+        if self._pending is not None:
+            return self._resolve_or_reprompt_pending(user_input)
+
+        classified = self._classify(user_input)
+
+        if isinstance(classified, dict):
+            return classified
+
+        if not classified.requires_confirmation:
+            return self._apply_pending(classified)
+
+        self._pending = classified
+        self._pending_prompt = _pending_prompt(classified)
+        return _clarify(self._pending_prompt)
+
+    def _classify(self, user_input: str) -> PendingEvent | Decision:
+        normalized_message = _normalize_message(user_input)
+
+        if normalized_message in _RESET_POLICY:
+            return PendingEvent(kind="reset_policies")
+
+        if normalized_message in _CLEAR_STATE:
+            return PendingEvent(kind="clear_state")
+
+        correction = _parse_correction(user_input)
+        if correction is not None:
+            if self._last_exclusive_fact_key is None:
+                return _clarify(
+                    "I don't have a previous focus setting to correct. What should focus.device be?"
+                )
+            if not correction.strip():
+                return _clarify("What should focus.device be?")
+            if _has_multiple_values(correction):
+                return _clarify("Corrections for focus.device must contain one value.")
+            if _invalid_exclusive_value(correction):
+                return _clarify("Corrections for focus.device must contain one value.")
+            return PendingEvent(kind="fact_set", fact_value=correction)
+
+        policy_add = _parse_hard_negative(normalized_message)
+        if policy_add is not None:
+            if not policy_add:
+                return _clarify("What should I prohibit?")
+            return PendingEvent(kind="policy_add", values=tuple(policy_add))
+
+        policy_remove = _parse_allow(user_input)
+        if policy_remove is not None:
+            if not policy_remove:
+                return _clarify("What should I allow?")
+            return PendingEvent(kind="policy_remove", values=tuple(policy_remove))
+
+        positive_value = _parse_hard_positive(user_input, normalized_message)
+        if positive_value is not None:
+            if not positive_value.strip():
+                return _clarify("What should focus.device be?")
+            if _has_multiple_values(positive_value):
+                return _clarify("focus.device accepts one value. Please provide a single value.")
+            if _invalid_exclusive_value(positive_value):
+                return _clarify("focus.device value is unclear. Please provide one value.")
+            return PendingEvent(kind="fact_set", fact_value=positive_value)
+
+        pending = _parse_ambiguous_mutation(user_input)
+        if pending is not None:
+            if len(pending.values) != 1:
+                return _clarify("Your directive was unclear. Please specify one item.")
+            return PendingEvent(
+                kind=pending.kind,
+                values=pending.values,
+                fact_value=pending.fact_value,
+                requires_confirmation=True,
+            )
+
+        return _PASSTHROUGH.copy()
+
+    def _resolve_or_reprompt_pending(self, user_input: str) -> Decision:
+        assert self._pending is not None
+        pending = self._pending
+        response = _normalize_message(user_input)
+
+        if response == "yes":
+            self._pending = None
+            self._pending_prompt = None
+            return self._apply_pending(pending)
+
+        if response == "no":
+            self._pending = None
+            self._pending_prompt = None
+            return _PASSTHROUGH.copy()
+
+        prompt = self._pending_prompt or "Please answer yes or no."
+        return _clarify(f"{prompt} Please answer yes or no.")
+
+    def _apply_pending(self, pending: PendingEvent) -> Decision:
+        return self._apply_event(pending)
+
+    def _apply_event(self, event: PendingEvent) -> Decision:
+        """Apply a PendingEvent to authoritative state."""
+        if event.kind == "policy_add":
+            return self._add_policies(list(event.values))
+        if event.kind == "policy_remove":
+            return self._remove_policies(list(event.values))
+        if event.kind == "fact_set":
+            assert event.fact_value is not None
+            return self._set_focus_device(event.fact_value)
+        if event.kind == "reset_policies":
+            self._state = _initial_state()
+            self._last_exclusive_fact_key = None
+            return _update_decision(self._state)
+
+        self._state = _initial_state()
+        self._last_exclusive_fact_key = None
+        return _update_decision(self._state)
+
+    def _set_focus_device(self, value: str) -> Decision:
+        self._state["facts"]["focus.device"] = _clean_fact_value(value)
+        self._last_exclusive_fact_key = "focus.device"
+        return _update_decision(self._state)
+
+    def _add_policies(self, values: list[str]) -> Decision:
+        existing = set(self._state["policies"]["prohibit"])
+        for value in values:
+            existing.add(value)
+        self._state["policies"]["prohibit"] = sorted(existing)
+        return _update_decision(self._state)
+
+    def _remove_policies(self, values: list[str]) -> Decision:
+        existing = set(self._state["policies"]["prohibit"])
+        for value in values:
+            existing.discard(value)
+        self._state["policies"]["prohibit"] = sorted(existing)
+        return _update_decision(self._state)
+
+
+def _initial_state() -> State:
+    return {
+        "facts": {"focus.device": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def _clarify(prompt: str) -> Decision:
+    return {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": prompt,
+    }
+
+
+def _update_decision(state: State) -> Decision:
+    return {
+        "kind": "update",
+        "state": deepcopy(state),
+        "prompt_to_user": None,
+    }
+
+
+def _normalize_message(text: str) -> str:
+    normalized = unicode_normalize("NFKC", text).lower().strip()
+    normalized = normalized.replace("’", "'").replace("`", "'")
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = re.sub(r"\bdont\b", "don't", normalized)
+    return normalized
+
+
+def _clean_fact_value(value: str) -> str:
+    normalized = unicode_normalize("NFKC", value).strip()
+    normalized = normalized.replace("’", "'").replace("`", "'")
+    return re.sub(r"\s+", " ", normalized)
+
+
+def _normalize_item(text: str) -> str:
+    item = _normalize_message(text)
+    item = re.sub(r"^(?:a|an|the)\s+", "", item)
+    return item.strip()
+
+
+def _split_items(text: str) -> list[str]:
+    pieces = _SPLIT_RE.split(text)
+    values: list[str] = []
+    for piece in pieces:
+        normalized = _normalize_item(piece)
+        if normalized:
+            values.append(normalized)
+    return values
+
+
+def _has_multiple_values(text: str) -> bool:
+    pieces = _SPLIT_RE.split(text)
+    non_empty = [piece.strip() for piece in pieces if piece.strip()]
+    return len(non_empty) > 1
+
+
+def _invalid_exclusive_value(text: str) -> bool:
+    lowered = _normalize_message(text)
+    return (
+        lowered.startswith("and ")
+        or lowered.startswith("or ")
+        or lowered == "and"
+        or lowered == "or"
+    )
+
+
+def _parse_correction(user_input: str) -> str | None:
+    match = _CORRECTION_RE.match(user_input)
+    if not match:
+        return None
+    return match.group(2)
+
+
+def _parse_hard_negative(normalized_message: str) -> list[str] | None:
+    msg = normalized_message
+
+    for rule in _NEGATIVE_DIRECTIVE_RULES:
+        if not msg.startswith(rule.starter):
+            continue
+
+        payload = msg[len(rule.starter) :].strip()
+        if rule.strip_leading_use:
+            payload = re.sub(r"^use\s+", "", payload, count=1)
+        return _split_items(payload)
+
+    return None
+
+
+def _parse_hard_positive(user_input: str, normalized_message: str) -> str | None:
+    if not (
+        normalized_message.startswith("use ")
+        or normalized_message.startswith("set ")
+        or normalized_message.startswith("i am using ")
+        or normalized_message.startswith("i'm using ")
+    ):
+        return None
+
+    candidate = user_input.strip()
+    if re.match(r"(?i)^please\s+", candidate):
+        candidate = re.sub(r"(?i)^please\s+", "", candidate, count=1)
+
+    match = _POSITIVE_RE.match(candidate)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _parse_allow(user_input: str) -> list[str] | None:
+    match_prefix = _ALLOW_PREFIX_RE.match(user_input)
+    if match_prefix:
+        return _split_items(match_prefix.group(1))
+
+    match_suffix = _ALLOW_SUFFIX_RE.match(user_input)
+    if match_suffix:
+        return _split_items(match_suffix.group(1))
+
+    return None
+
+
+def _parse_ambiguous_mutation(user_input: str) -> PendingEvent | None:
+    match = _AMBIGUOUS_NEGATIVE_RE.match(user_input)
+    if not match:
+        return None
+
+    values = _split_items(match.group(1))
+    if values:
+        return PendingEvent(kind="policy_add", values=tuple(values))
+
+    return None
+
+
+def _pending_prompt(pending: PendingEvent) -> str:
+    if pending.kind == "policy_add" and pending.values:
+        return f"Did you mean to prohibit '{pending.values[0]}'?"
+    if pending.kind == "policy_remove" and pending.values:
+        return f"Did you mean to allow '{pending.values[0]}'?"
+    if pending.kind == "fact_set" and pending.fact_value is not None:
+        return f"Did you mean to set focus.device to '{pending.fact_value}'?"
+    return "Your directive was unclear. Did you mean to change state?"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from context_compiler import create_engine
+
+
+def test_directive_parsing_positive_negative_and_allow() -> None:
+    engine = create_engine()
+
+    decision1 = engine.step("use Nord Stage 4")
+    assert decision1["kind"] == "update"
+    assert engine.state["facts"]["focus.device"] == "Nord Stage 4"
+
+    decision2 = engine.step("please don't use the parallel octaves and a voice crossing")
+    assert decision2["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["parallel octaves", "voice crossing"]
+
+    decision3 = engine.step("allow voice crossing")
+    assert decision3["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["parallel octaves"]
+
+
+def test_hard_negative_dont_use_stores_item_without_use_prefix() -> None:
+    engine = create_engine()
+
+    decision = engine.step("don't use docker")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["docker"]
+
+
+def test_hard_negative_avoid_use_keeps_use_token() -> None:
+    engine = create_engine()
+
+    decision = engine.step("avoid use docker")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["use docker"]
+
+
+def test_correction_replaces_most_recent_exclusive_fact() -> None:
+    engine = create_engine()
+
+    engine.step("I am using Nord Stage 3")
+    decision = engine.step("actually Nord Stage 4")
+
+    assert decision["kind"] == "update"
+    assert engine.state["facts"]["focus.device"] == "Nord Stage 4"
+
+
+def test_correction_without_prior_exclusive_fact_requires_clarification() -> None:
+    engine = create_engine()
+
+    decision = engine.step("correction: Nord Stage 4")
+
+    assert decision["kind"] == "clarify"
+    assert engine.state["facts"]["focus.device"] is None
+
+
+def test_policy_additions_are_sorted_unique_and_removal_is_noop_when_absent() -> None:
+    engine = create_engine()
+
+    engine.step("avoid voice crossing")
+    engine.step("avoid the parallel octaves")
+    decision = engine.step("avoid voice crossing")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["parallel octaves", "voice crossing"]
+
+    decision2 = engine.step("allow docker")
+    assert decision2["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["parallel octaves", "voice crossing"]
+
+
+def test_ambiguity_returns_clarify_and_does_not_mutate() -> None:
+    engine = create_engine()
+
+    decision = engine.step("don use parallel octaves")
+
+    assert decision["kind"] == "clarify"
+    assert engine.state == {
+        "facts": {"focus.device": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_ambiguous_multi_item_directive_requires_clarification() -> None:
+    engine = create_engine()
+
+    decision = engine.step("no use docker and parallel octaves")
+
+    assert decision["kind"] == "clarify"
+    assert engine.state == {
+        "facts": {"focus.device": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_correction_does_not_bypass_pending_clarification() -> None:
+    engine = create_engine()
+
+    # create ambiguity
+    decision1 = engine.step("no use docker")
+    assert decision1["kind"] == "clarify"
+
+    # attempt correction while pending
+    decision2 = engine.step("actually avoid docker")
+
+    assert decision2["kind"] == "clarify"
+    assert engine.state == {
+        "facts": {"focus.device": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_yes_no_passthrough_without_pending_clarification() -> None:
+    engine = create_engine()
+    before = engine.state
+
+    decision_yes = engine.step("yes")
+    assert decision_yes["kind"] == "passthrough"
+    assert engine.state == before
+
+    decision_no = engine.step("no")
+    assert decision_no["kind"] == "passthrough"
+    assert engine.state == before
+
+
+def test_pending_reprompts_on_non_yes_no() -> None:
+    engine = create_engine()
+    engine.step("no use docker")
+    before = engine.state
+
+    d = engine.step("maybe")
+    assert d["kind"] == "clarify"
+    assert engine.state == before
+
+
+def test_pending_clarification_blocks_other_mutations_until_resolved() -> None:
+    engine = create_engine()
+
+    decision1 = engine.step("no use docker")
+    assert decision1["kind"] == "clarify"
+
+    decision2 = engine.step("use Nord Stage 4")
+    assert decision2["kind"] == "clarify"
+    assert engine.state["facts"]["focus.device"] is None
+    assert engine.state["policies"]["prohibit"] == []
+
+    decision3 = engine.step("yes")
+    assert decision3["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["docker"]
+    assert engine.state["facts"]["focus.device"] is None
+
+
+def test_reset_commands() -> None:
+    engine = create_engine()
+
+    engine.step("use Nord Stage 4")
+    engine.step("avoid parallel octaves")
+
+    decision1 = engine.step("reset policies")
+    assert decision1["kind"] == "update"
+    assert engine.state == {
+        "facts": {"focus.device": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+    engine.step("use Nord Stage 4")
+    engine.step("avoid parallel octaves")
+
+    decision_constraints = engine.step("clear constraints")
+    assert decision_constraints["kind"] == "update"
+    assert engine.state == {
+        "facts": {"focus.device": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+    engine.step("use Nord Stage 4")
+    engine.step("avoid parallel octaves")
+
+    decision2 = engine.step("clear state")
+    assert decision2["kind"] == "update"
+    assert engine.state == {
+        "facts": {"focus.device": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_passthrough_input_does_not_mutate_state() -> None:
+    engine = create_engine()
+    before = engine.state
+
+    decision = engine.step("hello there")
+
+    assert decision["kind"] == "passthrough"
+    assert engine.state == before
+
+
+def test_reset_policies_when_already_empty_resets_state() -> None:
+    engine = create_engine()
+
+    engine.step("use Nord Stage 4")
+
+    decision = engine.step("reset policies")
+
+    assert decision["kind"] == "update"
+    assert engine.state == {
+        "facts": {"focus.device": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_unicode_apostrophe_positive_directive() -> None:
+    engine = create_engine()
+
+    decision = engine.step("i’m using Nord Stage 4")
+
+    assert decision["kind"] == "update"
+    assert engine.state["facts"]["focus.device"] == "Nord Stage 4"
+
+
+def test_unicode_apostrophe_negative_directive() -> None:
+    engine = create_engine()
+
+    decision = engine.step("don’t use docker")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["docker"]
+
+
+def test_correction_with_empty_payload_clarifies() -> None:
+    engine = create_engine()
+
+    engine.step("use Nord Stage 3")
+    decision = engine.step("actually   ")
+
+    assert decision["kind"] == "clarify"
+
+
+def test_correction_with_invalid_conjunction_clarifies() -> None:
+    engine = create_engine()
+
+    engine.step("use Nord Stage 3")
+    decision = engine.step("actually and Nord")
+
+    assert decision["kind"] == "clarify"
+
+
+def test_pending_yes_with_whitespace_resolves() -> None:
+    engine = create_engine()
+
+    engine.step("no use docker")
+    decision = engine.step("   yes   ")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["docker"]
+
+
+def test_yes_after_non_pending_clarify_is_passthrough() -> None:
+    engine = create_engine()
+
+    decision1 = engine.step("no use docker and x")
+    assert decision1["kind"] == "clarify"
+
+    decision2 = engine.step("yes")
+
+    assert decision2["kind"] == "passthrough"
+    assert engine.state == {
+        "facts": {"focus.device": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_unicode_apostrophe_negative_directive_with_please() -> None:
+    engine = create_engine()
+
+    decision = engine.step("please don’t use docker")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["docker"]
+
+
+def test_refrain_from_does_not_strip_use_prefix() -> None:
+    engine = create_engine()
+
+    decision = engine.step("refrain from use docker")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["use docker"]
+
+
+def test_hard_negative_dont_without_apostrophe_updates_policy() -> None:
+    engine = create_engine()
+
+    decision = engine.step("dont use docker")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["docker"]
+
+
+def test_hard_negative_please_dont_without_apostrophe_updates_policy() -> None:
+    engine = create_engine()
+
+    decision = engine.step("please dont use docker")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["docker"]
+
+
+def test_hard_negative_dont_without_use_still_adds_policy() -> None:
+    engine = create_engine()
+
+    decision = engine.step("dont docker")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == ["docker"]

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import re
+
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from context_compiler import create_engine
+from context_compiler.engine import State, _has_multiple_values, _split_items
+
+
+def _run_sequence(inputs: list[str]) -> State:
+    engine = create_engine()
+    for item in inputs:
+        engine.step(item)
+    return engine.state
+
+
+def _clean(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip())
+
+
+@given(st.lists(st.text(max_size=40), min_size=0, max_size=20))
+def test_determinism_same_input_sequence_same_state(inputs: list[str]) -> None:
+    assert _run_sequence(inputs) == _run_sequence(inputs)
+
+
+@given(st.text(min_size=1, max_size=30))
+def test_policy_addition_is_idempotent(item: str) -> None:
+    engine = create_engine()
+
+    engine.step(f"avoid {item}")
+    once = list(engine.state["policies"]["prohibit"])
+
+    engine.step(f"avoid {item}")
+    twice = list(engine.state["policies"]["prohibit"])
+
+    assert twice == once
+
+
+@given(
+    st.from_regex(r"[A-Za-z0-9][A-Za-z0-9 ]{0,20}", fullmatch=True),
+    st.from_regex(r"[A-Za-z0-9][A-Za-z0-9 ]{0,20}", fullmatch=True),
+)
+def test_exclusive_fact_replacement_last_write_wins(first: str, second: str) -> None:
+    assume(" and " not in first.lower() and "," not in first)
+    assume(" and " not in second.lower() and "," not in second)
+
+    engine = create_engine()
+
+    engine.step(f"use {first}")
+    engine.step(f"use {second}")
+
+    assert engine.state["facts"]["focus.device"] == _clean(second)
+
+
+@given(
+    st.sampled_from(
+        [
+            "don use parallel octaves",
+            "dnot use docker",
+            "i using nord",
+            "allow",
+            "set",
+            "no use docker",
+            "do n't use x",
+            "use and set",
+        ]
+    )
+)
+def test_safety_near_miss_inputs_do_not_mutate_state(text: str) -> None:
+    engine = create_engine()
+    before = engine.state
+
+    decision = engine.step(text)
+
+    assert decision["kind"] != "update"
+    assert engine.state == before
+
+
+@given(st.from_regex(r"[a-z]{1,10}-and-[a-z]{1,10}", fullmatch=True))
+def test_hyphenated_and_token_not_split(token: str) -> None:
+    engine = create_engine()
+
+    decision = engine.step(f"avoid {token}")
+
+    assert decision["kind"] == "update"
+    assert engine.state["policies"]["prohibit"] == [token]
+
+
+@given(st.from_regex(r"[A-Za-z0-9][A-Za-z0-9 ]{0,20}", fullmatch=True))
+def test_please_use_is_not_a_supported_positive_directive(value: str) -> None:
+    assume("," not in value)
+    assume(" and " not in value.lower())
+
+    engine = create_engine()
+    before = engine.state
+    decision = engine.step(f"please use {value}")
+
+    assert decision["kind"] != "update"
+    assert engine.state == before
+
+
+@given(st.text(max_size=80))
+def test_split_and_has_multiple_values_are_consistent(text: str) -> None:
+    non_empty = [item for item in _split_items(text) if item]
+    assert _has_multiple_values(text) == (len(non_empty) > 1)


### PR DESCRIPTION
Add deterministic state engine for explicit user directives.

- implement Engine, State, and Decision model
- support directive grammar including "refrain from X"
- add unit tests and Hypothesis property tests
- align specification documents with implementation
- update pre-commit so mypy can import Hypothesis