### PR TITLE
chore: prepare 0.6.6 installability docs patch

### DIFF
--- a/examples/integrations/litellm/README.md
+++ b/examples/integrations/litellm/README.md
@@ -18,6 +18,42 @@ For `with_preprocessor.py`:
 pip install "context-compiler[experimental]"
 ```
 
+## Quickstart (copy/paste)
+
+```shell
+pip install "context-compiler[integrations]"
+export OPENAI_API_KEY=...
+export MODEL=openai/gpt-4o-mini
+python - <<'PY'
+from context_compiler import create_engine
+from examples.integrations.litellm.basic import handle_turn
+engine = create_engine()
+print(handle_turn("set premise concise replies", engine))
+PY
+```
+
+For preprocessor behavior:
+
+```shell
+pip install "context-compiler[experimental]"
+export OPENAI_API_KEY=...
+export MODEL=openai/gpt-4o-mini
+python - <<'PY'
+from context_compiler import create_engine
+from examples.integrations.litellm.with_preprocessor import handle_turn
+engine = create_engine()
+print(handle_turn("set premise to concise replies", engine))
+PY
+```
+
+## Environment configuration
+
+Required:
+
+```shell
+export OPENAI_API_KEY=...
+```
+
 Optional:
 
 ```shell
@@ -41,6 +77,12 @@ These files are importable integration references for host applications.
 - Create and retain an engine instance in host/session state.
 - Pass each user input through `handle_turn(user_input, engine)`.
 - Display the returned assistant text.
+
+## Troubleshooting
+
+- `litellm is required`: install `context-compiler[integrations]` (or `context-compiler[experimental]` for preprocessor).
+- `OPENAI_API_KEY is required`: export a key before running.
+- model/provider errors (`Model not found`, provider auth errors): confirm `MODEL` uses LiteLLM format and provider credentials are valid.
 
 ## Basic vs preprocessor behavior
 

--- a/examples/integrations/litellm_proxy/README.md
+++ b/examples/integrations/litellm_proxy/README.md
@@ -24,6 +24,16 @@ For `context_compiler_precall_hook_with_preprocessor.py`:
 pip install "context-compiler[experimental]"
 ```
 
+### Quickstart (copy/paste)
+
+From the repo root:
+
+```shell
+pip install "context-compiler[litellm_proxy]"
+export OPENAI_API_KEY=...
+litellm --config examples/integrations/litellm_proxy/config.example.yaml
+```
+
 ### Run proxy
 
 Typical startup command (environment-sensitive):
@@ -40,6 +50,7 @@ was not re-validated end-to-end as-is in the latest smoke pass with
 The proxy runs on `http://localhost:4000` by default.
 By default, `config.example.yaml` points to the basic replay-only hook.
 To use the preprocessor variant, switch the callback path in the config.
+Run from the repo root, or set `PYTHONPATH` so `examples.integrations...` callback imports resolve.
 
 ### Make a request
 
@@ -97,3 +108,9 @@ Use `llama` only for LLM-only preprocessing with Llama-family models.
 
 - The callback path in `config.example.yaml` must be importable.
   Run the proxy from the repo root or set `PYTHONPATH` accordingly.
+
+### Troubleshooting
+
+- `ModuleNotFoundError` for callback path: run from repo root, or set `PYTHONPATH=<repo-root>`.
+- proxy starts but upstream calls fail: check `OPENAI_API_KEY` and upstream model/provider config in `config.example.yaml`.
+- preprocessor fallback issues: `PREPROCESSOR_MODEL` defaults to `MODEL`; set it explicitly only when using a separate fallback model.

--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -3,6 +3,7 @@
 Open WebUI Pipe Function examples for Context Compiler.
 
 Tested target: Open WebUI `v0.8.12` (latest at time of testing).
+Runtime-validated on stock Docker Open WebUI with a real backend model provider.
 
 ## Files
 
