### PR TITLE
feat: enforce 0.4 mixed-directive and pending-confirmation clarificat…

### DIFF
--- a/docs/M1Design.md
+++ b/docs/M1Design.md
@@ -142,6 +142,17 @@ Accepted markers:
 
 Corrections apply only to the most recently updated exclusive
 fact. If no such fact exists → clarification required.
+Correction payloads must represent a fact replacement value. If a
+correction payload appears to invoke another directive family (for
+example hard-negative directives, allow/removal directives, or
+reset/clear commands) → clarification required and no state mutation.
+
+Example:
+
+    use Nord Stage 4
+    actually don't use docker
+
+→ `Decision.kind = "clarify"` and state remains unchanged.
 
 #### 5.4 Allow / Removal Directives
 
@@ -200,6 +211,9 @@ If a message might mutate state but is unclear:
     Decision.kind = "clarify"
     Decision.prompt_to_user = clarification question
 
+This includes correction payloads that appear to invoke another
+directive family.
+
 Examples:
 
 - "don use parallel octaves"
@@ -223,11 +237,42 @@ Resolution:
 |              |               |
 |--------------|---------------|
 | **Response** | Action        |
-| yes          | apply event   |
-| no           | discard event |
+| affirmative confirmation token | apply event   |
+| negative confirmation token    | discard event |
 
-If no pending exists → yes/no is passthrough.
-While pending exists, no other mutation may occur.
+Confirmation parsing takes precedence over all other directive parsing
+while pending clarification exists.
+
+A pending clarification resolves only when normalized user input exactly
+matches one of the confirmation tokens.
+
+Normalization for pending confirmation matching:
+
+1. Trim surrounding whitespace
+2. Lowercase
+3. Collapse internal whitespace to single spaces
+4. Remove trailing punctuation: `. , ! ?`
+
+Accepted affirmative confirmation tokens:
+
+- `yes`
+- `yes please`
+- `yep`
+- `yeah`
+- `sure`
+- `ok`
+- `okay`
+
+Accepted negative confirmation tokens:
+
+- `no`
+- `nope`
+- `no thanks`
+
+If no pending exists → confirmation tokens are passthrough.
+If normalized input does not match a confirmation token while pending
+exists, the compiler remains in clarify, does not trigger other
+directive parsing, and does not mutate state.
 
 ### 9. State Update Semantics
 

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -90,6 +90,10 @@ _ALLOW_SUFFIX_RE = re.compile(r"^\s*(.+?)\s+is\s+fine\s*$", re.IGNORECASE)
 
 _AMBIGUOUS_NEGATIVE_RE = re.compile(r"^\s*(?:don\s+use|no\s+use)\s+(.+?)\s*$", re.IGNORECASE)
 _SPLIT_RE = re.compile(r",|\s+and\s+", re.IGNORECASE)
