### PR TITLE
test: add examples smoke coverage and doc clarification

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 This directory contains small integration examples showing typical host-side usage of the Context Compiler.
 
 These files are included in the base package install (`pip install context-compiler`).
+Non-integration example files in this directory are standalone scripts and can be run directly.
 
 ## 01_persistent_guardrails.py
 


### PR DESCRIPTION
## What changed
- add lightweight smoke tests for non-integration scripts under examples/
- execute each script with runpy.run_path and assert stable output markers
- clarify in examples/README.md that non-integration examples are standalone runnable scripts

## Why
- keeps examples validated without duplicating core logic tests
- makes example usage intent explicit in docs