### PR TITLE
docs: follow up openwebui minimal installability after 0.6.4

### DIFF
--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -11,11 +11,11 @@ Tested target: Open WebUI `v0.8.12` (latest at time of testing).
 
 ## Setup
 
-1. Install integration support in the Open WebUI Python environment:
-   - `pip install "context-compiler[integrations]"`
-2. Add one of the files above as a Function in Open WebUI.
-3. Set `BASE_MODEL_ID` to a valid Open WebUI model id (required).
-4. Select the pipe model in chat.
+1. Import `open_webui_pipe.py` (recommended/default) as a Function by URL.
+2. Open WebUI installs `context-compiler>=0.6.4` from the function frontmatter requirements.
+3. Enable the function.
+4. Set `BASE_MODEL_ID` to a valid Open WebUI model id (required).
+5. Select the pipe model in chat.
 
 Open WebUI is host-provided runtime infrastructure and must already be installed/configured separately.
 
@@ -34,6 +34,22 @@ If using `open_webui_pipe_with_preprocessor.py`:
 - Invalid configured model ids return explicit runtime misconfiguration errors:
   - `BASE_MODEL_ID` not found in Open WebUI models
   - `PREPROCESSOR_MODEL_ID` not found in Open WebUI models
+
+### Docker/manual install fallback
+
+If frontmatter dependency installs are disabled, offline, or unavailable:
+
+1. Open a shell in the Open WebUI container:
+   - `docker exec -it <openwebui-container> sh`
+2. Install the package manually:
+   - Minimal pipe: `pip install "context-compiler>=0.6.4"`
+   - Preprocessor pipe: `pip install "context-compiler[experimental]>=0.6.4"`
+3. Import and enable the function in Open WebUI, then configure valves.
+
+### Finding valid model ids
+
+Use the Open WebUI model picker/list to copy exact model ids for `BASE_MODEL_ID`
+(and optional `PREPROCESSOR_MODEL_ID` for the preprocessor pipe).
 
 ## Limitations
 

--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -12,7 +12,7 @@ Tested target: Open WebUI `v0.8.12` (latest at time of testing).
 ## Setup
 
 1. Import `open_webui_pipe.py` (recommended/default) as a Function by URL.
-2. Open WebUI installs `context-compiler>=0.6.4` from the function frontmatter requirements.
+2. Open WebUI installs `context-compiler>=0.6.5` from the function frontmatter requirements.
 3. Enable the function.
 4. Set `BASE_MODEL_ID` to a valid Open WebUI model id (required).
 5. Select the pipe model in chat.
@@ -42,8 +42,8 @@ If frontmatter dependency installs are disabled, offline, or unavailable:
 1. Open a shell in the Open WebUI container:
    - `docker exec -it <openwebui-container> sh`
 2. Install the package manually:
-   - Minimal pipe: `pip install "context-compiler>=0.6.4"`
-   - Preprocessor pipe: `pip install "context-compiler[experimental]>=0.6.4"`
+   - Minimal pipe: `pip install "context-compiler>=0.6.5"`
+   - Preprocessor pipe: `pip install "context-compiler[experimental]>=0.6.5"`
 3. Import and enable the function in Open WebUI, then configure valves.
 
 ### Finding valid model ids

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -4,7 +4,7 @@ author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
 version: 0.1
-requirements: context-compiler>=0.6.4
+requirements: context-compiler>=0.6.5
 
 Minimal Open WebUI Pipe integration for Context Compiler.
 

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -4,6 +4,7 @@ author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
 version: 0.1
+requirements: context-compiler>=0.6.4
 
 Minimal Open WebUI Pipe integration for Context Compiler.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.4"
+version = "0.6.5"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed
- Added OpenWebUI frontmatter dependency declaration to the minimal pipe example: requirements: context-compiler>=0.6.4
- Tightened OpenWebUI integration setup guidance for the default minimal path: import by URL, frontmatter-driven dependency install, enable function, configure BASE_MODEL_ID, select pipe model
- Added explicit Docker/manual fallback instructions for environments where frontmatter installs are unavailable: docker exec -it <openwebui-container> sh, pip install "context-compiler>=0.6.4", and preprocessor note for context-compiler[experimental]>=0.6.4
- Added a short note on finding valid model IDs.

## Why
The published 0.6.4 path was close but the minimal OpenWebUI pipe lacked frontmatter requirements, which made URL-import auto-install less reliable. This follow-up aligns the minimal pipe and README with the intended easy-install story without changing integration behavior.