### PR TITLE
docs: refine readme evidence flow and openwebui comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,12 +238,6 @@ For full directive grammar and edge-case behavior, see [DirectiveGrammarSpec.md]
 
 ---
 
-## Conformance Fixtures
-
-Cross-language conformance tests are defined in [`tests/fixtures/`](tests/fixtures/).
-
----
-
 ## Guarantees
 
 - State changes only through explicit user directives or confirmation.
@@ -288,6 +282,8 @@ These demonstrate deterministic clarification, state enforcement, and conflict h
 - [LLM preprocessor](docs/llm-preprocessor.md)
 - [Multiple engines](docs/multi-engine.md)
 
+For a full documentation map, see [docs/README.md](docs/README.md).
+
 ---
 
 ## Design Notes
@@ -296,6 +292,12 @@ More detailed design and milestone documents are available in:
 
 - [Project overview](docs/DescriptionAndMilestones.md)
 - [Directive grammar specification](docs/DirectiveGrammarSpec.md)
+
+---
+
+## Conformance Fixtures
+
+Cross-language conformance tests are defined in [`tests/fixtures/`](tests/fixtures/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -88,17 +88,57 @@ The host supplies the authoritative state to the model so the constraint persist
 
 ---
 
-## Evidence (cross-model runs)
+## Deterministic behavior (examples)
 
-Behavior was evaluated using a fixed set of deterministic [demo scenarios](demos/).
+LLMs interpret intent. Context Compiler enforces it.
 
-A run is considered a "pass" if the model output satisfies the scenario’s expected behavior.
+**Near-miss directive**
+```text
+set premise to concise replies
+```
+- Base model: silently accepts / rewrites
+- Context Compiler: clarifies (“Did you mean 'set premise concise replies'?”)
+
+**State-dependent operation**
+```text
+clear state
+use podman instead of docker
+```
+- Base model: generic explanation
+- Context Compiler: rejects (“No exact policy found for 'docker'…”)
+
+**Lifecycle enforcement**
+```text
+clear state
+change premise to formal tone
+```
+- Base model: conversational rewrite guidance
+- Context Compiler: clarifies (“No premise exists yet…”)
+
+---
+
+## Evidence
+
+### Behavioral correctness (key examples)
+
+Concrete behavioral comparisons (base model vs compiler) are available here:
+
+- [Open WebUI integration README](examples/integrations/openwebui/README.md)
+
+These demonstrate deterministic clarification, state enforcement, and conflict handling.
+
+### Cross-model evaluation
 
 - Models tested: `llama3.1:8b`, `gpt-4o-mini`, `gpt-4.1`, `gpt-5`, `claude-sonnet-4`, `claude-opus-4`
-- Demo scenarios (all pass with compiler) cover ambiguity handling, constraint persistence, correction replacement, and tool governance.
 - Pass-rate summary: baseline (LLM only) `2–4 / 6`; with compiler `6 / 6`; with compiler + compaction `6 / 6`.
+
+### Efficiency
+
 - Context reduction in long conversations: up to `99%`
 - Prompt size reduction: about `50%`
+
+### Additional results
+
 - [SWE curated results (compiler vs baseline)](evals/swe-bench/README.md) — cross-model evaluation on 6 tasks showing mostly positive deltas
 
 ---

--- a/README.md
+++ b/README.md
@@ -117,30 +117,6 @@ change premise to formal tone
 
 ---
 
-## Evidence
-
-### Behavioral correctness (key examples)
-
-Concrete behavioral comparisons (base model vs compiler) are available here:
-
-- [Open WebUI integration README](examples/integrations/openwebui/README.md)
-
-These demonstrate deterministic clarification, state enforcement, and conflict handling.
-
-### Cross-model evaluation
-
-- Models tested: `llama3.1:8b`, `gpt-4o-mini`, `gpt-4.1`, `gpt-5`, `claude-sonnet-4`, `claude-opus-4`
-- Pass-rate summary: baseline (LLM only) `2–4 / 6`; with compiler `6 / 6`; with compiler + compaction `6 / 6`.
-
-### Efficiency
-
-- Context reduction in long conversations: up to `99%`
-- Prompt size reduction: about `50%`
-
-### Additional results
-
-- [SWE curated results (compiler vs baseline)](evals/swe-bench/README.md) — cross-model evaluation on 6 tasks showing mostly positive deltas
-
 ---
 
 ## Architecture
@@ -268,13 +244,6 @@ Cross-language conformance tests are defined in [`tests/fixtures/`](tests/fixtur
 
 ---
 
-## Advanced topics
-
-- [LLM preprocessor](docs/llm-preprocessor.md)
-- [Multiple engines](docs/multi-engine.md)
-
----
-
 ## Guarantees
 
 - State changes only through explicit user directives or confirmation.
@@ -283,6 +252,41 @@ Cross-language conformance tests are defined in [`tests/fixtures/`](tests/fixtur
 - Ambiguous directives trigger clarification instead of changing state.
 
 These invariants are verified through behavioral tests and Hypothesis-based property tests.
+
+---
+
+## Evidence
+
+### Behavioral correctness (key examples)
+
+Concrete behavioral comparisons (base model vs compiler) are available here:
+
+- [Open WebUI integration README](examples/integrations/openwebui/README.md)
+
+These demonstrate deterministic clarification, state enforcement, and conflict handling.
+
+### Cross-model evaluation
+
+- Models tested: `llama3.1:8b`, `gpt-4o-mini`, `gpt-4.1`, `gpt-5`, `claude-sonnet-4`, `claude-opus-4`
+- Pass-rate summary: baseline (LLM only) `2–4 / 6`; with compiler `6 / 6`; with compiler + compaction `6 / 6`.
+
+### Efficiency
+
+- Context reduction in long conversations: up to `99%`
+- Prompt size reduction: about `50%`
+
+### Additional results
+
+- [SWE curated results (compiler vs baseline)](evals/swe-bench/README.md) — cross-model evaluation on 6 tasks showing mostly positive deltas
+
+
+---
+
+
+## Advanced topics
+
+- [LLM preprocessor](docs/llm-preprocessor.md)
+- [Multiple engines](docs/multi-engine.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ The host supplies the authoritative state to the model so the constraint persist
 
 LLMs interpret intent. Context Compiler enforces it.
 
-**Near-miss directive**
+**Explicit directive**
 ```text
-set premise to concise replies
+set premise concise replies
 ```
 - Base model: silently accepts / rewrites
-- Context Compiler: clarifies (“Did you mean 'set premise concise replies'?”)
+- Context Compiler: applies a deterministic state update
 
 **State-dependent operation**
 ```text

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,20 @@
-# Documentation
+# Documentation Index
 
-This directory contains the project design and milestone specifications.
+## Start Here
+- [Project README](../README.md)
 
-- [DescriptionAndMilestones.md](DescriptionAndMilestones.md) — project overview and milestone roadmap
-- [DirectiveGrammarSpec.md](DirectiveGrammarSpec.md) — authoritative behavioral specification for the deterministic directive engine
+## Core Concepts
+- [Directive Grammar](DirectiveGrammarSpec.md)
+
+## Integrations
+- [Open WebUI integration](../examples/integrations/openwebui/README.md)
+
+## Preprocessor
+- [LLM preprocessor](llm-preprocessor.md)
+
+## Evaluation & Evidence
+- [Behavioral comparisons (Open WebUI)](../examples/integrations/openwebui/README.md)
+- [SWE curated results](../evals/swe-bench/README.md)
+
+## Project Background
+- [Description and Milestones](DescriptionAndMilestones.md)

--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -47,3 +47,45 @@ If not set, the example will safely fall back to no-directive behavior.
 ## Manual Validation
 
 Validate clarify short-circuit, passthrough forwarding, update injection with one `[[cc_state]]`, no accumulation across repeated updates, chat isolation with real chat ids, restart state loss, and non-text bypass behavior.
+
+## Behavioral comparisons
+
+**Case 1**
+
+- prompt(s): `clear state` → `change premise to formal tone`
+- base model: “To adjust the tone… provide the original content…”
+- basic pipe: `No premise exists yet. Use 'set premise ...' first.`
+- preprocessor pipe: `No premise exists yet. Use 'set premise ...' first.`
+- why this is a real win: lifecycle rule is enforced deterministically; base model drifts into generic rewriting help.
+
+**Case 2**
+
+- prompt(s): `clear state` → `use docker` → `prohibit docker`
+- base model: generic Docker/prohibition guidance text
+- basic pipe: `'docker' is already in use. Only one policy per item is allowed. Use 'reset policies' to change it.`
+- preprocessor pipe: same conflict clarify
+- why this is a real win: explicit conflict semantics are preserved instead of conversational interpretation.
+
+**Case 3**
+
+- prompt(s): `clear state` → `use podman instead of docker`
+- base model: generic “how to switch to Podman” tutorial
+- basic pipe: `No exact policy found for "docker". Replacement requires an exact policy match...`
+- preprocessor pipe: same replacement clarify
+- why this is a real win: replacement precondition (old item must exist) is enforced.
+
+**Case 4**
+
+- prompt(s): `clear state` → `set premise to concise replies` → `set premise formal tone`
+- base model: accepts both as conversational style requests
+- basic pipe: `Did you mean 'set premise concise replies'?` then conversational formal-tone rewrite
+- preprocessor pipe: `Premise set: Concise replies.` then `Premise already exists...`
+- why this is a real win: preprocessor canonicalizes near-miss form and preserves premise-slot semantics end-to-end.
+
+**Case 5**
+
+- prompt(s): `clear state` → `change premise concise replies`
+- base model: generic “please clarify changes” response
+- basic pipe: `Did you mean 'change premise to concise replies'?`
+- preprocessor pipe: `No premise exists yet. Use 'set premise ...' first.`
+- why this is a real win: preprocessor upgrades near-miss form and reaches the correct lifecycle clarify state instead of stopping at syntax clarify.


### PR DESCRIPTION
## What changed (unmerged commits only)
- Updated README evidence wording and section flow.
- Reordered README sections to improve scan order.
- Added a docs index refinement in docs/README.md.
- Expanded/clarified behavioral comparison notes in examples/integrations/openwebui/README.md.
- Aligned a README directive example with canonical core grammar wording.

## Commit set in this PR
- 39437e6 docs: align readme directive example with core grammar
- 4e15914 docs: reorder trailing README sections
- b1f19b8 docs: refine documentation index map
- abe800c docs: reorder evidence section after guarantees
- b25decd docs: clarify evidence and openwebui behavioral comparisons

## Files changed vs main
- README.md
- docs/README.md
- examples/integrations/openwebui/README.md