### PR TITLE
Add demo LLM pacing CLI and improve provider-throttling UXCodex/more demo cleanup

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -15,13 +15,15 @@ Install demo dependencies:
 pip install -e .[demos]
 ```
 
-Environment variables:
+Environment variables (OpenAI-compatible API):
 
 - `MODEL` (optional; default: `gpt-4.1-mini`)
 - `OPENAI_API_KEY` (required)
-- `OPENAI_BASE_URL` (optional; use for OpenAI-compatible local servers)
+- `OPENAI_BASE_URL` (optional; use for local or alternative endpoints)
 
-Ollama example:
+Example: locally hosted OpenAI-compatible endpoint (Ollama)
+
+Any locally hosted OpenAI-compatible endpoint will work (for example Ollama, LM Studio, or a llama.cpp server).
 
 ```bash
 export OPENAI_BASE_URL=http://localhost:11434/v1
@@ -55,6 +57,24 @@ Run all demos with detailed traces:
 ```bash
 uv run python -m demos.run_demo all --verbose
 ```
+
+Run demos with pacing for low-quota providers:
+
+```bash
+uv run python -m demos.run_demo all --llm-delay 1.5
+```
+
+### Provider throttling
+
+The demos make multiple LLM requests and may trigger rate limits on very low-quota hosted providers (especially free tiers).
+
+If you encounter throttling, you can slow requests using:
+
+```bash
+uv run python -m demos.run_demo all --llm-delay 1.5
+```
+
+Running against a local OpenAI-compatible endpoint avoids provider rate limits.
 
 ## Output modes
 

--- a/demos/llm_client.py
+++ b/demos/llm_client.py
@@ -39,6 +39,7 @@ class DemoLLMError(RuntimeError):
 
 _RETRY_DELAYS_SECONDS = (1, 2, 4)
 MAX_DEMO_RETRY_AFTER_SECONDS = 5
+DEFAULT_LLM_DELAY_SECONDS = 0.0
 
 
 def _is_model_not_found(exc_text: str, exc_name: str) -> bool:
@@ -136,6 +137,12 @@ def _retry_after_seconds_from_text(exc_text: str) -> int | None:
     return None
 
 
+def _configured_delay_seconds(delay_seconds: float) -> float:
+    if delay_seconds > 0:
+        return delay_seconds
+    return DEFAULT_LLM_DELAY_SECONDS
+
+
 def load_config() -> LLMConfig:
     """Load OpenAI-compatible configuration from environment variables."""
     base_url = os.getenv("OPENAI_BASE_URL")
@@ -173,19 +180,26 @@ def _build_openai_client(config: LLMConfig) -> Any:
 
 
 def complete_messages(
-    messages: list[Message], *, model: str | None = None, temperature: float = 0.0
+    messages: list[Message],
+    *,
+    model: str | None = None,
+    delay_seconds: float = 0,
 ) -> str:
     """Send exact message list to chat completions and return the text output."""
     config = load_config()
     client = _build_openai_client(config)
     target_model = model or config.model
+    configured_delay = _configured_delay_seconds(delay_seconds)
 
     for attempt in range(len(_RETRY_DELAYS_SECONDS) + 1):
         try:
+            if configured_delay > 0:
+                time.sleep(configured_delay)
             # Demos require deterministic decoding so PASS/FAIL results are reproducible.
             response = client.chat.completions.create(
                 model=target_model,
                 messages=messages,
+                # Intentionally hard-coded for deterministic demo behavior.
                 temperature=0,
                 top_p=1,
             )

--- a/demos/run_demo.py
+++ b/demos/run_demo.py
@@ -6,6 +6,7 @@ import runpy
 import sys
 from pathlib import Path
 
