### PR TITLE
refactor: migrate stable experimental preprocessor stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,6 @@ change premise to formal tone
 
 ---
 
----
-
 ## Architecture
 
 ```text
@@ -277,9 +275,23 @@ These demonstrate deterministic clarification, state enforcement, and conflict h
 ---
 
 
+## Optional: LLM Preprocessor (Experimental)
+
+An optional host-side preprocessor can convert natural-language instructions
+into canonical directives before compilation.
+
+It is designed to be conservative and must be used with validation:
+
+- heuristic-first, with LLM fallback when needed
+- all outputs must be validated with `parse_precompiler_output(...)`
+- raw outputs must not be passed directly to the compiler
+
+See [LLM preprocessor](docs/llm-preprocessor.md) and
+[`experimental/preprocessor/`](experimental/preprocessor/) for details.
+
+
 ## Advanced topics
 
-- [LLM preprocessor](docs/llm-preprocessor.md)
 - [Multiple engines](docs/multi-engine.md)
 
 For a full documentation map, see [docs/README.md](docs/README.md).

--- a/docs/llm-preprocessor.md
+++ b/docs/llm-preprocessor.md
@@ -11,6 +11,14 @@ maybe avoid docker but actually don't use docker anymore
 
 The compiler remains deterministic and authoritative. The preprocessor is optional and external.
 
+## Usage Recommendations
+
+- Default: use heuristic precompilation first, then validator, then LLM fallback.
+- This gives the safest behavior: deterministic structural handling plus conservative fallback.
+- Use LLM-only mode only when heuristic precompilation is unavailable.
+- In LLM-only mode, use stricter prompting and validate outputs before applying them.
+- Llama-family models are typically more interpretive in LLM-only mode and may require extra prompt strictness.
+
 ## What it does
 
 The preprocessor tries to:
@@ -45,6 +53,8 @@ Behavior:
 - replaces `<NULL_OR_VALUE>` with `null` or current premise
 - replaces `<SET OF CURRENT POLICY ITEMS>` with sorted policy keys or `(none)`
 - returns `None` if the file cannot be loaded
+
+LLM outputs should be validated before being applied to ensure they match allowed directive forms.
 
 ## Examples
 

--- a/docs/llm-preprocessor.md
+++ b/docs/llm-preprocessor.md
@@ -1,128 +1,37 @@
-# LLM Preprocessor (Optional)
+# LLM Preprocessor (Optional, Experimental)
 
-An LLM can be used as a preprocessor to convert natural language into canonical Context Compiler directives before compilation.
+The experimental preprocessor is an optional host-side layer that can convert
+natural-language messages into canonical Context Compiler directives before
+compilation.
 
-Example:
+The compiler remains deterministic and authoritative. The preprocessor does not
+replace core parsing or state semantics.
 
-```text
-maybe avoid docker but actually don't use docker anymore
-→ prohibit docker
-```
+## Required flow
 
-The compiler remains deterministic and authoritative. The preprocessor is optional and external.
+Recommended conceptual flow:
 
-## Usage Recommendations
+1. heuristic precompile
+2. validate candidate output
+3. LLM fallback precompile (only when needed)
+4. validate candidate output
+5. pass validated directive (or original input) to compiler
 
-- Default: use heuristic precompilation first, then validator, then LLM fallback.
-- This gives the safest behavior: deterministic structural handling plus conservative fallback.
-- Use LLM-only mode only when heuristic precompilation is unavailable.
-- In LLM-only mode, use stricter prompting and validate outputs before applying them.
-- Llama-family models are typically more interpretive in LLM-only mode and may require extra prompt strictness.
+All preprocessor outputs, including heuristic outputs, must be validated with
+`parse_precompiler_output(...)` before being applied.
 
-## What it does
+Raw heuristic/LLM outputs must not be passed directly to the compiler.
 
-The preprocessor tries to:
+## Limits
 
-- turn clear instructions into directives
-- ignore normal conversation
-- return `<NO_DIRECTIVE>` when unsure
+The preprocessor is best-effort and intentionally conservative. Ambiguous,
+reported, quoted, or mixed-intent inputs may still require abstention or host
+clarification behavior.
 
-It is designed to be conservative:
+## Status
 
-> if it is not clearly an instruction, it should do nothing.
+This preprocessor surface is experimental and may evolve independently of the
+core engine.
 
-## Prompt files
-
-Use prompt files from `experimental/preprocessor/prompts/`:
-
-- `default.txt` for most models
-- `llama.txt` for Llama-family models
-
-These files are the maintained prompt sources for host-side preprocessor use.
-
-## Prompt rendering helper
-
-Shared prompt rendering lives in `experimental/preprocessor/prompt_utils.py`:
-
-- `render_prompt(path: Path, state) -> str | None`
-
-Behavior:
-
-- reads the prompt file from `path`
-- strips leading `#` header comment lines and leading blank lines
-- replaces `<NULL_OR_VALUE>` with `null` or current premise
-- replaces `<SET OF CURRENT POLICY ITEMS>` with sorted policy keys or `(none)`
-- returns `None` if the file cannot be loaded
-
-LLM outputs should be validated before being applied to ensure they match allowed directive forms.
-
-## Examples
-
-```text
-use uv and not docker
-→ use uv instead of docker
-
-never use docker
-→ prohibit docker
-
-you can use docker now
-→ remove policy docker
-
-thanks
-→ <NO_DIRECTIVE>
-```
-
-## What to expect
-
-- Works well for clear instructions
-- Handles messy but obvious phrasing
-- Stronger models give cleaner results
-- Conservative prompting reduces false positives
-
-## Known limits
-
-Some inputs are inherently ambiguous or difficult to interpret. These fall into a few categories.
-
-### Clearly non-directive (should be ignored)
-
-- quoted or reported speech  
-  (`he said "use docker"`, `yesterday I said don't use docker`)
-
-These are mentions of directives, not instructions.
-
-### Ambiguous phrasing (may be interpreted either way)
-
-- descriptive statements  
-  (`I use docker`)
-- questions that imply intent  
-  (`can you switch from docker to podman?`)
-
-In normal conversation, these can function as indirect instructions, so models may reasonably interpret them as directives.
-
-### Conflicting instructions
-
-- multiple incompatible signals in one message  
-  (`use docker; actually don't use docker`)
-
-These require resolving intent, which is not always clear.
-
-The preprocessor is best-effort. It may occasionally extract a directive where none was intended, especially in ambiguous cases.
-
-The compiler remains the source of truth.
-
-## Model behavior
-
-The preprocessor relies on instruction-following behavior.
-
-In testing:
-
-- stronger models produced cleaner results
-- conservative prompting improved precision
-- some edge cases remained even on strong models
-
-## Summary
-
-- The preprocessor is helpful, but not required
-- It works best on clear instructions
-- Some inputs are inherently ambiguous
-- The compiler remains in control
+For concrete module usage, prompt guidance, and integration details, see:
+[`experimental/preprocessor/README.md`](../experimental/preprocessor/README.md).

--- a/docs/llm-preprocessor.md
+++ b/docs/llm-preprocessor.md
@@ -15,7 +15,8 @@ Recommended conceptual flow:
 2. validate candidate output
 3. LLM fallback precompile (only when needed)
 4. validate candidate output
-5. pass validated directive (or original input) to compiler
+5. If a valid directive is produced, pass it to the compiler.
+   Otherwise pass the original input unchanged.
 
 All preprocessor outputs, including heuristic outputs, must be validated with
 `parse_precompiler_output(...)` before being applied.

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -182,8 +182,10 @@ def _precompile_user_input(message: str, state: State) -> str | None:
             heuristic_result["outcome"] == PRECOMPILE_OUTCOME_DIRECTIVE
             and heuristic_result["directive"]
         ):
+            parsed = parse_precompiler_output(heuristic_result["directive"])
             logger.debug("preprocessor: heuristic_directive=%r", heuristic_result["directive"])
-            return heuristic_result["directive"]
+            if parsed is not None and parsed != PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+                return parsed
     except Exception:
         logger.debug("preprocessor: heuristic_exception", exc_info=True)
 

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -15,7 +15,6 @@ Intended host usage:
 
 import logging
 import os
-import re
 from collections.abc import Callable, Mapping, Sequence
 from importlib import import_module
 from pathlib import Path
@@ -23,20 +22,15 @@ from typing import TypedDict, cast
 
 from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
+from experimental.preprocessor.constants import (
+    PRECOMPILE_OUTCOME_DIRECTIVE,
+    PRECOMPILER_NO_DIRECTIVE_SENTINEL,
+)
 from experimental.preprocessor.heuristic_precompiler import precompile_heuristic
