### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.1"
+version = "0.6.2"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed
- bumped package version from 0.6.1 to 0.6.2 in pyproject.toml
- updated uv.lock package version entry to 0.6.2

## Why
- v0.6.1 tag is protected/immutable and cannot be retargeted after the packaging fix
- this follow-up version bump enables publishing a corrected release as v0.6.2