+import demos.llm_client as llm_client
 from demos.common import (
     VERBOSE_ENV_VAR,
     DemoReport,
@@ -13,7 +14,10 @@ from demos.common import (
     consume_last_info_report,
     consume_last_report,
 )
-from demos.llm_client import DemoLLMError, MissingDemoConfigError
+from demos.llm_client import (
+    DemoLLMError,
+    MissingDemoConfigError,
+)
 
 DEMO_FILES: dict[str, str] = {
     "1": "01_llm_constraint_drift.py",
@@ -41,19 +45,24 @@ def _print_compiler_regression_warning() -> None:
     print("baseline succeeded but compiler-mediated version failed")
 
 
-def _run(path: Path, *, verbose: bool) -> tuple[DemoReport | None, InfoReport | None]:
+def _run(
+    path: Path, *, verbose: bool, llm_delay: float
+) -> tuple[DemoReport | None, InfoReport | None]:
     if verbose:
         print(f"===== Running {_verbose_demo_label(path)} =====")
-    old_value = os.getenv(VERBOSE_ENV_VAR)
+    old_verbose = os.getenv(VERBOSE_ENV_VAR)
+    old_delay = llm_client.DEFAULT_LLM_DELAY_SECONDS
     os.environ[VERBOSE_ENV_VAR] = "1" if verbose else "0"
+    llm_client.DEFAULT_LLM_DELAY_SECONDS = llm_delay if llm_delay > 0 else 0.0
     try:
         runpy.run_path(str(path), run_name="__main__")
         return consume_last_report(), consume_last_info_report()
     finally:
-        if old_value is None:
+        if old_verbose is None:
             os.environ.pop(VERBOSE_ENV_VAR, None)
         else:
-            os.environ[VERBOSE_ENV_VAR] = old_value
+            os.environ[VERBOSE_ENV_VAR] = old_verbose
+        llm_client.DEFAULT_LLM_DELAY_SECONDS = old_delay
 
 
 def _print_config_error(exc: MissingDemoConfigError) -> None:
@@ -90,6 +99,12 @@ def main() -> None:
         action="store_true",
         help="Show detailed prompts, compiler decisions, and model output excerpts.",
     )
+    parser.add_argument(
+        "--llm-delay",
+        type=float,
+        default=0,
+        help="Delay between LLM calls in seconds (useful for low-quota providers).",
+    )
     args = parser.parse_args()
 
     if args.demo == "all":
@@ -103,7 +118,9 @@ def main() -> None:
             if index > 0 and not args.verbose:
                 print()
             try:
-                result, info_report = _run(root / DEMO_FILES[key], verbose=args.verbose)
+                result, info_report = _run(
+                    root / DEMO_FILES[key], verbose=args.verbose, llm_delay=args.llm_delay
+                )
             except MissingDemoConfigError as exc:
                 _print_config_error(exc)
                 raise SystemExit(2) from exc
@@ -163,7 +180,9 @@ def main() -> None:
         return
 
     try:
-        result, _ = _run(root / DEMO_FILES[args.demo], verbose=args.verbose)
+        result, _ = _run(
+            root / DEMO_FILES[args.demo], verbose=args.verbose, llm_delay=args.llm_delay
+        )
     except MissingDemoConfigError as exc:
         _print_config_error(exc)
         raise SystemExit(2) from exc

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -225,3 +225,21 @@ def test_complete_messages_uses_gemini_retry_delay_field(
     assert result == "ok"
     assert delays == [1]
     assert "[retry] LLM rate limit hit — retrying in 1s..." in stderr
+
+
+def test_complete_messages_applies_delay_seconds_before_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_client, "load_config", _fake_config)
+    monkeypatch.setattr(
+        llm_client,
+        "_build_openai_client",
+        lambda _config: _FakeClient([_FakeResponse("ok")]),
+    )
+    delays: list[float] = []
+    monkeypatch.setattr(llm_client.time, "sleep", lambda seconds: delays.append(seconds))
+
+    result = complete_messages([{"role": "user", "content": "hello"}], delay_seconds=1.5)
+
+    assert result == "ok"
+    assert delays == [1.5]

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -40,9 +40,10 @@ def test_runner_prints_per_demo_compiler_regression_warning(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     def fake_run(
-        path: Path, *, verbose: bool
+        path: Path, *, verbose: bool, llm_delay: float
     ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
         assert not verbose
+        assert llm_delay == 0
         print("01_fake — regression fixture")
         print("baseline: PASS")
         print("compiler: FAIL")
@@ -72,9 +73,10 @@ def test_runner_prints_summary_regression_banner_in_all_mode(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     def fake_run(
-        path: Path, *, verbose: bool
+        path: Path, *, verbose: bool, llm_delay: float
     ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
         assert not verbose
+        assert llm_delay == 0
         if path.name == "fake_01.py":
             print("01_fake — regression fixture")
             print("baseline: PASS")
@@ -107,9 +109,10 @@ def test_runner_prints_plural_summary_regression_banner_in_all_mode(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     def fake_run(
-        path: Path, *, verbose: bool
+        path: Path, *, verbose: bool, llm_delay: float
     ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
         assert not verbose
+        assert llm_delay == 0
         if path.name in {"fake_01.py", "fake_02.py"}:
             print(f"{path.stem} — regression fixture")
             print("baseline: PASS")
@@ -146,9 +149,10 @@ def test_informational_demo_is_non_scored_in_all_mode(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     def fake_run(
-        path: Path, *, verbose: bool
+        path: Path, *, verbose: bool, llm_delay: float
     ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
         assert not verbose
+        assert llm_delay == 0
         if path.name == "fake_01.py":
             print("01_fake — pass fixture")
             print("baseline: PASS")
@@ -185,8 +189,9 @@ def test_runner_prints_friendly_demo_llm_error_in_single_mode(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     def fake_run(
-        path: Path, *, verbose: bool
+        path: Path, *, verbose: bool, llm_delay: float
     ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
+        assert llm_delay == 0
         raise DemoLLMError(
             "Model 'bad-model' was not found at the configured endpoint. "
             "Check MODEL or OPENAI_BASE_URL."
@@ -212,9 +217,10 @@ def test_all_mode_scored_none_result_counts_as_failures(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     def fake_run(
-        path: Path, *, verbose: bool
+        path: Path, *, verbose: bool, llm_delay: float
     ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
         assert not verbose
+        assert llm_delay == 0
         if path.name == "fake_01.py":
             return None, None
         print("06_context_compaction — superseded directives eliminated")
@@ -240,9 +246,10 @@ def test_all_mode_counts_baseline_fail_and_compiler_pass(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     def fake_run(
-        path: Path, *, verbose: bool
+        path: Path, *, verbose: bool, llm_delay: float
     ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
         assert not verbose
+        assert llm_delay == 0
         if path.name == "fake_01.py":
             print("01_fake — mixed fixture")
             print("baseline: FAIL")
@@ -283,3 +290,24 @@ def test_compaction_demo_reports_sane_metrics() -> None:
     assert report["baseline_prompt_length"] > report["compiled_prompt_length"]
     assert report["context_reduction_percent"] > 0
     assert report["prompt_reduction_percent"] > 0
+
+
+def test_runner_passes_llm_delay_from_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, float] = {}
+
+    def fake_run(
+        path: Path, *, verbose: bool, llm_delay: float
+    ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
+        assert path.name == "fake_06.py"
+        assert not verbose
+        captured["llm_delay"] = llm_delay
+        return None, None
+
+    monkeypatch.setattr(run_demo, "DEMO_FILES", {"6": "fake_06.py"})
+    monkeypatch.setattr(run_demo, "SCORED_DEMOS", {"1", "2", "3", "4", "5"})
+    monkeypatch.setattr(run_demo, "_run", fake_run)
+    monkeypatch.setattr("sys.argv", ["run_demo", "6", "--llm-delay", "1.25"])
+
+    run_demo.main()
+
+    assert captured["llm_delay"] == 1.25


### PR DESCRIPTION
Adds --llm-delay to demos/run_demo.py to pace LLM calls for low-quota providers.
Wires delay into demos/llm_client.py so calls can be intentionally slowed without changing demo logic.
Keeps deterministic decoding explicit (temperature=0, top_p=1) and preserves existing retry/error behavior.
Improves demos/README.md wording around OpenAI-compatible endpoints and adds a short provider throttling section with mitigation guidance.
Updates deterministic tests for runner/LLM client pacing behavior.