### PR TITLE
chore: install demos deps in stress workflows

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install dev dependencies
-        run: uv sync --extra dev
+      - name: Install dev and demos dependencies
+        run: uv sync --extra dev --extra demos
 
       - name: Run pytest stress loop
         shell: bash

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install dev dependencies
-        run: uv sync --extra dev
+      - name: Install dev and demos dependencies
+        run: uv sync --extra dev --extra demos
 
       - name: Run pytest stress loop
         shell: bash


### PR DESCRIPTION
## What changed
- Updated stress workflow dependency install to `uv sync --extra dev --extra demos`.
- Updated publish workflow stress-gate dependency install to `uv sync --extra dev --extra demos`.

## Why this change was needed
Stress runs were skipping `tests/test_llm_client.py` because `litellm` was not installed. Adding the `demos` extra ensures stress workflows include LiteLLM-dependent tests.