+_TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
+
+_AFFIRMATIVE_CONFIRMATIONS = {"yes", "yes please", "yep", "yeah", "sure", "ok", "okay"}
+_NEGATIVE_CONFIRMATIONS = {"no", "nope", "no thanks"}
 
 _PASSTHROUGH: Decision = {
     "kind": DecisionKind.PASSTHROUGH,
@@ -201,6 +205,9 @@ class Engine:
     def _classify(self, user_input: str) -> PendingEvent | Decision:
         normalized_message = _normalize_message(user_input)
 
+        if _has_mixed_directive_families(user_input):
+            return _clarify("Your directive mixes multiple directive types. Please provide one.")
+
         if normalized_message in _RESET_POLICY:
             return PendingEvent(kind=EVENT_RESET_POLICIES)
 
@@ -211,6 +218,8 @@ class Engine:
         if correction is not None:
             if self._last_exclusive_fact_key is None:
                 return _clarify_no_prior_change(correction)
+            if _correction_payload_invokes_other_directive_family(correction):
+                return _clarify("Corrections must provide a replacement value to use.")
             if not correction.strip():
                 return _clarify_missing_value()
             if _has_multiple_values(correction):
@@ -257,14 +266,14 @@ class Engine:
     def _resolve_or_reprompt_pending(self, user_input: str) -> Decision:
         assert self._pending is not None
         pending = self._pending
-        response = _normalize_message(user_input)
+        response = _normalize_confirmation(user_input)
 
-        if response == "yes":
+        if response in _AFFIRMATIVE_CONFIRMATIONS:
             self._pending = None
             self._pending_prompt = None
             return self._apply_pending(pending)
 
-        if response == "no":
+        if response in _NEGATIVE_CONFIRMATIONS:
             self._pending = None
             self._pending_prompt = None
             return _PASSTHROUGH.copy()
@@ -422,6 +431,12 @@ def _normalize_message(text: str) -> str:
     return normalized
 
 
+def _normalize_confirmation(text: str) -> str:
+    normalized = _normalize_message(text)
+    normalized = _TRAILING_CONFIRM_PUNCT_RE.sub("", normalized).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
 def _clean_fact_value(value: str) -> str:
     normalized = unicode_normalize("NFKC", value).strip()
     normalized = normalized.replace("’", "'").replace("`", "'")
@@ -528,6 +543,64 @@ def _parse_ambiguous_mutation(user_input: str) -> PendingEvent | None:
         return PendingEvent(kind="policy_add", values=tuple(values))
 
     return None
+
+
+def _correction_payload_invokes_other_directive_family(payload: str) -> bool:
+    normalized_payload = _normalize_message(payload)
+    if not normalized_payload:
+        return False
+
+    if normalized_payload in _RESET_POLICY or normalized_payload in _CLEAR_STATE:
+        return True
+    if _parse_hard_negative(normalized_payload) is not None:
+        return True
+    if _parse_allow(payload) is not None:
+        return True
+    if _parse_hard_positive(payload, normalized_payload) is not None:
+        return True
+    return _parse_correction(payload) is not None
+
+
+def _classify_segment_family(segment: str) -> str | None:
+    normalized_segment = _normalize_message(segment)
+    if not normalized_segment:
+        return None
+
+    if normalized_segment in _RESET_POLICY:
+        return EVENT_RESET_POLICIES
+    if normalized_segment in _CLEAR_STATE:
+        return EVENT_CLEAR_STATE
+
+    if _parse_correction(segment) is not None:
+        return "correction"
+    if _parse_hard_negative(normalized_segment) is not None:
+        return "hard_negative"
+    if _parse_allow(segment) is not None:
+        return "allow_remove"
+    if _parse_hard_positive(segment, normalized_segment) is not None:
+        return "hard_positive"
+    return None
+
+
+def _has_mixed_directive_families(user_input: str) -> bool:
+    # Split by additive delimiters and detect directives independently per segment.
+    # Mixed families in one utterance are clarified to avoid partial execution.
+    segments = [piece.strip() for piece in _SPLIT_RE.split(user_input) if piece.strip()]
+    families: set[str] = set()
+    for segment in segments:
+        family = _classify_segment_family(segment)
+        if family is not None:
+            families.add(family)
+        if len(families) > 1:
+            return True
+
+    correction_payload = _parse_correction(user_input)
+    if correction_payload is not None and correction_payload.strip():
+        payload_family = _classify_segment_family(correction_payload)
+        if payload_family is not None and payload_family != "correction":
+            return True
+
+    return False
 
 
 def _pending_prompt(pending: PendingEvent) -> str:

--- a/tests/test_04_grammar_edge_cases.py
+++ b/tests/test_04_grammar_edge_cases.py
@@ -1,0 +1,253 @@
+import pytest
+
+from context_compiler import create_engine
+
+
+def test_clear_state_then_correction_requires_clarification() -> None:
+    engine = create_engine()
+    engine.step("use Nord Stage 4")
+    engine.step("clear state")
+
+    decision = engine.step("actually Nord Stage 3")
+
+    assert decision["kind"] == "clarify"
+    assert engine.state == {
+        "facts": {"focus.primary": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_pending_blocks_reset_policies_until_yes_no_resolution() -> None:
+    engine = create_engine()
+    first = engine.step("no use docker")
+    assert first["kind"] == "clarify"
+
+    decision = engine.step("reset policies")
+
+    assert decision["kind"] == "clarify"
+    assert (
+        decision["prompt_to_user"] == "Did you mean to prohibit 'docker'? Please answer yes or no."
+    )
+    assert engine.state == {
+        "facts": {"focus.primary": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_pending_blocks_clear_state_until_yes_no_resolution() -> None:
+    engine = create_engine()
+    first = engine.step("no use docker")
+    assert first["kind"] == "clarify"
+
+    decision = engine.step("clear state")
+
+    assert decision["kind"] == "clarify"
+    assert (
+        decision["prompt_to_user"] == "Did you mean to prohibit 'docker'? Please answer yes or no."
+    )
+    assert engine.state == {
+        "facts": {"focus.primary": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_pending_blocks_allow_until_yes_no_resolution() -> None:
+    engine = create_engine()
+    first = engine.step("no use docker")
+    assert first["kind"] == "clarify"
+
+    decision = engine.step("allow docker")
+
+    assert decision["kind"] == "clarify"
+    assert (
+        decision["prompt_to_user"] == "Did you mean to prohibit 'docker'? Please answer yes or no."
+    )
+    assert engine.state == {
+        "facts": {"focus.primary": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_policy_then_fact_then_correction_targets_fact_not_policy() -> None:
+    engine = create_engine()
+    engine.step("don't use docker")
+    engine.step("use Nord Stage 4")
+
+    decision = engine.step("actually Nord Stage 3")
+
+    assert decision["kind"] == "update"
+    assert engine.state == {
+        "facts": {"focus.primary": "Nord Stage 3"},
+        "policies": {"prohibit": ["docker"]},
+        "version": 1,
+    }
+
+
+def test_i_meant_marker_behaves_like_actually() -> None:
+    engine = create_engine()
+    engine.step("use Nord Stage 4")
+
+    decision = engine.step("I meant Nord Stage 3")
+
+    assert decision["kind"] == "update"
+    assert engine.state == {
+        "facts": {"focus.primary": "Nord Stage 3"},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_no_comma_marker_behaves_like_actually_when_fact_exists() -> None:
+    engine = create_engine()
+    engine.step("use Nord Stage 4")
+
+    decision = engine.step("no, Nord Stage 3")
+
+    assert decision["kind"] == "update"
+    assert engine.state == {
+        "facts": {"focus.primary": "Nord Stage 3"},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_mixed_positive_and_negative_in_one_utterance_requires_clarify() -> None:
+    engine = create_engine()
+    engine.step("use baseline")
+    before = engine.state
+
+    decision = engine.step("use Nord Stage 4 and don't use docker")
+
+    assert decision["kind"] == "clarify"
+    assert engine.state == before
+
+
+def test_mixed_negative_and_allow_in_one_utterance_requires_clarify() -> None:
+    engine = create_engine()
+    engine.step("use baseline")
+    before = engine.state
+
+    decision = engine.step("don't use docker and allow shellfish")
+
+    assert decision["kind"] == "clarify"
+    assert engine.state == before
+
+
+def test_mixed_allow_and_negative_in_one_utterance_requires_clarify() -> None:
+    engine = create_engine()
+    engine.step("don't use shellfish")
+    before = engine.state
+
+    decision = engine.step("allow docker and don't use shellfish")
+
+    assert decision["kind"] == "clarify"
+    assert engine.state == before
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "yes",
+        "YES",
+        "yes.",
+        "yes!",
+        "yes!!!",
+        "yes please",
+        "Yes please.",
+        "  yes   please  ",
+        "yep",
+        "yeah!",
+        "sure",
+        "SURE!",
+        "ok",
+        "OK.",
+        "okay",
+        "Okay!",
+    ],
+)
+def test_pending_confirmation_accepts_affirmative_variants(response: str) -> None:
+    engine = create_engine()
+    engine.step("no use docker")
+
+    decision = engine.step(response)
+
+    assert decision["kind"] == "update"
+    assert engine.state == {
+        "facts": {"focus.primary": None},
+        "policies": {"prohibit": ["docker"]},
+        "version": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "no",
+        "NO",
+        "no.",
+        "no!",
+        "no!!",
+        "no!!!",
+        "no!!!!!",
+        "nope",
+        "no thanks",
+        "no thanks!",
+        "  no   thanks!  ",
+    ],
+)
+def test_pending_confirmation_accepts_negative_variants(response: str) -> None:
+    engine = create_engine()
+    before = engine.state
+    engine.step("no use docker")
+
+    decision = engine.step(response)
+
+    assert decision["kind"] == "passthrough"
+    assert engine.state == before
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "yes maybe",
+        "yeah maybe",
+        "sure maybe",
+        "ok maybe",
+        "no maybe",
+        "maybe",
+        "sounds good",
+        "works for me",
+        "y",
+        "n",
+    ],
+)
+def test_pending_confirmation_rejects_non_matching_phrases(response: str) -> None:
+    engine = create_engine()
+    engine.step("no use docker")
+
+    decision = engine.step(response)
+
+    assert decision["kind"] == "clarify"
+    assert (
+        decision["prompt_to_user"] == "Did you mean to prohibit 'docker'? Please answer yes or no."
+    )
+    assert engine.state == {
+        "facts": {"focus.primary": None},
+        "policies": {"prohibit": []},
+        "version": 1,
+    }
+
+
+def test_correction_payload_that_looks_like_command_requires_clarify() -> None:
+    engine = create_engine()
+    engine.step("use Nord Stage 4")
+    before = engine.state
+
+    decision = engine.step("actually don't use docker")
+
+    assert decision["kind"] == "clarify"
+    assert engine.state == before


### PR DESCRIPTION
…ion semantics

- clarify (no mutation) when a single utterance mixes directive families (hard positive, hard negative, allow/removal, reset/clear, correction)
- clarify (no mutation) when correction payload invokes another directive family (e.g. "actually don't use docker", "actually allow docker", "actually reset policies")
- expand pending-confirmation resolution vocabulary with exact normalized matching (affirmative: yes/yes please/yep/yeah/sure/ok/okay; negative: no/nope/no thanks)
- normalize pending confirmations by trimming, lowercasing, collapsing whitespace, and stripping trailing . , ! ? punctuation (including repeated punctuation)
- update M1 spec sections for correction-marker and pending-clarification rules
- add/strengthen grammar edge-case tests for mixed-family directives, correction payloads, confirmation token acceptance, and non-matching phrase rejection