### PR TITLE
refactor: use public state helpers in user-facing code

### DIFF
--- a/examples/_util.py
+++ b/examples/_util.py
@@ -1,5 +1,7 @@
 import json
-from typing import Any
+from typing import Any, Literal
+
+from context_compiler import get_policy_items, get_premise_value
 
 
 def canonical_json(obj: Any) -> str:
@@ -10,21 +12,19 @@ def print_json(obj: Any) -> None:
     print(canonical_json(obj))
 
 
-def _format_policy_values(policies: dict[str, str], value: str) -> str:
-    items = sorted(key for key, stored in policies.items() if stored == value)
+def _format_policy_values(state: Any, value: Literal["use", "prohibit"]) -> str:
+    items = get_policy_items(state, value)
     return ", ".join(items) if items else "(none)"
 
 
 def print_state_summary(state: Any, label: str = "state") -> None:
-    premise = state.get("premise")
+    premise = get_premise_value(state)
     premise_text = premise if premise is not None else "(none)"
-    policies = state.get("policies")
-    assert isinstance(policies, dict)
 
     print(f"{label}:")
     print(f"- premise: {premise_text}")
-    print(f"- use policies: {_format_policy_values(policies, 'use')}")
-    print(f"- prohibit policies: {_format_policy_values(policies, 'prohibit')}")
+    print(f"- use policies: {_format_policy_values(state, 'use')}")
+    print(f"- prohibit policies: {_format_policy_values(state, 'prohibit')}")
 
 
 def print_decision_summary(decision: Any) -> None:

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -1,7 +1,7 @@
 import sys
 from typing import TextIO
 
-from . import create_engine
+from . import create_engine, get_policy_items, get_premise_value
 from .engine import Decision, DecisionKind, State
 
 _EXIT_TOKENS = {"exit", "quit"}
@@ -45,10 +45,18 @@ def _print_interactive_help(out_stream: TextIO) -> None:
 
 
 def _render_state_lines(state: State) -> list[str]:
-    premise = state["premise"]
+    premise = get_premise_value(state)
     premise_line = "premise: (none)" if premise is None else f"premise: {premise}"
 
-    policy_items = sorted(state["policies"].items())
+    all_policy_items = get_policy_items(state)
+    if not all_policy_items:
+        return [premise_line, "policies: (none)"]
+
+    use_items = set(get_policy_items(state, "use"))
+    policy_items: list[tuple[str, str]] = []
+    for item in all_policy_items:
+        value = "use" if item in use_items else "prohibit"
+        policy_items.append((item, value))
     if not policy_items:
         return [premise_line, "policies: (none)"]
 


### PR DESCRIPTION
## What changed
- Replaced direct `premise` reads in user-facing helpers with `get_premise_value(state)`.
- Replaced direct `policies` reads/iteration in user-facing helpers with `get_policy_items(state, ...)`.
- Updated REPL state rendering to derive policy display lines via public helpers while preserving output order and formatting.

## Why this was needed
- Keeps user-facing/reference code aligned with the public read boundary instead of raw state-shape coupling.
- Reduces schema-coupling risk in examples and REPL while preserving existing behavior.