### PR TITLE
fix: remove top_p for broader provider compatibility

### DIFF
--- a/demos/llm_client.py
+++ b/demos/llm_client.py
@@ -201,7 +201,6 @@ def complete_messages(
                 messages=messages,
                 # Intentionally hard-coded for deterministic demo behavior.
                 temperature=0,
-                top_p=1,
             )
             break
         except Exception as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.4.0"
+version = "0.4.1"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed
- Removed  from demo chat completion requests in demos/llm_client.py
- Kept deterministic decoding via 
- Bumped package version to 0.4.1 in pyproject.toml
- Updated uv.lock package version metadata to 0.4.1

## Why
Some OpenAI-compatible providers reject requests that specify both temperature and top_p. Removing  top_p preserves deterministic demo behavior while improving provider compatibility.