### PR TITLE
fix: remove duplicate preprocessor prompt packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,6 @@ context-compiler = "context_compiler.repl:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/context_compiler", "experimental"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"experimental/preprocessor/prompts" = "experimental/preprocessor/prompts"
-
 [project.optional-dependencies]
 demos = [
   "litellm>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed
- removed redundant Hatch wheel force-include for experimental/preprocessor/prompts
- kept prompt assets included via packaged experimental module path
- updated uv.lock package version metadata alignment

## Why
PyPI rejected the 0.6.1 wheel with 'Duplicate filename in local headers' because prompt files were included twice in the wheel archive.