### PR TITLE
feat: route openwebui preprocessor fallback via host models

### DIFF
--- a/examples/integrations/litellm/README.md
+++ b/examples/integrations/litellm/README.md
@@ -22,11 +22,13 @@ Optional:
 
 ```shell
 export MODEL=openai/gpt-4o-mini
+export PREPROCESSOR_MODEL=openai/gpt-4o-mini
 export OPENAI_BASE_URL=...
 export PREPROCESSOR_PROMPT_PROFILE=default
 ```
 
 `MODEL` uses LiteLLM format: `<provider>/<model>`.
+`PREPROCESSOR_MODEL` is optional and defaults to `MODEL`.
 
 For heuristic-first usage, keep `PREPROCESSOR_PROMPT_PROFILE=default`.
 Use `llama` only for LLM-only preprocessing with Llama-family models.

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -148,9 +148,12 @@ def _llm_fallback_precompile(message: str, state: State) -> str | None:
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         return None
+    preprocessor_model = os.getenv("PREPROCESSOR_MODEL", "").strip()
+    if not preprocessor_model:
+        preprocessor_model = os.getenv("MODEL", "openai/gpt-4o-mini")
 
     kwargs: _LiteLLMCallKwargs = {
-        "model": os.getenv("MODEL", "openai/gpt-4o-mini"),
+        "model": preprocessor_model,
         "messages": [
             {"role": "system", "content": prompt},
             {"role": "user", "content": message},

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -17,8 +17,8 @@ import logging
 import os
 from collections.abc import Callable, Mapping, Sequence
 from importlib import import_module
-from importlib.abc import Traversable
 from importlib.resources import as_file, files
+from importlib.resources.abc import Traversable
 from typing import TypedDict, cast
 
 from context_compiler import State, get_policy_items, get_premise_value

--- a/examples/integrations/litellm_proxy/README.md
+++ b/examples/integrations/litellm_proxy/README.md
@@ -88,6 +88,8 @@ export PREPROCESSOR_MODEL=openai/gpt-4o-mini
 export PREPROCESSOR_PROMPT_PROFILE=default
 ```
 
+`PREPROCESSOR_MODEL` is optional and defaults to `MODEL`.
+
 For heuristic-first usage, keep `PREPROCESSOR_PROMPT_PROFILE=default`.
 Use `llama` only for LLM-only preprocessing with Llama-family models.
 

--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
@@ -11,8 +11,8 @@ import logging
 import os
 from collections.abc import Callable, Mapping, Sequence
 from importlib import import_module
-from importlib.abc import Traversable
 from importlib.resources import as_file, files
+from importlib.resources.abc import Traversable
 from typing import Any, cast
 
 from litellm.integrations.custom_logger import CustomLogger

--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
@@ -141,6 +141,8 @@ def _llm_fallback_precompile(message: str, state: State) -> str | None:
 
     preprocessor_model = os.getenv("PREPROCESSOR_MODEL", "").strip()
     if not preprocessor_model:
+        preprocessor_model = os.getenv("MODEL", "").strip()
+    if not preprocessor_model:
         return None
 
     api_key = os.getenv("OPENAI_API_KEY")

--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -6,8 +6,8 @@ Tested target: Open WebUI `v0.8.12` (latest at time of testing).
 
 ## Files
 
-- `open_webui_pipe.py`: basic integration, no preprocessor layer.
-- `open_webui_pipe_with_preprocessor.py`: heuristic-first preprocessor plus LLM fallback before `engine.step(...)`.
+- `open_webui_pipe.py`: basic integration, no preprocessor layer (recommended/default).
+- `open_webui_pipe_with_preprocessor.py`: optional/experimental preprocessor layer (heuristic first, then model fallback) before `engine.step(...)`.
 
 ## Setup
 
@@ -27,9 +27,13 @@ If using `open_webui_pipe_with_preprocessor.py`:
   repo-relative paths).
 - Set `PREPROCESSOR_PROMPT_PROFILE` to `default` for heuristic-first usage.
 - Use `llama` only for LLM-only preprocessing with Llama-family models.
-- Ensure `OPENAI_API_KEY` is set (and `OPENAI_BASE_URL` if needed).
 - Prompt files are loaded from the installed package prompts (`default`/`llama` profiles).
-- LLM fallback uses `BASE_MODEL_ID` as its model.
+- Optional: set `PREPROCESSOR_MODEL_ID` to route fallback precompilation through
+  a separate model. If unset, fallback uses `BASE_MODEL_ID`.
+- Fallback routing is Open WebUI-native (no LiteLLM dependency for this pipe).
+- Invalid configured model ids return explicit runtime misconfiguration errors:
+  - `BASE_MODEL_ID` not found in Open WebUI models
+  - `PREPROCESSOR_MODEL_ID` not found in Open WebUI models
 
 ## Limitations
 

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -18,8 +18,8 @@ Core decision handling remains the same as the base integration.
 """
 
 import logging
-from importlib.abc import Traversable
 from importlib.resources import as_file, files
+from importlib.resources.abc import Traversable
 from typing import Any, Literal
 
 from fastapi import Request  # type: ignore[import-not-found]

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -4,28 +4,28 @@ author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
 version: 0.1
+requirements: context-compiler[experimental]>=0.6.4
 
 Open WebUI integration with Context Compiler preprocessor.
 
 This example extends `open_webui_pipe.py` by inserting a preprocessing step:
 
 1. Run heuristic precompiler (fast, high-precision cases)
-2. Fall back to LLM-based precompiler when needed
+2. Fall back to Open WebUI-native model completion when needed
 3. Pass resulting directive (or original input) to `engine.step(...)`
 
 Core decision handling remains the same as the base integration.
 """
 
-import importlib
 import logging
-import os
 from importlib.abc import Traversable
 from importlib.resources import as_file, files
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from fastapi import Request  # type: ignore[import-not-found]
 from open_webui.models.users import Users  # type: ignore[import-not-found]
 from open_webui.utils.chat import generate_chat_completion  # type: ignore[import-not-found]
+from open_webui.utils.models import get_all_models  # type: ignore[import-not-found]
 from pydantic import BaseModel, Field
 
 from context_compiler import State, create_engine, get_policy_items, get_premise_value
@@ -124,87 +124,46 @@ def _replace_compiler_system_message(
     ]
 
 
-def _llm_fallback_precompile(
-    message: str, state: State, *, prompt_profile: str, model: str
-) -> str | None:
-    with as_file(_prompt_file_path(prompt_profile)) as prompt_path:
-        prompt = render_prompt(prompt_path, state)
-    if prompt is None:
-        return None
+def _extract_completion_content(response: object) -> str | None:
+    choices_attr = getattr(response, "choices", None)
+    if isinstance(choices_attr, list) and choices_attr:
+        first_choice = choices_attr[0]
+        message_attr = getattr(first_choice, "message", None)
+        content_attr = getattr(message_attr, "content", None)
+        if isinstance(content_attr, str):
+            return content_attr
 
-    try:
-        litellm_module = importlib.import_module("litellm")
-        completion = cast(Any, litellm_module.completion)
-    except ModuleNotFoundError:
-        return None
+    if isinstance(response, dict):
+        choices = response.get("choices")
+        if isinstance(choices, list) and choices:
+            first_choice = choices[0]
+            if isinstance(first_choice, dict):
+                message = first_choice.get("message")
+                if isinstance(message, dict):
+                    content = message.get("content")
+                    if isinstance(content, str):
+                        return content
 
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        return None
-
-    kwargs: dict[str, Any] = {
-        "model": model,
-        "messages": [
-            {"role": "system", "content": prompt},
-            {"role": "user", "content": message},
-        ],
-        "api_key": api_key,
-        "temperature": 0,
-    }
-    api_base = os.getenv("OPENAI_BASE_URL")
-    if api_base:
-        kwargs["api_base"] = api_base
-
-    try:
-        response = completion(**kwargs)
-        raw_output = cast(Any, response.choices[0].message.content)
-    except Exception:
-        return None
-
-    parsed = parse_precompiler_output(raw_output)
-    if parsed is None or parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
-        return None
-    return parsed
-
-
-def _precompile_user_input(
-    message: str,
-    state: State,
-    *,
-    prompt_profile: str,
-    model: str,
-) -> str | None:
-    # Heuristic first for precision, determinism, and low latency.
-    # If heuristic does not produce a directive, try LLM fallback.
-    heuristic_result = precompile_heuristic(message)
-
-    if (
-        heuristic_result["outcome"] == PRECOMPILE_OUTCOME_DIRECTIVE
-        and heuristic_result["directive"]
-    ):
-        parsed = parse_precompiler_output(heuristic_result["directive"])
-        if parsed is not None and parsed != PRECOMPILER_NO_DIRECTIVE_SENTINEL:
-            return parsed
-
-    return _llm_fallback_precompile(
-        message,
-        state,
-        prompt_profile=prompt_profile,
-        model=model,
-    )
+    return None
 
 
 class Pipe:
     """Map Context Compiler decisions into Open WebUI pipe behavior.
 
     This variant adds a precompiler stage before ``engine.step(...)``:
-    heuristic first, then LLM fallback.
+    heuristic first, then Open WebUI-native LLM fallback.
     """
 
     class Valves(BaseModel):
         BASE_MODEL_ID: str = Field(
             default="",
             description="Open WebUI model id used as the base model for forwarding.",
+        )
+        PREPROCESSOR_MODEL_ID: str = Field(
+            default="",
+            description=(
+                "Optional model id for fallback precompilation (defaults to BASE_MODEL_ID)."
+            ),
         )
         PREPROCESSOR_PROMPT_PROFILE: Literal["default", "llama"] = Field(
             default="default",
@@ -249,14 +208,150 @@ class Pipe:
             )
         return None
 
+    def _normalize_preprocessor_error(self, response: Any) -> str | None:
+        if self._contains_model_not_found(response):
+            return (
+                "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID was not found "
+                "in Open WebUI models."
+            )
+        return None
+
+    def _normalize_preprocessor_exception(self, exc: Exception) -> str | None:
+        detail = getattr(exc, "detail", None)
+        if self._contains_model_not_found(detail) or self._contains_model_not_found(str(exc)):
+            return (
+                "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID was not found "
+                "in Open WebUI models."
+            )
+        return None
+
+    def _resolve_preprocessor_model_id(self, base_model_id: str) -> str:
+        preprocessor_model_id = self.valves.PREPROCESSOR_MODEL_ID.strip()
+        if preprocessor_model_id:
+            return preprocessor_model_id
+        return base_model_id
+
+    async def _validate_configured_model_ids(
+        self,
+        request: Request,
+        user_payload: dict[str, Any],
+        *,
+        base_model_id: str,
+        preprocessor_model_id: str,
+    ) -> str | None:
+        # Best-effort preflight: fail closed only for clear missing-model mismatches.
+        # If model discovery fails, preserve runtime behavior and rely on call-path
+        # normalization below.
+        user = Users.get_user_by_id(user_payload["id"])
+        try:
+            models = await get_all_models(request, user=user)
+        except Exception:
+            return None
+
+        known_model_ids: set[str] = set()
+        if isinstance(models, list):
+            for model in models:
+                if not isinstance(model, dict):
+                    continue
+                model_id = model.get("id")
+                if isinstance(model_id, str):
+                    known_model_ids.add(model_id)
+
+        if base_model_id and base_model_id not in known_model_ids:
+            return (
+                "Context Compiler pipe misconfigured: BASE_MODEL_ID was not found "
+                "in Open WebUI models."
+            )
+        if preprocessor_model_id and preprocessor_model_id not in known_model_ids:
+            return (
+                "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID was not found "
+                "in Open WebUI models."
+            )
+        return None
+
+    async def _llm_fallback_precompile(
+        self,
+        message: str,
+        state: State,
+        *,
+        request: Request,
+        user_payload: dict[str, Any],
+        prompt_profile: str,
+        model_id: str,
+    ) -> tuple[str | None, str | None]:
+        with as_file(_prompt_file_path(prompt_profile)) as prompt_path:
+            prompt = render_prompt(prompt_path, state)
+        if prompt is None:
+            return None, None
+
+        payload: dict[str, Any] = {
+            "model": model_id,
+            "stream": False,
+            "messages": [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": message},
+            ],
+        }
+        user = Users.get_user_by_id(user_payload["id"])
+        try:
+            response = await generate_chat_completion(request, payload, user)
+        except Exception as exc:
+            normalized_exception = self._normalize_preprocessor_exception(exc)
+            if normalized_exception is not None:
+                return None, normalized_exception
+            return None, None
+
+        normalized_error = self._normalize_preprocessor_error(response)
+        if normalized_error is not None:
+            return None, normalized_error
+
+        raw_output = _extract_completion_content(response)
+        parsed = parse_precompiler_output(raw_output)
+        if parsed is None or parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+            return None, None
+        return parsed, None
+
+    async def _precompile_user_input(
+        self,
+        message: str,
+        state: State,
+        *,
+        request: Request,
+        user_payload: dict[str, Any],
+        prompt_profile: str,
+        model_id: str,
+    ) -> tuple[str | None, str | None]:
+        # Heuristic first for precision, determinism, and low latency.
+        # If heuristic does not produce a directive, try Open WebUI-native fallback.
+        heuristic_result = precompile_heuristic(message)
+
+        if (
+            heuristic_result["outcome"] == PRECOMPILE_OUTCOME_DIRECTIVE
+            and heuristic_result["directive"]
+        ):
+            parsed = parse_precompiler_output(heuristic_result["directive"])
+            if parsed is not None and parsed != PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+                return parsed, None
+
+        return await self._llm_fallback_precompile(
+            message,
+            state,
+            request=request,
+            user_payload=user_payload,
+            prompt_profile=prompt_profile,
+            model_id=model_id,
+        )
+
     async def _forward_passthrough(
         self,
         body: dict[str, Any],
         user_payload: dict[str, Any],
         request: Request,
+        *,
+        base_model_id: str,
     ) -> Any:
         payload = {**body}
-        payload["model"] = self.valves.BASE_MODEL_ID
+        payload["model"] = base_model_id
         user = Users.get_user_by_id(user_payload["id"])
         try:
             response = await generate_chat_completion(request, payload, user)
@@ -276,9 +371,11 @@ class Pipe:
         user_payload: dict[str, Any],
         request: Request,
         state: State,
+        *,
+        base_model_id: str,
     ) -> Any:
         payload = {**body}
-        payload["model"] = self.valves.BASE_MODEL_ID
+        payload["model"] = base_model_id
 
         raw_messages = body.get("messages")
         messages = (
@@ -324,7 +421,9 @@ class Pipe:
             else []
         )
         base_model_id = self.valves.BASE_MODEL_ID.strip()
+        preprocessor_model_id = self._resolve_preprocessor_model_id(base_model_id)
         current_model_id = str(body.get("model", "")).strip()
+
         if not base_model_id and not self.valves.ALLOW_MISSING_BASE_MODEL_FOR_DEBUG:
             return (
                 "Context Compiler pipe misconfigured: BASE_MODEL_ID is required "
@@ -335,12 +434,31 @@ class Pipe:
                 "Context Compiler pipe misconfigured: BASE_MODEL_ID must not match "
                 "the selected pipe model id to avoid recursive routing."
             )
+        if preprocessor_model_id and current_model_id and preprocessor_model_id == current_model_id:
+            return (
+                "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID must not "
+                "match the selected pipe model id to avoid recursive routing."
+            )
+
+        preflight_error = await self._validate_configured_model_ids(
+            __request__,
+            __user__,
+            base_model_id=base_model_id,
+            preprocessor_model_id=preprocessor_model_id,
+        )
+        if preflight_error is not None:
+            return preflight_error
 
         latest_user_text = _extract_latest_user_text(messages)
         logger.debug("preprocessor: user_input_found=%s", latest_user_text is not None)
 
         if latest_user_text is None:
-            return await self._forward_passthrough(body, __user__, __request__)
+            return await self._forward_passthrough(
+                body,
+                __user__,
+                __request__,
+                base_model_id=base_model_id,
+            )
 
         chat_key = _resolve_chat_key(__user__, __chat_id__, __metadata__)
         engine = _ENGINES_BY_CHAT_KEY.get(chat_key)
@@ -348,12 +466,17 @@ class Pipe:
             engine = create_engine()
             _ENGINES_BY_CHAT_KEY[chat_key] = engine
 
-        precompiled = _precompile_user_input(
+        precompiled, precompile_error = await self._precompile_user_input(
             latest_user_text,
             engine.state,
+            request=__request__,
+            user_payload=__user__,
             prompt_profile=self.valves.PREPROCESSOR_PROMPT_PROFILE,
-            model=base_model_id,
+            model_id=preprocessor_model_id,
         )
+        if precompile_error is not None:
+            return precompile_error
+
         logger.debug("preprocessor: precompiled=%r", precompiled)
         # Preserve core behavior: if precompile yields no directive, use raw user
         # text so the compiler still decides clarify/passthrough/update.
@@ -367,8 +490,24 @@ class Pipe:
         if kind == "clarify":
             return decision["prompt_to_user"] or ""
         if kind == "passthrough":
-            return await self._forward_passthrough(body, __user__, __request__)
+            return await self._forward_passthrough(
+                body,
+                __user__,
+                __request__,
+                base_model_id=base_model_id,
+            )
         if kind == "update":
-            return await self._forward_update(body, __user__, __request__, engine.state)
+            return await self._forward_update(
+                body,
+                __user__,
+                __request__,
+                engine.state,
+                base_model_id=base_model_id,
+            )
 
-        return await self._forward_passthrough(body, __user__, __request__)
+        return await self._forward_passthrough(
+            body,
+            __user__,
+            __request__,
+            base_model_id=base_model_id,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.3"
+version = "0.6.4"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_litellm_preprocessor_model_config.py
+++ b/tests/test_litellm_preprocessor_model_config.py
@@ -1,0 +1,131 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+LITELLM_WITH_PREPROC_PATH = Path("examples/integrations/litellm/with_preprocessor.py")
+LITELLM_PROXY_WITH_PREPROC_PATH = Path(
+    "examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py"
+)
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_litellm_proxy_module_with_stubs(monkeypatch, module_name: str):
+    litellm_mod = types.ModuleType("litellm")
+    integrations_mod = types.ModuleType("litellm.integrations")
+    custom_logger_mod = types.ModuleType("litellm.integrations.custom_logger")
+
+    class _CustomLogger:
+        pass
+
+    custom_logger_mod.CustomLogger = _CustomLogger
+
+    monkeypatch.setitem(sys.modules, "litellm", litellm_mod)
+    monkeypatch.setitem(sys.modules, "litellm.integrations", integrations_mod)
+    monkeypatch.setitem(sys.modules, "litellm.integrations.custom_logger", custom_logger_mod)
+
+    return _load_module(module_name, LITELLM_PROXY_WITH_PREPROC_PATH)
+
+
+def test_litellm_preprocessor_model_defaults_to_model(monkeypatch):
+    module = _load_module("litellm_with_preproc_cfg_default", LITELLM_WITH_PREPROC_PATH)
+
+    seen: dict[str, Any] = {}
+
+    def _completion(**kwargs):
+        seen["model"] = kwargs["model"]
+        return {"choices": [{"message": {"content": "use docker"}}]}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("MODEL", "openai/main-model")
+    monkeypatch.delenv("PREPROCESSOR_MODEL", raising=False)
+
+    monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
+    monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
+
+    result = module._llm_fallback_precompile("please use docker", None)
+
+    assert result == "use docker"
+    assert seen["model"] == "openai/main-model"
+
+
+def test_litellm_preprocessor_model_override(monkeypatch):
+    module = _load_module("litellm_with_preproc_cfg_override", LITELLM_WITH_PREPROC_PATH)
+
+    seen: dict[str, Any] = {}
+
+    def _completion(**kwargs):
+        seen["model"] = kwargs["model"]
+        return {"choices": [{"message": {"content": "use docker"}}]}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("MODEL", "openai/main-model")
+    monkeypatch.setenv("PREPROCESSOR_MODEL", "openai/preprocessor-model")
+
+    monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
+    monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
+
+    result = module._llm_fallback_precompile("please use docker", None)
+
+    assert result == "use docker"
+    assert seen["model"] == "openai/preprocessor-model"
+
+
+def test_litellm_proxy_preprocessor_model_defaults_to_model(monkeypatch):
+    module = _load_litellm_proxy_module_with_stubs(
+        monkeypatch, "litellm_proxy_with_preproc_cfg_default"
+    )
+
+    seen: dict[str, Any] = {}
+
+    def _completion(**kwargs):
+        seen["model"] = kwargs["model"]
+        return {"choices": [{"message": {"content": "use docker"}}]}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("MODEL", "openai/main-model")
+    monkeypatch.delenv("PREPROCESSOR_MODEL", raising=False)
+
+    monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
+    monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
+
+    result = module._llm_fallback_precompile("please use docker", None)
+
+    assert result == "use docker"
+    assert seen["model"] == "openai/main-model"
+
+
+def test_litellm_proxy_preprocessor_model_override(monkeypatch):
+    module = _load_litellm_proxy_module_with_stubs(
+        monkeypatch, "litellm_proxy_with_preproc_cfg_override"
+    )
+
+    seen: dict[str, Any] = {}
+
+    def _completion(**kwargs):
+        seen["model"] = kwargs["model"]
+        return {"choices": [{"message": {"content": "use docker"}}]}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("MODEL", "openai/main-model")
+    monkeypatch.setenv("PREPROCESSOR_MODEL", "openai/preprocessor-model")
+
+    monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
+    monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
+
+    result = module._llm_fallback_precompile("please use docker", None)
+
+    assert result == "use docker"
+    assert seen["model"] == "openai/preprocessor-model"

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -1,0 +1,163 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+MODULE_PATH = Path("examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py")
+
+
+def _load_module_with_openwebui_stubs(module_name: str):
+    fastapi_mod = types.ModuleType("fastapi")
+
+    class _Request:  # minimal placeholder for type import
+        pass
+
+    fastapi_mod.Request = _Request
+
+    open_webui_mod = types.ModuleType("open_webui")
+    open_webui_models_mod = types.ModuleType("open_webui.models")
+    open_webui_models_users_mod = types.ModuleType("open_webui.models.users")
+    open_webui_utils_mod = types.ModuleType("open_webui.utils")
+    open_webui_utils_chat_mod = types.ModuleType("open_webui.utils.chat")
+    open_webui_utils_models_mod = types.ModuleType("open_webui.utils.models")
+
+    class _Users:
+        @staticmethod
+        def get_user_by_id(user_id: object) -> dict[str, object]:
+            return {"id": user_id}
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        return {"choices": [{"message": {"content": payload.get("_mock_content", "")}}]}
+
+    async def _all_models(_: object, user: object = None) -> list[dict[str, str]]:
+        del user
+        return [{"id": "base-model"}, {"id": "prep-model"}, {"id": "pipe-model"}]
+
+    open_webui_models_users_mod.Users = _Users
+    open_webui_utils_chat_mod.generate_chat_completion = _chat_completion
+    open_webui_utils_models_mod.get_all_models = _all_models
+
+    sys.modules["fastapi"] = fastapi_mod
+    sys.modules["open_webui"] = open_webui_mod
+    sys.modules["open_webui.models"] = open_webui_models_mod
+    sys.modules["open_webui.models.users"] = open_webui_models_users_mod
+    sys.modules["open_webui.utils"] = open_webui_utils_mod
+    sys.modules["open_webui.utils.chat"] = open_webui_utils_chat_mod
+    sys.modules["open_webui.utils.models"] = open_webui_utils_models_mod
+
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_preprocessor_model_defaults_to_base_model() -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_defaults")
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = ""
+
+    assert pipe._resolve_preprocessor_model_id("base-model") == "base-model"
+
+
+def test_preprocessor_model_can_be_overridden() -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_override")
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+
+    assert pipe._resolve_preprocessor_model_id("base-model") == "prep-model"
+
+
+def test_invalid_preprocessor_model_is_normalized() -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_invalid")
+    pipe = module.Pipe()
+
+    async def _models(_: object, user: object = None) -> list[dict[str, str]]:
+        del user
+        return [{"id": "base-model"}]
+
+    module.get_all_models = _models
+
+    error = asyncio.run(
+        pipe._validate_configured_model_ids(
+            request=object(),
+            user_payload={"id": "u1"},
+            base_model_id="base-model",
+            preprocessor_model_id="missing-prep-model",
+        )
+    )
+
+    assert error == (
+        "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID was not found "
+        "in Open WebUI models."
+    )
+
+
+def test_preprocessor_fallback_uses_preprocessor_model_only() -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_routing")
+    pipe = module.Pipe()
+
+    calls: list[str] = []
+
+    async def _chat_completion(_: object, payload: dict[str, Any], __: object) -> dict[str, object]:
+        calls.append(str(payload.get("model", "")))
+        # First call is fallback precompile completion; return no directive.
+        # Second call is main forward passthrough.
+        if len(calls) == 1:
+            return {"choices": [{"message": {"content": "no_directive"}}]}
+        return {"ok": True}
+
+    async def _models(_: object, user: object = None) -> list[dict[str, str]]:
+        del user
+        return [{"id": "base-model"}, {"id": "prep-model"}, {"id": "pipe-model"}]
+
+    def _heuristic(_: str) -> dict[str, object]:
+        return {"outcome": "no_directive", "directive": None}
+
+    module.generate_chat_completion = _chat_completion
+    module.get_all_models = _models
+    module.precompile_heuristic = _heuristic
+
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+
+    body = {
+        "model": "pipe-model",
+        "messages": [{"role": "user", "content": "please use docker"}],
+    }
+    result = asyncio.run(
+        pipe.pipe(
+            body,
+            __user__={"id": "u1"},
+            __request__=object(),
+        )
+    )
+
+    assert result == {"ok": True}
+    assert calls == ["prep-model", "base-model"]
+
+
+def test_recursion_guard_for_preprocessor_model() -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_recursion")
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "pipe-model"
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hi"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+        )
+    )
+
+    assert result == (
+        "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID must not "
+        "match the selected pipe model id to avoid recursive routing."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed
- switched `open_webui_pipe_with_preprocessor.py` fallback precompile calls from LiteLLM to OpenWebUI-native `generate_chat_completion` model routing
- added optional `PREPROCESSOR_MODEL_ID` valve that defaults to `BASE_MODEL_ID`
- kept OpenWebUI main response forwarding on `BASE_MODEL_ID`
- added runtime model-id preflight/normalization for `BASE_MODEL_ID` and `PREPROCESSOR_MODEL_ID`
- added recursion guards for configured model ids vs selected pipe model id
- updated OpenWebUI integration README to reflect optional/experimental preprocessor behavior and new model-id handling
- fixed Python 3.14 compatibility for `Traversable` imports in preprocessor examples
- implemented LiteLLM-side follow-up for issue scope completion:
  - `examples/integrations/litellm/with_preprocessor.py`: `PREPROCESSOR_MODEL` now optional and defaults to `MODEL`
  - `examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py`: `PREPROCESSOR_MODEL` now optional and defaults to `MODEL`
- updated LiteLLM integration READMEs to document `PREPROCESSOR_MODEL` defaulting behavior
- added focused tests:
  - `tests/test_openwebui_preprocessor_pipe.py`
  - `tests/test_litellm_preprocessor_model_config.py`
- bumped package version to `0.6.4` and synced `uv.lock`

## Why this was needed
- OpenWebUI preprocessor fallback should not require LiteLLM when host model routing is already available
- preprocessor integrations need optional dedicated preprocessor-model control while preserving backward-compatible defaults
- invalid model-id misconfigurations should surface as clear runtime messages instead of opaque failures

Closes #87