+from experimental.preprocessor.output_validation import parse_precompiler_output
 from experimental.preprocessor.prompt_utils import render_prompt
 
 logger = logging.getLogger(__name__)
-
-_ALLOWED_DIRECTIVE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"^set premise (?!to\b)\S(?:.*\S)?$"),
-    re.compile(r"^change premise to \S(?:.*\S)?$"),
-    re.compile(r"^use \S(?:.*\S)? instead of \S(?:.*\S)?$"),
-    re.compile(r"^use (?!.*\sinstead of(?:\s|$))\S(?:.*\S)?$"),
-    re.compile(r"^prohibit \S(?:.*\S)?$"),
-    re.compile(r"^remove policy \S(?:.*\S)?$"),
-)
-_ALLOWED_DIRECTIVE_EXACT = {"clear premise", "reset policies", "clear state"}
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _PROMPTS_DIR = _REPO_ROOT / "experimental" / "preprocessor" / "prompts"
@@ -133,26 +127,6 @@ def _call_litellm(messages: list[dict[str, str]]) -> str:
     return content
 
 
-def _normalize_precompiler_output(raw_output: object) -> str | None:
-    if not isinstance(raw_output, str):
-        return None
-    stripped = raw_output.strip()
-    if stripped.upper() == "<NO_DIRECTIVE>":
-        return "<NO_DIRECTIVE>"
-
-    non_empty_lines = [line.strip() for line in raw_output.splitlines() if line.strip()]
-    if non_empty_lines and non_empty_lines[-1].upper() == "<NO_DIRECTIVE>":
-        return "<NO_DIRECTIVE>"
-
-    return stripped
-
-
-def _is_allowed_directive(text: str) -> bool:
-    if text in _ALLOWED_DIRECTIVE_EXACT:
-        return True
-    return any(pattern.fullmatch(text) for pattern in _ALLOWED_DIRECTIVE_PATTERNS)
-
-
 def _prompt_file_path() -> Path:
     profile = os.getenv("PREPROCESSOR_PROMPT_PROFILE", "default").strip().lower()
     if profile == "llama":
@@ -193,10 +167,8 @@ def _llm_fallback_precompile(message: str, state: State) -> str | None:
     except Exception:
         return None
 
-    parsed = _normalize_precompiler_output(raw_output)
-    if parsed is None or parsed == "<NO_DIRECTIVE>" or not parsed:
-        return None
-    if not _is_allowed_directive(parsed):
+    parsed = parse_precompiler_output(raw_output)
+    if parsed is None or parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
         return None
     return parsed
 
@@ -206,7 +178,10 @@ def _precompile_user_input(message: str, state: State) -> str | None:
     try:
         heuristic_result = precompile_heuristic(message)
         logger.debug("preprocessor: heuristic_outcome=%s", heuristic_result["outcome"])
-        if heuristic_result["outcome"] == "directive" and heuristic_result["directive"]:
+        if (
+            heuristic_result["outcome"] == PRECOMPILE_OUTCOME_DIRECTIVE
+            and heuristic_result["directive"]
+        ):
             logger.debug("preprocessor: heuristic_directive=%r", heuristic_result["directive"])
             return heuristic_result["directive"]
     except Exception:

--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
@@ -180,7 +180,9 @@ def _precompile_last_user_message(message: str, state: State | None) -> str | No
             heuristic_result["outcome"] == PRECOMPILE_OUTCOME_DIRECTIVE
             and heuristic_result["directive"]
         ):
-            return heuristic_result["directive"]
+            parsed = parse_precompiler_output(heuristic_result["directive"])
+            if parsed is not None and parsed != PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+                return parsed
     except Exception:
         logger.debug("litellm_proxy: heuristic_exception", exc_info=True)
 

--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
@@ -9,38 +9,26 @@ Architecture:
 
 import logging
 import os
-import re
 from collections.abc import Callable, Mapping, Sequence
 from importlib import import_module
 from pathlib import Path
-from typing import Any, TypedDict, cast
+from typing import Any, cast
 
 from litellm.integrations.custom_logger import CustomLogger
 
 from context_compiler import State, compile_transcript, get_policy_items, get_premise_value
+from experimental.preprocessor.constants import (
+    PRECOMPILE_OUTCOME_DIRECTIVE,
+    PRECOMPILER_NO_DIRECTIVE_SENTINEL,
+)
 from experimental.preprocessor.heuristic_precompiler import precompile_heuristic
+from experimental.preprocessor.output_validation import parse_precompiler_output
 from experimental.preprocessor.prompt_utils import render_prompt
 
 logger = logging.getLogger(__name__)
 
-_ALLOWED_DIRECTIVE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"^set premise (?!to\b)\S(?:.*\S)?$"),
-    re.compile(r"^change premise to \S(?:.*\S)?$"),
-    re.compile(r"^use \S(?:.*\S)? instead of \S(?:.*\S)?$"),
-    re.compile(r"^use (?!.*\sinstead of(?:\s|$))\S(?:.*\S)?$"),
-    re.compile(r"^prohibit \S(?:.*\S)?$"),
-    re.compile(r"^remove policy \S(?:.*\S)?$"),
-)
-_ALLOWED_DIRECTIVE_EXACT = {"clear premise", "reset policies", "clear state"}
-
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _PROMPTS_DIR = _REPO_ROOT / "experimental" / "preprocessor" / "prompts"
-
-
-class PrecompileResult(TypedDict):
-    outcome: str
-    directive: str | None
-    rule_id: str | None
 
 
 def _render_compiled_state_contract(compiled_state: State) -> str:
@@ -97,21 +85,6 @@ def _extract_user_transcript(messages: list[dict[str, object]]) -> list[dict[str
     return transcript
 
 
-def _normalize_precompiler_output(raw_output: object) -> str | None:
-    if not isinstance(raw_output, str):
-        return None
-
-    stripped = raw_output.strip()
-    if stripped.upper() == "<NO_DIRECTIVE>":
-        return "<NO_DIRECTIVE>"
-
-    non_empty_lines = [line.strip() for line in raw_output.splitlines() if line.strip()]
-    if non_empty_lines and non_empty_lines[-1].upper() == "<NO_DIRECTIVE>":
-        return "<NO_DIRECTIVE>"
-
-    return stripped
-
-
 def _extract_response_content(response: object) -> str | None:
     if isinstance(response, Mapping):
         choices = response.get("choices")
@@ -133,12 +106,6 @@ def _extract_response_content(response: object) -> str | None:
             return content_attr
 
     return None
-
-
-def _is_allowed_directive(text: str) -> bool:
-    if text in _ALLOWED_DIRECTIVE_EXACT:
-        return True
-    return any(pattern.fullmatch(text) for pattern in _ALLOWED_DIRECTIVE_PATTERNS)
 
 
 def _prompt_file_path() -> Path:
@@ -190,10 +157,8 @@ def _llm_fallback_precompile(message: str, state: State) -> str | None:
     except Exception:
         return None
 
-    parsed = _normalize_precompiler_output(raw_output)
-    if parsed is None or parsed == "<NO_DIRECTIVE>" or not parsed:
-        return None
-    if not _is_allowed_directive(parsed):
+    parsed = parse_precompiler_output(raw_output)
+    if parsed is None or parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
         return None
     return parsed
 
@@ -210,8 +175,11 @@ def _state_before_last_message(user_transcript: list[dict[str, object]]) -> Stat
 
 def _precompile_last_user_message(message: str, state: State | None) -> str | None:
     try:
-        heuristic_result = cast(PrecompileResult, precompile_heuristic(message))
-        if heuristic_result["outcome"] == "directive" and heuristic_result["directive"]:
+        heuristic_result = precompile_heuristic(message)
+        if (
+            heuristic_result["outcome"] == PRECOMPILE_OUTCOME_DIRECTIVE
+            and heuristic_result["directive"]
+        ):
             return heuristic_result["directive"]
     except Exception:
         logger.debug("litellm_proxy: heuristic_exception", exc_info=True)

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -39,18 +39,50 @@ _CC_MARKER = "[[cc_state]]"
 _ENGINES_BY_CHAT_KEY: dict[str, Engine] = {}
 _HEURISTIC_PRECOMPILE: Any | None = None
 _RENDER_PROMPT_HELPER: Any | None = None
+_PARSE_PRECOMPILER_OUTPUT_HELPER: Any | None = None
 
-# Keep accepted output strict: fallback text must be a canonical directive line
-# or we treat it as no directive.
-_ALLOWED_DIRECTIVE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"^set premise (?!to\b)\S(?:.*\S)?$"),
-    re.compile(r"^change premise to \S(?:.*\S)?$"),
-    re.compile(r"^use \S(?:.*\S)? instead of \S(?:.*\S)?$"),
-    re.compile(r"^use (?!.*\sinstead of(?:\s|$))\S(?:.*\S)?$"),
-    re.compile(r"^prohibit \S(?:.*\S)?$"),
-    re.compile(r"^remove policy \S(?:.*\S)?$"),
-)
-_ALLOWED_DIRECTIVE_EXACT = {"clear premise", "reset policies", "clear state"}
+try:
+    from experimental.preprocessor.constants import (
+        CANONICAL_DIRECTIVE_EXACT as _IMPORTED_ALLOWED_DIRECTIVE_EXACT,
+    )
+    from experimental.preprocessor.constants import (
+        CANONICAL_DIRECTIVE_PATTERNS as _IMPORTED_ALLOWED_DIRECTIVE_PATTERNS,
+    )
+    from experimental.preprocessor.constants import (
+        PRECOMPILE_OUTCOME_DIRECTIVE as _IMPORTED_PRECOMPILE_OUTCOME_DIRECTIVE,
+    )
+    from experimental.preprocessor.constants import (
+        PRECOMPILE_OUTCOME_NO_DIRECTIVE as _IMPORTED_PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+    )
+    from experimental.preprocessor.constants import (
+        PRECOMPILER_NO_DIRECTIVE_SENTINEL as _IMPORTED_NO_DIRECTIVE_SENTINEL,
+    )
+    from experimental.preprocessor.output_validation import (
+        parse_precompiler_output as _IMPORTED_PARSE_PRECOMPILER_OUTPUT,
+    )
+
+    _NO_DIRECTIVE_SENTINEL = _IMPORTED_NO_DIRECTIVE_SENTINEL
+    _PRECOMPILE_OUTCOME_DIRECTIVE = _IMPORTED_PRECOMPILE_OUTCOME_DIRECTIVE
+    _PRECOMPILE_OUTCOME_NO_DIRECTIVE = _IMPORTED_PRECOMPILE_OUTCOME_NO_DIRECTIVE
+    _ALLOWED_DIRECTIVE_PATTERNS = _IMPORTED_ALLOWED_DIRECTIVE_PATTERNS
+    _ALLOWED_DIRECTIVE_EXACT = _IMPORTED_ALLOWED_DIRECTIVE_EXACT
+    _PARSE_PRECOMPILER_OUTPUT_HELPER = _IMPORTED_PARSE_PRECOMPILER_OUTPUT
+except Exception:  # pragma: no cover - fallback for standalone Open WebUI deployment
+    _NO_DIRECTIVE_SENTINEL = "<NO_DIRECTIVE>"
+    _PRECOMPILE_OUTCOME_DIRECTIVE = "directive"
+    _PRECOMPILE_OUTCOME_NO_DIRECTIVE = "no_directive"
+    # Keep accepted output strict: fallback text must be a canonical directive
+    # line or we treat it as no directive.
+    _ALLOWED_DIRECTIVE_PATTERNS = (
+        re.compile(r"^set premise (?!to\b)\S(?:.*\S)?$"),
+        re.compile(r"^change premise to \S(?:.*\S)?$"),
+        re.compile(r"^use \S(?:.*\S)? instead of \S(?:.*\S)?$"),
+        re.compile(r"^use (?!.*\sinstead of(?:\s|$))\S(?:.*\S)?$"),
+        re.compile(r"^prohibit \S(?:.*\S)?$"),
+        re.compile(r"^remove policy \S(?:.*\S)?$"),
+    )
+    _ALLOWED_DIRECTIVE_EXACT = frozenset({"clear premise", "reset policies", "clear state"})
+    _PARSE_PRECOMPILER_OUTPUT_HELPER = None
 
 
 class PrecompileResult(TypedDict):
@@ -60,7 +92,10 @@ class PrecompileResult(TypedDict):
 
 
 _NOOP_PRECOMPILE_RESULT: PrecompileResult = {
-    "outcome": "no_directive",
+    "outcome": cast(
+        Literal["directive", "no_directive", "unknown"],
+        _PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+    ),
     "directive": None,
     "rule_id": "unavailable",
 }
@@ -239,12 +274,12 @@ def _normalize_precompiler_output(raw_output: object) -> str | None:
         return None
 
     stripped = raw_output.strip()
-    if stripped.upper() == "<NO_DIRECTIVE>":
-        return "<NO_DIRECTIVE>"
+    if stripped.upper() == _NO_DIRECTIVE_SENTINEL:
+        return _NO_DIRECTIVE_SENTINEL
 
     non_empty_lines = [line.strip() for line in raw_output.splitlines() if line.strip()]
-    if non_empty_lines and non_empty_lines[-1].upper() == "<NO_DIRECTIVE>":
-        return "<NO_DIRECTIVE>"
+    if non_empty_lines and non_empty_lines[-1].upper() == _NO_DIRECTIVE_SENTINEL:
+        return _NO_DIRECTIVE_SENTINEL
 
     return stripped
 
