### PR TITLE
chore: add release-gated stress workflow and nightly/manual stress runs

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,12 +3,6 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      stress_loops:
-        description: Number of full pytest stress loops to run before publish
-        required: false
-        default: "10"
 
 permissions:
   contents: read
@@ -18,8 +12,6 @@ jobs:
   stress-tests:
     name: Stress tests (release gate)
     runs-on: ubuntu-latest
-    env:
-      STRESS_LOOPS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stress_loops || '10' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -40,11 +32,7 @@ jobs:
       - name: Run pytest stress loop
         shell: bash
         run: |
-          loops="${STRESS_LOOPS}"
-          if ! [[ "$loops" =~ ^[1-9][0-9]*$ ]]; then
-            echo "Invalid stress loop count: $loops"
-            exit 1
-          fi
+          loops="10"
           for i in $(seq 1 "$loops"); do
             echo "== stress run $i/$loops =="
             uv run pytest -q

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -50,11 +50,13 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
       - name: Build sdist and wheel
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install build
-          python -m build
+        run: uv run --with build python -m build
 
       - name: Show built distributions
         run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,12 +4,52 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      stress_loops:
+        description: Number of full pytest stress loops to run before publish
+        required: false
+        default: "10"
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
+  stress-tests:
+    name: Stress tests (release gate)
+    runs-on: ubuntu-latest
+    env:
+      STRESS_LOOPS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stress_loops || '10' }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dev dependencies
+        run: uv sync --extra dev
+
+      - name: Run pytest stress loop
+        shell: bash
+        run: |
+          loops="${STRESS_LOOPS}"
+          if ! [[ "$loops" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid stress loop count: $loops"
+            exit 1
+          fi
+          for i in $(seq 1 "$loops"); do
+            echo "== stress run $i/$loops =="
+            uv run pytest -q
+          done
+
   build:
     name: Build distributions
     runs-on: ubuntu-latest
@@ -41,7 +81,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: build
+    needs: [build, stress-tests]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -1,0 +1,47 @@
+name: Stress Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      stress_loops:
+        description: Number of full pytest stress loops
+        required: false
+        default: "10"
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  stress-tests:
+    name: Stress tests
+    runs-on: ubuntu-latest
+    env:
+      STRESS_LOOPS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stress_loops || '10' }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dev dependencies
+        run: uv sync --extra dev
+
+      - name: Run pytest stress loop
+        shell: bash
+        run: |
+          loops="${STRESS_LOOPS}"
+          if ! [[ "$loops" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid stress loop count: $loops"
+            exit 1
+          fi
+          for i in $(seq 1 "$loops"); do
+            echo "== stress run $i/$loops =="
+            uv run pytest -q
+          done


### PR DESCRIPTION
## What changed
- Added a dedicated stress workflow: `.github/workflows/stress-tests.yml`.
  - Supports manual runs via `workflow_dispatch` with configurable `stress_loops`.
  - Runs nightly via `schedule`.
- Kept publish release-gated by stress tests in `.github/workflows/publish-pypi.yml`.
  - Publish workflow still runs stress checks before publishing.
  - Publish-side stress gate uses a fixed loop count for deterministic release behavior.
- Optimized publish build setup to use `uv` cache in the build job.
  - Added `astral-sh/setup-uv` with cache enabled.
  - Build command now uses `uv run --with build python -m build`.

## Why this change was needed
We wanted stress testing to be usable independently (manual + nightly) while still enforcing stress checks before release publish. This keeps normal CI fast, improves release confidence, and adds flexible operational stress coverage outside release events.

The publish build step update reduces repeated dependency setup overhead while keeping job isolation and release behavior unchanged.