@@ -11,13 +12,16 @@ Tested target: Open WebUI `v0.8.12` (latest at time of testing).
 
 ## Setup
 
+The minimal pipe path below is the easiest first-run flow and was validated end-to-end in Docker with a real backend model.
+
 1. Import `open_webui_pipe.py` (recommended/default) as a Function by URL.
-2. Open WebUI installs `context-compiler>=0.6.5` from the function frontmatter requirements.
+2. Open WebUI installs `context-compiler>=0.6.6` from the function frontmatter requirements.
 3. Enable the function.
 4. Set `BASE_MODEL_ID` to a valid Open WebUI model id (required).
 5. Select the pipe model in chat.
 
 Open WebUI is host-provided runtime infrastructure and must already be installed/configured separately.
+Open WebUI also needs at least one real backend model/provider configured (for example Ollama or OpenAI) so `BASE_MODEL_ID` resolves to an actual model.
 
 If using `open_webui_pipe_with_preprocessor.py`:
 - Install preprocessor support in the Open WebUI environment:
@@ -42,8 +46,8 @@ If frontmatter dependency installs are disabled, offline, or unavailable:
 1. Open a shell in the Open WebUI container:
    - `docker exec -it <openwebui-container> sh`
 2. Install the package manually:
-   - Minimal pipe: `pip install "context-compiler>=0.6.5"`
-   - Preprocessor pipe: `pip install "context-compiler[experimental]>=0.6.5"`
+   - Minimal pipe: `pip install "context-compiler>=0.6.6"`
+   - Preprocessor pipe: `pip install "context-compiler[experimental]>=0.6.6"`
 3. Import and enable the function in Open WebUI, then configure valves.
 
 ### Finding valid model ids

--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -12,7 +12,7 @@ Runtime-validated on stock Docker Open WebUI with a real backend model provider.
 
 ## Setup
 
-The minimal pipe path below is the easiest first-run flow and was validated end-to-end in Docker with a real backend model.
+The minimal pipe path below is the easiest first-run flow and was runtime-validated in Docker via API flow with a real backend model.
 
 1. Import `open_webui_pipe.py` (recommended/default) as a Function by URL.
 2. Open WebUI installs `context-compiler>=0.6.6` from the function frontmatter requirements.

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -4,7 +4,7 @@ author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
 version: 0.1
-requirements: context-compiler>=0.6.5
+requirements: context-compiler>=0.6.6
 
 Minimal Open WebUI Pipe integration for Context Compiler.
 

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -4,7 +4,7 @@ author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
 version: 0.1
-requirements: context-compiler[experimental]>=0.6.4
+requirements: context-compiler[experimental]>=0.6.6
 
 Open WebUI integration with Context Compiler preprocessor.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.5"
+version = "0.6.6"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.5"
+version = "0.6.6"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed
- Bumped package version to 0.6.6 (`pyproject.toml`, `uv.lock`).
- Aligned OpenWebUI packaged example frontmatter and install docs to 0.6.6:
  - `open_webui_pipe.py` now requires `context-compiler>=0.6.6`.
  - `open_webui_pipe_with_preprocessor.py` now requires `context-compiler[experimental]>=0.6.6`.
  - OpenWebUI README fallback/install examples now reference 0.6.6.
- Updated OpenWebUI messaging to reflect validated runtime behavior:
  - minimal pipe remains default/recommended and easy to try.
  - preprocessor path remains optional/experimental.
  - explicit note that a real backend model/provider must be configured.
- Improved LiteLLM and LiteLLM Proxy first-run usability docs:
  - copy/paste quickstart sections
  - required vs optional environment/config guidance
  - explicit `PREPROCESSOR_MODEL` defaults-to-`MODEL` guidance
  - clearer proxy callback import/path guidance
  - concise troubleshooting notes.

## Why
This is a narrow 0.6.6 patch focused on docs/examples/installability/usability alignment after runtime validation, without changing core engine behavior or redesigning integrations.