@@ -301,8 +336,14 @@ def _llm_fallback_precompile(
     except Exception:
         return None
 
+    if _PARSE_PRECOMPILER_OUTPUT_HELPER is not None:
+        parsed = cast(str | None, _PARSE_PRECOMPILER_OUTPUT_HELPER(raw_output))
+        if parsed is None or parsed == _NO_DIRECTIVE_SENTINEL:
+            return None
+        return parsed
+
     parsed = _normalize_precompiler_output(raw_output)
-    if parsed is None or parsed == "<NO_DIRECTIVE>" or not parsed:
+    if parsed is None or parsed == _NO_DIRECTIVE_SENTINEL or not parsed:
         return None
     if not _is_allowed_directive(parsed):
         return None
@@ -321,7 +362,10 @@ def _precompile_user_input(
     heuristic = _get_heuristic_precompile()
     heuristic_result = cast(PrecompileResult, heuristic(message))
 
-    if heuristic_result["outcome"] == "directive" and heuristic_result["directive"]:
+    if (
+        heuristic_result["outcome"] == _PRECOMPILE_OUTCOME_DIRECTIVE
+        and heuristic_result["directive"]
+    ):
         return heuristic_result["directive"]
 
     return _llm_fallback_precompile(

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -366,7 +366,21 @@ def _precompile_user_input(
         heuristic_result["outcome"] == _PRECOMPILE_OUTCOME_DIRECTIVE
         and heuristic_result["directive"]
     ):
-        return heuristic_result["directive"]
+        if _PARSE_PRECOMPILER_OUTPUT_HELPER is not None:
+            parsed = cast(
+                str | None, _PARSE_PRECOMPILER_OUTPUT_HELPER(heuristic_result["directive"])
+            )
+            if parsed is not None and parsed != _NO_DIRECTIVE_SENTINEL:
+                return parsed
+        else:
+            parsed = _normalize_precompiler_output(heuristic_result["directive"])
+            if (
+                parsed is not None
+                and parsed != _NO_DIRECTIVE_SENTINEL
+                and parsed
+                and _is_allowed_directive(parsed)
+            ):
+                return parsed
 
     return _llm_fallback_precompile(
         message,

--- a/experimental/preprocessor/README.md
+++ b/experimental/preprocessor/README.md
@@ -1,0 +1,62 @@
+# Experimental Preprocessor Package
+
+This package provides optional host-layer preprocessing utilities for Context
+Compiler integrations.
+
+It is experimental and separate from the deterministic core engine in `src/`.
+
+## Modules
+
+- `heuristic_precompiler.py`: conservative structural precompile pass.
+- `output_validation.py`: shared normalization/validation boundary.
+- `prompt_utils.py`: state-aware prompt rendering helper.
+- `constants.py`: shared protocol literals and directive validation patterns.
+- `prompts/default.txt`: default runtime prompt.
+- `prompts/llama.txt`: stricter prompt for Llama-family models in LLM-only mode.
+
+## Validation boundary (required)
+
+Public validator entry point:
+
+- `parse_precompiler_output(raw_output: object) -> str | None`
+
+All preprocessor outputs (heuristic or LLM) must be validated with
+`parse_precompiler_output(...)` before being applied.
+
+Raw preprocessor/LLM outputs must not be passed directly to the compiler.
+
+## Safe usage pattern
+
+1. Run `precompile_heuristic(message)`.
+2. If a heuristic candidate directive exists, validate it with
+   `parse_precompiler_output(...)`.
+3. If no valid directive was produced, run LLM fallback precompile.
+4. Validate fallback output with `parse_precompiler_output(...)`.
+5. Only then pass validated directive (or original input) into
+   `engine.step(...)` / transcript replay.
+
+## Prompt guidance
+
+- Use `prompts/default.txt` as the recommended default prompt.
+- Use `prompts/llama.txt` only for LLM-only preprocessing with Llama-family
+  models.
+- Heuristic-first integrations should still keep `default.txt` as the normal
+  fallback prompt unless there is a model-specific reason not to.
+
+## Prompt rendering helper
+
+`prompt_utils.py` exposes:
+
+- `render_prompt(path: Path, state: State) -> str | None`
+
+Behavior:
+
+- reads prompt text from `path`
+- strips leading `#` header lines and leading blank lines
+- replaces `<NULL_OR_VALUE>` and `<SET OF CURRENT POLICY ITEMS>` using state
+- returns `None` if prompt loading fails
+
+## Notes
+
+- This package does not mutate compiler state directly.
+- State changes still occur only through compiler parsing/replay paths.

--- a/experimental/preprocessor/README.md
+++ b/experimental/preprocessor/README.md
@@ -32,8 +32,12 @@ Raw preprocessor/LLM outputs must not be passed directly to the compiler.
    `parse_precompiler_output(...)`.
 3. If no valid directive was produced, run LLM fallback precompile.
 4. Validate fallback output with `parse_precompiler_output(...)`.
-5. Only then pass validated directive (or original input) into
-   `engine.step(...)` / transcript replay.
+5. If a valid directive is produced, pass it through a normal compiler input path.
+   For session-owned integrations, use `engine.step(...)`.
+   For transcript-based integrations that receive full chat history each turn:
+   - use `context_compiler.compile_transcript(...)` for stateless evaluation
+   - use `engine.apply_transcript(...)` to update an existing engine
+   Otherwise pass the original user input unchanged.
 
 ## Prompt guidance
 

--- a/experimental/preprocessor/constants.py
+++ b/experimental/preprocessor/constants.py
@@ -1,0 +1,29 @@
+"""Shared protocol constants for experimental preprocessor paths."""
+
+import re
+from typing import Final, Literal
+
+PRECOMPILER_NO_DIRECTIVE_SENTINEL: Final = "<NO_DIRECTIVE>"
+
+PRECOMPILE_OUTCOME_DIRECTIVE: Final = "directive"
+PRECOMPILE_OUTCOME_NO_DIRECTIVE: Final = "no_directive"
+PRECOMPILE_OUTCOME_UNKNOWN: Final = "unknown"
+PrecompileOutcome = Literal["directive", "no_directive", "unknown"]
+
+PROMPT_TOKEN_NULL_OR_VALUE: Final = "<NULL_OR_VALUE>"
+PROMPT_TOKEN_POLICY_SET: Final = "<SET OF CURRENT POLICY ITEMS>"
+
+CANONICAL_DIRECTIVE_PATTERN_TEXTS: Final[tuple[str, ...]] = (
+    r"^set premise (?!to\b)\S(?:.*\S)?$",
+    r"^change premise to \S(?:.*\S)?$",
+    r"^use \S(?:.*\S)? instead of \S(?:.*\S)?$",
+    r"^use (?!.*\sinstead of(?:\s|$))\S(?:.*\S)?$",
+    r"^prohibit \S(?:.*\S)?$",
+    r"^remove policy \S(?:.*\S)?$",
+)
+CANONICAL_DIRECTIVE_PATTERNS: Final[tuple[re.Pattern[str], ...]] = tuple(
+    re.compile(pattern) for pattern in CANONICAL_DIRECTIVE_PATTERN_TEXTS
+)
+CANONICAL_DIRECTIVE_EXACT: Final[frozenset[str]] = frozenset(
+    {"clear premise", "reset policies", "clear state"}
+)

--- a/experimental/preprocessor/heuristic_precompiler.py
+++ b/experimental/preprocessor/heuristic_precompiler.py
@@ -7,9 +7,26 @@ high-precision, preferring no-op outcomes over false positives.
 """
 
 import re
-from typing import Literal, TypedDict
+from typing import TypedDict
 
-PrecompileOutcome = Literal["directive", "no_directive", "unknown"]
+try:
+    from .constants import (
+        CANONICAL_DIRECTIVE_EXACT,
+        CANONICAL_DIRECTIVE_PATTERNS,
+        PRECOMPILE_OUTCOME_DIRECTIVE,
+        PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+        PRECOMPILE_OUTCOME_UNKNOWN,
+        PrecompileOutcome,
+    )
+except ImportError:  # pragma: no cover - direct module loading in tests/evals
+    from experimental.preprocessor.constants import (
+        CANONICAL_DIRECTIVE_EXACT,
+        CANONICAL_DIRECTIVE_PATTERNS,
+        PRECOMPILE_OUTCOME_DIRECTIVE,
+        PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+        PRECOMPILE_OUTCOME_UNKNOWN,
+        PrecompileOutcome,
+    )
 
 
 class PrecompileResult(TypedDict):
@@ -17,17 +34,6 @@ class PrecompileResult(TypedDict):
     directive: str | None
     rule_id: str | None
 
-
-_CANONICAL_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"^set premise (?!to\b)\S(?:.*\S)?$"),
-    re.compile(r"^change premise to \S(?:.*\S)?$"),
-    re.compile(r"^use \S(?:.*\S)? instead of \S(?:.*\S)?$"),
-    re.compile(r"^use (?!.*\sinstead of(?:\s|$))\S(?:.*\S)?$"),
-    re.compile(r"^prohibit \S(?:.*\S)?$"),
-    re.compile(r"^remove policy \S(?:.*\S)?$"),
-)
-
-_CANONICAL_EXACT = {"clear premise", "reset policies", "clear state"}
 
 _MULTI_INSTRUCTION_CASES = {
     "clear premise then clear state",
@@ -61,6 +67,23 @@ _REPORTING_BRACKET_MARKERS = (
 
 _SET_PREMISE_TO_PATTERN = re.compile(r"^set premise to\s+(.+\S)\s*$")
 _CHANGE_PREMISE_MISSING_TO_PATTERN = re.compile(r"^change premise\s+(?!to\b)(.+\S)\s*$")
+_LIST_MARKER_PATTERN = re.compile(r"^\s*(?:\d+[.)]|[-*])\s+\S")
+_META_PREFIX_PATTERN = re.compile(
+    r"^\s*(?:example:|for example\b|the command is\b|(?:i|he|she|they) said\b)"
+)
+_MULTI_SEGMENT_PATTERN = re.compile(
+    r"^\s*(?:use|prohibit|remove policy|set premise|change premise to|clear premise|"
+    r"reset policies|clear state)\b"
+    r".*\b(?:because|then continue|and)\b"
+)
+_PUNCTUATION_TRIM_PATTERN = re.compile(r"[.!]+\s*$")
+_WRAPPER_PAIRS = {
+    ('"', '"'),
+    ("'", "'"),
+    ("`", "`"),
+    ("(", ")"),
+    ("[", "]"),
+}
 
 
 def _normalized_for_match(message: str) -> str:
@@ -74,60 +97,128 @@ def _contains_reporting_bracket_mention(message: str) -> bool:
     return any(marker in lower for marker in _REPORTING_BRACKET_MARKERS)
 
 
+def _strip_terminal_punctuation(message: str) -> str:
+    return _PUNCTUATION_TRIM_PATTERN.sub("", message).strip()
+
+
+def _strip_exact_wrapper(message: str) -> str:
+    stripped = message.strip()
+    if len(stripped) < 2:
+        return stripped
+    opener = stripped[0]
+    closer = stripped[-1]
+    if (opener, closer) not in _WRAPPER_PAIRS:
+        return stripped
+    inner = stripped[1:-1].strip()
+    if not inner:
+        return stripped
+    return inner
+
+
+def _normalize_candidate(message: str) -> str:
+    stripped = message.strip()
+    no_punct = _strip_terminal_punctuation(stripped)
+    unwrapped = _strip_exact_wrapper(no_punct)
+    return re.sub(r"\s+", " ", unwrapped).strip().lower()
+
+
 def precompile_heuristic(message: str) -> PrecompileResult:
     # Precision-first hard rejection for question-like inputs.
     if "?" in message:
-        return {"outcome": "no_directive", "directive": None, "rule_id": "reject.question_mark"}
+        return {
+            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "directive": None,
+            "rule_id": "reject.question_mark",
+        }
+
+    if _LIST_MARKER_PATTERN.match(message):
+        return {
+            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "directive": None,
+            "rule_id": "reject.list_or_enumeration",
+        }
 
     normalized = _normalized_for_match(message)
 
+    if _META_PREFIX_PATTERN.match(normalized):
+        return {
+            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "directive": None,
+            "rule_id": "reject.meta_or_reporting",
+        }
+
+    if _MULTI_SEGMENT_PATTERN.match(normalized):
+        return {
+            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "directive": None,
+            "rule_id": "reject.multi_segment_or_mixed_prose",
+        }
+
     if normalized in _MULTI_INSTRUCTION_CASES:
-        return {"outcome": "no_directive", "directive": None, "rule_id": "reject.multi_instruction"}
+        return {
+            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "directive": None,
+            "rule_id": "reject.multi_instruction",
+        }
 
     if _contains_reporting_bracket_mention(message):
         return {
-            "outcome": "no_directive",
+            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
             "directive": None,
             "rule_id": "reject.quoted_reported_bracket",
         }
 
     if normalized in _QUOTED_OR_REPORTED_CASES:
-        return {"outcome": "no_directive", "directive": None, "rule_id": "reject.quoted_reported"}
+        return {
+            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "directive": None,
+            "rule_id": "reject.quoted_reported",
+        }
 
-    stripped = message.strip()
+    normalized_candidate = _normalize_candidate(message)
 
-    set_premise_to_match = _SET_PREMISE_TO_PATTERN.fullmatch(stripped)
+    set_premise_to_match = _SET_PREMISE_TO_PATTERN.fullmatch(normalized_candidate)
     if set_premise_to_match is not None:
         payload = set_premise_to_match.group(1).strip()
         if payload:
             return {
-                "outcome": "directive",
+                "outcome": PRECOMPILE_OUTCOME_DIRECTIVE,
                 "directive": f"set premise {payload}",
                 "rule_id": "canonical.structural_set_premise_to",
             }
 
-    change_premise_missing_to_match = _CHANGE_PREMISE_MISSING_TO_PATTERN.fullmatch(stripped)
+    change_premise_missing_to_match = _CHANGE_PREMISE_MISSING_TO_PATTERN.fullmatch(
+        normalized_candidate
+    )
     if change_premise_missing_to_match is not None:
         payload = change_premise_missing_to_match.group(1).strip()
         if payload:
             return {
-                "outcome": "directive",
+                "outcome": PRECOMPILE_OUTCOME_DIRECTIVE,
                 "directive": f"change premise to {payload}",
                 "rule_id": "canonical.structural_change_premise_missing_to",
             }
 
     if normalized in _NEAR_MISS_ALIAS_CASES:
-        return {"outcome": "no_directive", "directive": None, "rule_id": "reject.near_miss_alias"}
+        return {
+            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "directive": None,
+            "rule_id": "reject.near_miss_alias",
+        }
 
-    if stripped in _CANONICAL_EXACT:
-        return {"outcome": "directive", "directive": stripped, "rule_id": "canonical.full_match"}
+    if normalized_candidate in CANONICAL_DIRECTIVE_EXACT:
+        return {
+            "outcome": PRECOMPILE_OUTCOME_DIRECTIVE,
+            "directive": normalized_candidate,
+            "rule_id": "canonical.full_match",
+        }
 
-    for pattern in _CANONICAL_PATTERNS:
-        if pattern.fullmatch(stripped):
+    for pattern in CANONICAL_DIRECTIVE_PATTERNS:
+        if pattern.fullmatch(normalized_candidate):
             return {
-                "outcome": "directive",
-                "directive": stripped,
+                "outcome": PRECOMPILE_OUTCOME_DIRECTIVE,
+                "directive": normalized_candidate,
                 "rule_id": "canonical.full_match",
             }
 
-    return {"outcome": "unknown", "directive": None, "rule_id": None}
+    return {"outcome": PRECOMPILE_OUTCOME_UNKNOWN, "directive": None, "rule_id": None}

--- a/experimental/preprocessor/output_validation.py
+++ b/experimental/preprocessor/output_validation.py
@@ -1,0 +1,89 @@
+"""Shared precompiler output normalization and validation helpers.
+
+Public API:
+- parse_precompiler_output
+
+Internal helpers are implementation details and may change.
+"""
+
+import re
+
+from .constants import (
+    CANONICAL_DIRECTIVE_EXACT,
+    CANONICAL_DIRECTIVE_PATTERNS,
+    PRECOMPILER_NO_DIRECTIVE_SENTINEL,
+)
+
+__all__ = ["parse_precompiler_output"]
+
+_MALFORMED_SENTINEL_TAGS = {
+    "<NO_DIRECTIPLE>",
+    "<NO_DIRECTITIVE>",
+    "<NO_DIRECT_DIRECTIVE>",
+}
+_MALFORMED_SENTINEL_TAG_PATTERN = re.compile(r"^<NO_DIRECTDIRECTIVE[A-Z_]*>$", re.IGNORECASE)
+
+
+def _normalize_abstain_tag(tag: str) -> str | None:
+    upper_tag = tag.strip().upper()
+    if upper_tag == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+        return PRECOMPILER_NO_DIRECTIVE_SENTINEL
+    if upper_tag in _MALFORMED_SENTINEL_TAGS:
+        return PRECOMPILER_NO_DIRECTIVE_SENTINEL
+    if _MALFORMED_SENTINEL_TAG_PATTERN.fullmatch(upper_tag):
+        return PRECOMPILER_NO_DIRECTIVE_SENTINEL
+    return None
+
+
+def _extract_leading_tag(text: str) -> str | None:
+    if not text.startswith("<"):
+        return None
+    close = text.find(">")
+    if close <= 0:
+        return None
+    return text[: close + 1]
+
+
+def _normalize_precompiler_output(raw_output: object) -> str | None:
+    if not isinstance(raw_output, str):
+        return None
+
+    stripped = raw_output.strip()
+    if not stripped:
+        return stripped
+
+    normalized = _normalize_abstain_tag(stripped)
+    if normalized is not None:
+        return normalized
+
+    leading_tag = _extract_leading_tag(stripped)
+    if leading_tag is not None:
+        normalized = _normalize_abstain_tag(leading_tag)
+        if normalized is not None:
+            return normalized
+
+    non_empty_lines = [line.strip() for line in raw_output.splitlines() if line.strip()]
+    if non_empty_lines:
+        last_line = non_empty_lines[-1]
+        normalized = _normalize_abstain_tag(last_line)
+        if normalized is not None:
+            return normalized
+
+    return stripped
+
+
+def _is_allowed_directive(text: str) -> bool:
+    if text in CANONICAL_DIRECTIVE_EXACT:
+        return True
+    return any(pattern.fullmatch(text) for pattern in CANONICAL_DIRECTIVE_PATTERNS)
+
+
+def parse_precompiler_output(raw_output: object) -> str | None:
+    normalized = _normalize_precompiler_output(raw_output)
+    if normalized is None:
+        return None
+    if normalized == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+        return normalized
+    if _is_allowed_directive(normalized):
+        return normalized
+    return None

--- a/experimental/preprocessor/prompt_utils.py
+++ b/experimental/preprocessor/prompt_utils.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from context_compiler import State, get_policy_items, get_premise_value
 
+from .constants import PROMPT_TOKEN_NULL_OR_VALUE, PROMPT_TOKEN_POLICY_SET
+
 
 def _strip_leading_headers(prompt_template: str) -> str:
     """Remove leading blank/comment header lines from a prompt template."""
@@ -45,6 +47,6 @@ def render_prompt(path: Path, state: State) -> str | None:
     )
     policies_value = ", ".join(all_policy_items) if all_policy_items else "(none)"
 
-    rendered = template.replace("<NULL_OR_VALUE>", premise_value)
-    rendered = rendered.replace("<SET OF CURRENT POLICY ITEMS>", policies_value)
+    rendered = template.replace(PROMPT_TOKEN_NULL_OR_VALUE, premise_value)
+    rendered = rendered.replace(PROMPT_TOKEN_POLICY_SET, policies_value)
     return rendered

--- a/tests/test_precompiler_heuristic.py
+++ b/tests/test_precompiler_heuristic.py
@@ -1,0 +1,258 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "experimental"
+    / "preprocessor"
+    / "heuristic_precompiler.py"
+)
+_SPEC = spec_from_file_location("heuristic_precompiler", _MODULE_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+_MODULE = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+precompile_heuristic = _MODULE.precompile_heuristic
+
+
+def test_heuristic_rejects_consistent_high_risk_non_directives() -> None:
+    cases = [
+        "allow docker",
+        "set policy peanuts prohibit",
+        "stop using peanuts",
+        "use instead of docker",
+        "use podman instead of",
+        "use podman not docker",
+        "wipe policies",
+        "clear premise then clear state",
+        "prohibit peanuts and use almonds",
+        "set premise concise; reset policies",
+        "use docker, actually prohibit docker",
+        '"set premise concise replies" is invalid syntax, right?',
+        'For example, you could "remove policy docker".',
+        'He said "use docker".',
+        'The doc literally says: "clear premise".',
+    ]
+
+    for message in cases:
+        result = precompile_heuristic(message)
+        assert result["outcome"] == "no_directive"
+        assert result["directive"] is None
+        assert result["rule_id"] is not None
+
+
+def test_heuristic_accepts_trailing_period_or_bang_for_whole_message_directives() -> None:
+    cases = [
+        ("clear state.", "clear state"),
+        ("reset policies!", "reset policies"),
+        ("use docker.", "use docker"),
+    ]
+    for message, expected in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "directive",
+            "directive": expected,
+            "rule_id": "canonical.full_match",
+        }
+
+
+def test_heuristic_allows_exact_full_message_wrappers_for_directives() -> None:
+    cases = [
+        ("`use docker`", "use docker"),
+        ('"clear state"', "clear state"),
+        ("(reset policies)", "reset policies"),
+        ("[prohibit peanuts]", "prohibit peanuts"),
+    ]
+    for message, expected in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "directive",
+            "directive": expected,
+            "rule_id": "canonical.full_match",
+        }
+
+
+def test_heuristic_case_normalizes_exact_command_shapes() -> None:
+    cases = [
+        ("CLEAR STATE", "clear state"),
+        ("Use Docker", "use docker"),
+        ("Prohibit Peanuts", "prohibit peanuts"),
+    ]
+    for message, expected in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "directive",
+            "directive": expected,
+            "rule_id": "canonical.full_match",
+        }
+
+
+def test_heuristic_rejects_any_question_mark() -> None:
+    cases = [
+        "use docker?",
+        "clear state?",
+        "can you use pytest instead of unittest?",
+    ]
+    for message in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "no_directive",
+            "directive": None,
+            "rule_id": "reject.question_mark",
+        }
+
+
+def test_heuristic_rejects_meta_reporting_or_example_prefixes() -> None:
+    cases = [
+        "example: use docker",
+        "the command is clear state",
+        'I said "use docker"',
+        'he said "reset policies"',
+        'example: "use docker"',
+    ]
+    for message in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "no_directive",
+            "directive": None,
+            "rule_id": "reject.meta_or_reporting",
+        }
+
+
+def test_heuristic_rejects_list_or_enumeration_inputs() -> None:
+    cases = [
+        "1. use docker",
+        "- clear state",
+        "* prohibit peanuts",
+    ]
+    for message in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "no_directive",
+            "directive": None,
+            "rule_id": "reject.list_or_enumeration",
+        }
+
+
+def test_heuristic_rejects_multi_segment_or_mixed_prose_inputs() -> None:
+    cases = [
+        "use docker because this repo already has Docker",
+        "clear state then continue",
+        "use docker and prohibit peanuts",
+    ]
+    for message in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "no_directive",
+            "directive": None,
+            "rule_id": "reject.multi_segment_or_mixed_prose",
+        }
+
+
+def test_heuristic_rejects_notes_and_reporting_with_bracketed_mentions() -> None:
+    cases = [
+        "In my notes: [clear state] [reset policies]",
+        "Notes: [use docker] [prohibit peanuts]",
+        "I wrote down [change premise to concise replies] yesterday",
+    ]
+    for message in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "no_directive",
+            "directive": None,
+            "rule_id": "reject.quoted_reported_bracket",
+        }
+
+
+def test_heuristic_accepts_bracket_wrapper_without_reporting_marker() -> None:
+    assert precompile_heuristic("[clear state]") == {
+        "outcome": "directive",
+        "directive": "clear state",
+        "rule_id": "canonical.full_match",
+    }
+
+
+def test_heuristic_canonicalizes_set_premise_to_whole_message_only() -> None:
+    cases = [
+        ("set premise to concise replies", "set premise concise replies"),
+        ("set premise to formal tone", "set premise formal tone"),
+    ]
+    for message, expected in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "directive",
+            "directive": expected,
+            "rule_id": "canonical.structural_set_premise_to",
+        }
+
+
+def test_heuristic_does_not_canonicalize_set_premise_to_with_empty_payload() -> None:
+    assert precompile_heuristic("set premise to   ") == {
+        "outcome": "unknown",
+        "directive": None,
+        "rule_id": None,
+    }
+
+
+def test_heuristic_does_not_canonicalize_set_premise_to_when_not_whole_message() -> None:
+    assert precompile_heuristic("please set premise to concise replies") == {
+        "outcome": "unknown",
+        "directive": None,
+        "rule_id": None,
+    }
+
+
+def test_heuristic_canonicalizes_change_premise_missing_to_whole_message_only() -> None:
+    cases = [
+        ("change premise concise replies", "change premise to concise replies"),
+        ("change premise formal tone", "change premise to formal tone"),
+    ]
+    for message, expected in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "directive",
+            "directive": expected,
+            "rule_id": "canonical.structural_change_premise_missing_to",
+        }
+
+
+def test_heuristic_does_not_canonicalize_change_premise_with_empty_payload() -> None:
+    assert precompile_heuristic("change premise   ") == {
+        "outcome": "unknown",
+        "directive": None,
+        "rule_id": None,
+    }
+
+
+def test_heuristic_does_not_canonicalize_change_premise_when_not_whole_message() -> None:
+    assert precompile_heuristic("please change premise concise replies") == {
+        "outcome": "unknown",
+        "directive": None,
+        "rule_id": None,
+    }
+
+
+def test_heuristic_accepts_strict_canonical_directives() -> None:
+    directives = [
+        "set premise concise replies",
+        "change premise to concise replies",
+        "use docker",
+        "prohibit peanuts",
+        "remove policy docker",
+        "use podman instead of docker",
+        "clear premise",
+        "reset policies",
+        "clear state",
+    ]
+
+    for directive in directives:
+        result = precompile_heuristic(directive)
+        assert result == {
+            "outcome": "directive",
+            "directive": directive,
+            "rule_id": "canonical.full_match",
+        }
+
+
+def test_heuristic_returns_unknown_for_unresolved_cases() -> None:
+    unresolved = [
+        "Could we maybe use uv later",
+        "not sure this is right",
+    ]
+
+    for message in unresolved:
+        assert precompile_heuristic(message) == {
+            "outcome": "unknown",
+            "directive": None,
+            "rule_id": None,
+        }

--- a/tests/test_precompiler_heuristic_properties.py
+++ b/tests/test_precompiler_heuristic_properties.py
@@ -1,0 +1,148 @@
+import re
+
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from experimental.preprocessor.constants import (
+    PRECOMPILE_OUTCOME_DIRECTIVE,
+    PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+)
+from experimental.preprocessor.heuristic_precompiler import precompile_heuristic
+from experimental.preprocessor.output_validation import (
+    _is_allowed_directive,
+    parse_precompiler_output,
+)
+
+CANONICAL_DIRECTIVES = [
+    "set premise concise replies",
+    "change premise to formal tone",
+    "use docker",
+    "prohibit peanuts",
+    "remove policy docker",
+    "use podman instead of docker",
+    "clear premise",
+    "reset policies",
+    "clear state",
+]
+
+NON_EMPTY_TEXT = st.text(min_size=1, max_size=40).filter(lambda s: s.strip() != "")
+WRAPPERS = st.sampled_from(
+    [
+        ('"', '"'),
+        ("'", "'"),
+        ("`", "`"),
+        ("(", ")"),
+        ("[", "]"),
+    ]
+)
+
+
+@given(st.sampled_from(CANONICAL_DIRECTIVES), st.sampled_from([".", "!"]))
+def test_heuristic_accepts_canonical_directive_with_trailing_period_or_bang(
+    directive: str, punctuation: str
+) -> None:
+    result = precompile_heuristic(f"{directive}{punctuation}")
+    assert result["outcome"] == PRECOMPILE_OUTCOME_DIRECTIVE
+    parsed = parse_precompiler_output(result["directive"])
+    assert parsed == result["directive"]
+
+
+@given(st.sampled_from(CANONICAL_DIRECTIVES))
+def test_heuristic_question_suffix_never_produces_directive(directive: str) -> None:
+    result = precompile_heuristic(f"{directive}?")
+    assert result["outcome"] == PRECOMPILE_OUTCOME_NO_DIRECTIVE
+    assert result["directive"] is None
+
+
+@given(st.sampled_from(CANONICAL_DIRECTIVES), WRAPPERS)
+def test_heuristic_accepts_single_layer_exact_wrapper(
+    directive: str, wrapper: tuple[str, str]
+) -> None:
+    left, right = wrapper
+    result = precompile_heuristic(f"{left}{directive}{right}")
+    assert result["outcome"] == PRECOMPILE_OUTCOME_DIRECTIVE
+    parsed = parse_precompiler_output(result["directive"])
+    assert parsed == result["directive"]
+
+
+@given(
+    st.sampled_from(CANONICAL_DIRECTIVES),
+    WRAPPERS,
+    st.sampled_from(["example:", "for example", "i said", "he said", "the command is"]),
+)
+def test_heuristic_rejects_wrapped_directive_with_surrounding_meta_text(
+    directive: str, wrapper: tuple[str, str], prefix: str
+) -> None:
+    left, right = wrapper
+    message = f"{prefix} {left}{directive}{right}"
+    result = precompile_heuristic(message)
+    assert result["outcome"] != PRECOMPILE_OUTCOME_DIRECTIVE
+
+
+@given(st.text(max_size=60), st.text(max_size=60))
+def test_heuristic_question_mark_is_always_rejected(prefix: str, suffix: str) -> None:
+    message = f"{prefix}?{suffix}"
+    assert precompile_heuristic(message) == {
+        "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+        "directive": None,
+        "rule_id": "reject.question_mark",
+    }
+
+
+@given(st.text(max_size=120))
+def test_heuristic_directive_output_is_always_validator_safe(message: str) -> None:
+    result = precompile_heuristic(message)
+    if result["outcome"] != PRECOMPILE_OUTCOME_DIRECTIVE:
+        return
+    directive = result["directive"]
+    assert isinstance(directive, str)
+    assert parse_precompiler_output(directive) == directive
+
+
+@given(st.sampled_from(CANONICAL_DIRECTIVES), NON_EMPTY_TEXT, NON_EMPTY_TEXT)
+def test_heuristic_whole_message_discipline_for_surrounded_directive(
+    directive: str, prefix: str, suffix: str
+) -> None:
+    message = f"{prefix} {directive} {suffix}"
+    normalized = re.sub(r"\s+", " ", message.strip().lower())
+    assume(prefix.strip() not in {'"', "'", "`", "(", "["})
+    assume(suffix.strip() not in {'"', "'", "`", ")", "]"})
+    assume(not message.strip().lower().startswith("change premise "))
+    assume(not _is_allowed_directive(normalized))
+    result = precompile_heuristic(message)
+    assert result["outcome"] != PRECOMPILE_OUTCOME_DIRECTIVE
+
+
+@given(NON_EMPTY_TEXT)
+def test_heuristic_list_or_enumeration_prefix_never_directive(rest: str) -> None:
+    for prefix in ("1. ", "- ", "* "):
+        result = precompile_heuristic(f"{prefix}{rest}")
+        assert result["outcome"] != PRECOMPILE_OUTCOME_DIRECTIVE
+
+
+@given(st.sampled_from(CANONICAL_DIRECTIVES))
+def test_heuristic_meta_reporting_prefix_never_directive(directive: str) -> None:
+    samples = [
+        f"example: {directive}",
+        f"for example {directive}",
+        f"the command is {directive}",
+        f'i said "{directive}"',
+        f'he said "{directive}"',
+    ]
+    for message in samples:
+        result = precompile_heuristic(message)
+        assert result["outcome"] != PRECOMPILE_OUTCOME_DIRECTIVE
+
+
+@given(st.sampled_from(["use docker", "clear state", "prohibit peanuts"]), NON_EMPTY_TEXT)
+def test_heuristic_mixed_prose_connector_forms_never_directive(
+    directive_seed: str, detail: str
+) -> None:
+    messages = [
+        f"{directive_seed} because {detail}",
+        f"{directive_seed} then continue {detail}",
+        f"{directive_seed} and {detail}",
+    ]
+    for message in messages:
+        result = precompile_heuristic(message)
+        assert result["outcome"] != PRECOMPILE_OUTCOME_DIRECTIVE

--- a/tests/test_precompiler_output_validation.py
+++ b/tests/test_precompiler_output_validation.py
@@ -1,0 +1,50 @@
+from experimental.preprocessor.constants import PRECOMPILER_NO_DIRECTIVE_SENTINEL
+from experimental.preprocessor.output_validation import (
+    _is_allowed_directive,
+    _normalize_precompiler_output,
+    parse_precompiler_output,
+)
+
+
+def test_normalize_accepts_exact_abstain_sentinel() -> None:
+    assert _normalize_precompiler_output("<NO_DIRECTIVE>") == PRECOMPILER_NO_DIRECTIVE_SENTINEL
+
+
+def test_normalize_repairs_known_malformed_abstain_tags() -> None:
+    assert _normalize_precompiler_output("<NO_DIRECTIPLE>") == PRECOMPILER_NO_DIRECTIVE_SENTINEL
+    assert _normalize_precompiler_output("<NO_DIRECTITIVE>") == PRECOMPILER_NO_DIRECTIVE_SENTINEL
+    assert (
+        _normalize_precompiler_output("<NO_DIRECT_DIRECTIVE>") == PRECOMPILER_NO_DIRECTIVE_SENTINEL
+    )
+
+
+def test_normalize_repairs_malformed_abstain_with_suffix_text() -> None:
+    raw = "<NO_DIRECTDirective> Directive cannot be generated..."
+    assert _normalize_precompiler_output(raw) == PRECOMPILER_NO_DIRECTIVE_SENTINEL
+
+
+def test_normalize_preserves_last_non_empty_line_abstain_behavior() -> None:
+    raw = "<NO_DIRECT Directive>\n<NO_DIRECTIVE>"
+    assert _normalize_precompiler_output(raw) == PRECOMPILER_NO_DIRECTIVE_SENTINEL
+
+
+def test_normalize_returns_none_for_non_string() -> None:
+    assert _normalize_precompiler_output(None) is None
+    assert _normalize_precompiler_output(123) is None
+
+
+def test_is_allowed_directive_accepts_canonical_shapes() -> None:
+    assert _is_allowed_directive("clear state")
+    assert _is_allowed_directive("set premise concise replies")
+    assert _is_allowed_directive("change premise to formal tone")
+    assert _is_allowed_directive("use podman instead of docker")
+
+
+def test_parse_accepts_valid_directive_and_rejects_malformed_directive() -> None:
+    assert parse_precompiler_output("prohibit peanuts") == "prohibit peanuts"
+    assert parse_precompiler_output("set premise to concise replies") is None
+    assert parse_precompiler_output("wipe policies") is None
+
+
+def test_parse_maps_malformed_abstain_to_canonical_sentinel() -> None:
+    assert parse_precompiler_output("<NO_DIRECTIPLE>") == PRECOMPILER_NO_DIRECTIVE_SENTINEL

--- a/tests/test_precompiler_prompt_utils.py
+++ b/tests/test_precompiler_prompt_utils.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from context_compiler import create_engine
+from context_compiler.engine import State
+from experimental.preprocessor.constants import PROMPT_TOKEN_NULL_OR_VALUE, PROMPT_TOKEN_POLICY_SET
+from experimental.preprocessor.prompt_utils import render_prompt
+
+
+def _write_prompt(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+
+
+def _empty_state() -> State:
+    return create_engine().state
+
+
+def _populated_state() -> State:
+    engine = create_engine()
+    engine.step("set premise concise replies")
+    engine.step("use zeta")
+    engine.step("use beta")
+    engine.step("prohibit alpha")
+    return engine.state
+
+
+def test_render_prompt_returns_none_when_file_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.txt"
+    assert render_prompt(missing, _empty_state()) is None
+
+
+def test_render_prompt_strips_leading_header_comments_and_blank_lines(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    _write_prompt(
+        prompt_file,
+        "\n# header one\n  # header two\n\n"
+        f"premise={PROMPT_TOKEN_NULL_OR_VALUE}\n"
+        f"policies={PROMPT_TOKEN_POLICY_SET}\n",
+    )
+
+    rendered = render_prompt(prompt_file, _empty_state())
+    assert rendered is not None
+    assert rendered.startswith("premise=null\n")
+    assert "# header" not in rendered
+
+
+def test_render_prompt_replaces_tokens_for_empty_state(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    _write_prompt(
+        prompt_file,
+        f"premise={PROMPT_TOKEN_NULL_OR_VALUE}\npolicies={PROMPT_TOKEN_POLICY_SET}\n",
+    )
+
+    rendered = render_prompt(prompt_file, _empty_state())
+    assert rendered == "premise=null\npolicies=(none)"
+
+
+def test_render_prompt_replaces_tokens_for_populated_state_with_sorted_policy_keys(
+    tmp_path: Path,
+) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    _write_prompt(
+        prompt_file,
+        f"premise={PROMPT_TOKEN_NULL_OR_VALUE}\npolicies={PROMPT_TOKEN_POLICY_SET}\n",
+    )
+
+    rendered = render_prompt(prompt_file, _populated_state())
+    assert rendered == "premise=concise replies\npolicies=alpha, beta, zeta"

--- a/tests/test_precompiler_validator_properties.py
+++ b/tests/test_precompiler_validator_properties.py
@@ -1,0 +1,173 @@
+import string
+
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from experimental.preprocessor.constants import PRECOMPILER_NO_DIRECTIVE_SENTINEL
+from experimental.preprocessor.output_validation import (
+    _is_allowed_directive,
+    _normalize_precompiler_output,
+    parse_precompiler_output,
+)
+
+CANONICAL_DIRECTIVES = [
+    "set premise concise replies",
+    "change premise to formal tone",
+    "use docker",
+    "prohibit peanuts",
+    "remove policy docker",
+    "use podman instead of docker",
+    "clear premise",
+    "reset policies",
+    "clear state",
+]
+
+SPACE_TEXT = st.text(alphabet=" \t\n", min_size=0, max_size=4)
+NON_EMPTY_TEXT = st.text(min_size=1, max_size=40).filter(lambda s: s.strip() != "")
+
+NOISY_TEXT = st.one_of(
+    st.text(min_size=0, max_size=80),
+    st.builds(lambda a, b: f"{a}\n{b}", st.text(max_size=40), st.text(max_size=40)),
+    st.builds(lambda t: f'"{t}"', st.text(max_size=60)),
+    st.builds(lambda t: f"`{t}`", st.text(max_size=60)),
+    st.builds(lambda t: f"[{t}]", st.text(max_size=60)),
+    st.builds(lambda a, b: f"{a}; {b}", st.text(max_size=30), st.text(max_size=30)),
+    st.builds(lambda a, b: f"{a}: {b}", st.text(max_size=30), st.text(max_size=30)),
+)
+
+MALFORMED_ABSTAIN = st.one_of(
+    st.sampled_from(
+        [
+            "<NO_DIRECTIPLE>",
+            "<NO_DIRECTITIVE>",
+            "<NO_DIRECT_DIRECTIVE>",
+            "<NO_DIRECTDirective> Directive cannot be generated...",
+        ]
+    ),
+    st.builds(
+        lambda middle: f"<NO_DIRECT{middle}>",
+        st.text(alphabet=string.ascii_uppercase + "_", min_size=1, max_size=20),
+    ),
+    st.builds(
+        lambda middle, suffix: f"<NO_DIRECT{middle}> {suffix}",
+        st.text(alphabet=string.ascii_uppercase + "_", min_size=1, max_size=20),
+        st.text(min_size=1, max_size=40),
+    ),
+)
+
+
+@given(
+    st.one_of(
+        st.none(),
+        st.integers(),
+        st.floats(),
+        st.booleans(),
+        st.binary(),
+        st.lists(st.integers()),
+        st.dictionaries(st.text(max_size=10), st.integers()),
+    )
+)
+def test_parse_non_string_never_produces_directive(raw_output: object) -> None:
+    assert parse_precompiler_output(raw_output) is None
+
+
+@given(NOISY_TEXT)
+def test_parse_invalid_text_never_becomes_directive(text: str) -> None:
+    stripped = text.strip()
+    assume(stripped.upper() != PRECOMPILER_NO_DIRECTIVE_SENTINEL)
+    assume(not _is_allowed_directive(stripped))
+    parsed = parse_precompiler_output(text)
+    assert parsed in {None, PRECOMPILER_NO_DIRECTIVE_SENTINEL}
+
+
+@given(MALFORMED_ABSTAIN)
+def test_parse_malformed_abstain_only_maps_to_sentinel_or_rejects(text: str) -> None:
+    parsed = parse_precompiler_output(text)
+    assert parsed in {None, PRECOMPILER_NO_DIRECTIVE_SENTINEL}
+
+
+@given(st.sampled_from(CANONICAL_DIRECTIVES), SPACE_TEXT, SPACE_TEXT)
+def test_parse_valid_canonical_directive_always_passes(
+    directive: str, leading_ws: str, trailing_ws: str
+) -> None:
+    raw = f"{leading_ws}{directive}{trailing_ws}"
+    assert parse_precompiler_output(raw) == directive
+
+
+@given(NOISY_TEXT)
+def test_normalization_is_idempotent(text: str) -> None:
+    normalized_once = _normalize_precompiler_output(text)
+    if normalized_once is None:
+        return
+    assert _normalize_precompiler_output(normalized_once) == normalized_once
+
+
+@given(st.sampled_from(CANONICAL_DIRECTIVES), NON_EMPTY_TEXT, NON_EMPTY_TEXT)
+def test_parse_rejects_directive_with_surrounding_text(
+    directive: str, prefix: str, suffix: str
+) -> None:
+    raw = f"{prefix} {directive} {suffix}"
+    stripped = raw.strip()
+    assume(stripped.upper() != PRECOMPILER_NO_DIRECTIVE_SENTINEL)
+    assume(not _is_allowed_directive(stripped))
+    parsed = parse_precompiler_output(raw)
+    assert parsed in {None, PRECOMPILER_NO_DIRECTIVE_SENTINEL}
+
+
+@given(
+    st.sampled_from(CANONICAL_DIRECTIVES),
+    st.sampled_from(
+        [
+            'example: "{}"',
+            "for example `{}`",
+            "notes: [{}]",
+            'he said "{}"',
+            'command = "{}"',
+        ]
+    ),
+)
+def test_parse_rejects_directive_in_constrained_wrappers(directive: str, wrapper: str) -> None:
+    wrapped = wrapper.format(directive)
+    assert parse_precompiler_output(wrapped) is None
+
+
+def test_parse_malformed_abstain_negative_boundaries_remain_narrow() -> None:
+    cases = {
+        "<NO_DIRECT>": None,
+        "<NO_DIRECTION>": None,
+        "<NO_DIRECTIVE please>": None,
+        "notes: <NO_DIRECTIVE>": None,
+        "prefix <NO_DIRECTIPLE>": None,
+        "<NOT_DIRECTIVE>": None,
+        "<NO_DIRECTIPLE>": PRECOMPILER_NO_DIRECTIVE_SENTINEL,
+    }
+    for raw, expected in cases.items():
+        parsed = parse_precompiler_output(raw)
+        assert parsed == expected
+        if parsed is not None:
+            assert parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL or _is_allowed_directive(parsed)
+
+
+def test_parse_rejects_near_miss_directives_when_wrapped_or_prefixed() -> None:
+    cases = [
+        "`set premise to concise replies`",
+        '"use podman not docker"',
+        "example: clear state",
+        "notes: [set premise to concise replies]",
+        'he said "use docker"',
+    ]
+    for raw in cases:
+        parsed = parse_precompiler_output(raw)
+        assert parsed in {None, PRECOMPILER_NO_DIRECTIVE_SENTINEL}
+        if parsed is not None:
+            assert parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL
+
+
+@given(st.one_of(st.none(), st.integers(), st.text(max_size=120)))
+def test_parse_output_idempotent(raw_output: object) -> None:
+    first = parse_precompiler_output(raw_output)
+    second = parse_precompiler_output(first)
+    if first is None:
+        assert second is None
+    else:
+        assert second == first


### PR DESCRIPTION
## What changed
- Migrated stable preprocessor runtime pieces into `experimental/preprocessor/`:
  - added shared protocol constants module
  - added shared output validation module with `parse_precompiler_output(...)` as the public entry point
  - tightened heuristic precompiler structural handling and kept validator-safe outputs
  - kept prompt rendering centralized and aligned with runtime prompt assets
- Updated preprocessor-enabled integration examples to use the shared validation boundary consistently:
  - LiteLLM SDK example
  - LiteLLM proxy pre-call hook example
  - Open WebUI pipe with preprocessor example
- Added/expanded preprocessor-focused test coverage:
  - heuristic tests
  - validator tests
  - Hypothesis property tests for validator/heuristic boundaries
  - prompt rendering utility tests
- Split and clarified preprocessor docs:
  - high-level architecture/contract in `docs/llm-preprocessor.md`
  - practical module usage in `experimental/preprocessor/README.md`
  - top-level README now includes an explicit optional preprocessor section

## Why
- Finalize a stable, release-scoped experimental preprocessor surface for 0.6.1.
- Enforce a single safe boundary for preprocessor outputs (`parse_precompiler_output(...)`) before compiler application.
- Keep integration examples aligned with the intended conservative flow: heuristic first, validated fallback when needed, and no raw preprocessor output applied directly.