### PR TITLE
feat: add checkpoint export/import api with serialized continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,12 @@ Meaning:
 | `engine.state` | Read current authoritative in-memory state snapshot. |
 | `get_premise_value(state)` | Read the current premise value from a state snapshot. |
 | `get_policy_items(state, value=None)` | Read policy items from a state snapshot (all, `use`, or `prohibit`). |
-| `engine.export_json()` | Export current state as JSON for persistence/transport. |
-| `engine.import_json(payload)` | Load/restore state from exported JSON payload. |
+| `engine.export_json()` | Export authoritative state as JSON (`str`) for state transport/persistence. |
+| `engine.import_json(payload)` | Load/restore authoritative state from exported JSON (`str`). |
+| `engine.export_checkpoint()` | Export resumable checkpoint object (`Checkpoint`). |
+| `engine.import_checkpoint(payload)` | Restore full checkpoint (`Checkpoint`) and return `None`. |
+| `engine.export_checkpoint_json()` | Export checkpoint as canonical JSON (`str`). |
+| `engine.import_checkpoint_json(payload)` | Restore checkpoint from JSON (`str`) and return `None`. |
 
 ---
 
@@ -197,6 +201,50 @@ The compiler maintains an authoritative state snapshot.
 Identical input sequences always produce identical state.
 
 The internal structure of the state is intentionally opaque to host applications.
+
+---
+
+## Checkpoint Contract
+
+`export_json()` / `import_json()` and checkpoint APIs serve different boundaries:
+
+- `export_json()` / `import_json()` transport **authoritative state only**
+- checkpoint APIs transport **serialized continuation**:
+  - authoritative state
+  - pending confirmation-required continuation state
+
+Checkpoint object shape:
+
+```json
+{
+  "checkpoint_version": 1,
+  "authoritative_state": {
+    "premise": "concise replies",
+    "policies": {
+      "docker": "use"
+    },
+    "version": 2
+  },
+  "pending": {
+    "kind": "replacement",
+    "replacement": {
+      "kind": "use_only",
+      "new_item": "kubectl",
+      "old_item": null
+    },
+    "prompt_to_user": "..."
+  }
+}
+```
+
+Notes:
+
+- `pending` is `null` when no continuation is waiting for confirmation.
+- `pending` captures confirmation-required operations (for example replacement flows).
+- `old_item` may be `null` for `"use_only"` when confirming “use X instead?” without an existing exact policy to replace.
+- checkpoint restore is full and deterministic: authoritative state and pending continuation are restored together.
+- checkpoint validation is all-or-nothing; invalid payloads raise and no partial restore occurs.
+- `checkpoint_version` is independent of authoritative state `version` and must be bumped when checkpoint contract shape changes (especially `pending`).
 
 ---
 

--- a/docs/DescriptionAndMilestones.md
+++ b/docs/DescriptionAndMilestones.md
@@ -73,10 +73,12 @@ Extend host-level workflows around persisted exported state safely and intention
 - Export the current authoritative state
 - Initialize a new engine from previously exported state
 - Ensure restored state behaves identically to live state
+- Support serialized continuation checkpoints for restoring both authoritative state and pending confirmation-required continuation state
 
 **Deliverables:**
 
 - Host-side storage/recovery patterns built on the existing import/export API
+- Host-side storage/recovery patterns for checkpoint object/JSON continuation restore
 
 **User-visible outcome:**
 

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -328,6 +328,48 @@ JSON persistence boundary:
 - `engine.export_json()` serializes authoritative state.
 - `engine.import_json(payload)` validates/canonicalizes payload and replaces active state.
 
+Checkpoint boundary:
+
+- `engine.export_checkpoint()` exports a checkpoint object contract.
+- `engine.import_checkpoint(payload)` validates/restores a checkpoint object and returns `None`.
+- `engine.export_checkpoint_json()` and `engine.import_checkpoint_json(payload)` are JSON string wrappers around the object form.
+- Checkpoint includes both authoritative state and pending continuation state.
+
+Checkpoint object contract:
+
+```json
+{
+  "checkpoint_version": 1,
+  "authoritative_state": {
+    "premise": "Use concise, formal language.",
+    "policies": {
+      "docker": "prohibit",
+      "pytest": "use"
+    },
+    "version": 2
+  },
+  "pending": {
+    "kind": "replacement",
+    "replacement": {
+      "kind": "use_only",
+      "new_item": "kubectl",
+      "old_item": null
+    },
+    "prompt_to_user": "..."
+  }
+}
+```
+
+Checkpoint semantics:
+
+- `authoritative_state` uses the same validation/canonicalization boundary as `export_json` / `import_json`.
+- `pending` captures confirmation-required continuation (for example replacement clarifications).
+- `pending` is `null` when there is no outstanding continuation.
+- In `"use_only"` pending replacement cases, `old_item` may be `null` because no exact existing policy matched for replacement; confirmation asks whether to apply a new `use` item while keeping current policies.
+- Restore is all-or-nothing: invalid checkpoint payloads raise and no partial state restore occurs.
+- Continuation behavior is deterministic after restore (same confirmation token handling and resolution outcomes as live pending state).
+- `checkpoint_version` is independent of authoritative state `version`; it must be bumped when checkpoint contract shape changes (especially `pending`).
+
 ## 12. Invariants
 
 1. State changes only from valid directive transitions or pending-confirmation acceptance.

--- a/src/context_compiler/__init__.py
+++ b/src/context_compiler/__init__.py
@@ -2,6 +2,7 @@ from importlib.metadata import version
 
 from .engine import (
     ApplyResult,
+    Checkpoint,
     Decision,
     Engine,
     State,
@@ -17,6 +18,7 @@ __version__ = version("context-compiler")
 
 __all__ = [
     "ApplyResult",
+    "Checkpoint",
     "Decision",
     "Engine",
     "State",

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -28,6 +28,24 @@ class State(TypedDict):
     version: Literal[2]
 
 
+class CheckpointPendingReplacement(TypedDict):
+    kind: Literal["use_only", "replace_use"]
+    new_item: str
+    old_item: str | None
+
+
+class CheckpointPending(TypedDict):
+    kind: Literal["replacement"]
+    replacement: CheckpointPendingReplacement
+    prompt_to_user: str
+
+
+class Checkpoint(TypedDict):
+    checkpoint_version: Literal[1]
+    authoritative_state: State
+    pending: CheckpointPending | None
+
+
 class DecisionKind(StrEnum):
     UPDATE = "update"
     PASSTHROUGH = "passthrough"
@@ -99,6 +117,7 @@ _PASSTHROUGH: Decision = {
 _AFFIRMATIVE_CONFIRMATIONS = {"yes", "yes please", "yep", "yeah", "sure", "ok", "okay"}
 _NEGATIVE_CONFIRMATIONS = {"no", "nope", "no thanks"}
 _TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
+_CHECKPOINT_VERSION: Literal[1] = 1
 
 
 def create_engine(state: State | None = None) -> "Engine":
@@ -136,6 +155,45 @@ class Engine:
 
     def import_json(self, payload: str) -> None:
         self._replace_state(_load_state_json(payload))
+
+    def export_checkpoint(self) -> Checkpoint:
+        pending: CheckpointPending | None = None
+        if self._pending_replacement is not None:
+            assert self._pending_prompt is not None
+            pending = {
+                "kind": "replacement",
+                "replacement": {
+                    "kind": self._pending_replacement.kind,
+                    "new_item": self._pending_replacement.new_item,
+                    "old_item": self._pending_replacement.old_item,
+                },
+                "prompt_to_user": self._pending_prompt,
+            }
+
+        # Reuse authoritative export/import path for canonicalized state payload.
+        authoritative_state = _load_state_json(self.export_json())
+        return {
+            "checkpoint_version": _CHECKPOINT_VERSION,
+            "authoritative_state": authoritative_state,
+            "pending": pending,
+        }
+
+    def import_checkpoint(self, payload: Checkpoint) -> None:
+        state, pending_replacement, pending_prompt = _load_checkpoint_obj(payload)
+        self._replace_state(state)
+        self._pending_replacement = pending_replacement
+        self._pending_prompt = pending_prompt
+
+    def export_checkpoint_json(self) -> str:
+        return json.dumps(self.export_checkpoint(), sort_keys=True, separators=(",", ":"))
+
+    def import_checkpoint_json(self, payload: str) -> None:
+        try:
+            raw = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Invalid JSON payload.") from exc
+
+        self.import_checkpoint(raw)
 
     def step(self, user_input: str) -> Decision:
         if self._pending_replacement is not None:
@@ -538,6 +596,67 @@ def _load_state_obj(raw: object) -> State:
         STATE_POLICIES: dict(sorted(normalized_policies.items())),
         STATE_VERSION: SCHEMA_VERSION,
     }
+
+
+def _load_checkpoint_obj(raw: object) -> tuple[State, PendingReplacement | None, str | None]:
+    if not isinstance(raw, dict):
+        raise ValueError("Invalid checkpoint payload.")
+
+    if set(raw.keys()) != {"checkpoint_version", "authoritative_state", "pending"}:
+        raise ValueError("Invalid checkpoint payload.")
+
+    checkpoint_version = raw["checkpoint_version"]
+    if checkpoint_version != _CHECKPOINT_VERSION:
+        raise ValueError(f"Unsupported checkpoint version: {checkpoint_version!r}")
+
+    authoritative_state = _load_state_obj(raw["authoritative_state"])
+    pending_replacement, pending_prompt = _load_checkpoint_pending_obj(raw["pending"])
+    return authoritative_state, pending_replacement, pending_prompt
+
+
+def _load_checkpoint_pending_obj(
+    raw: object,
+) -> tuple[PendingReplacement | None, str | None]:
+    if raw is None:
+        return None, None
+    if not isinstance(raw, dict):
+        raise ValueError("Invalid checkpoint payload.")
+    if set(raw.keys()) != {"kind", "replacement", "prompt_to_user"}:
+        raise ValueError("Invalid checkpoint payload.")
+    if raw["kind"] != "replacement":
+        raise ValueError("Invalid checkpoint payload.")
+
+    prompt = raw["prompt_to_user"]
+    if not isinstance(prompt, str):
+        raise ValueError("Invalid checkpoint payload.")
+
+    replacement = _load_checkpoint_replacement_obj(raw["replacement"])
+    return replacement, prompt
+
+
+def _load_checkpoint_replacement_obj(raw: object) -> PendingReplacement:
+    if not isinstance(raw, dict):
+        raise ValueError("Invalid checkpoint payload.")
+    if set(raw.keys()) != {"kind", "new_item", "old_item"}:
+        raise ValueError("Invalid checkpoint payload.")
+
+    kind = raw["kind"]
+    new_item = raw["new_item"]
+    old_item = raw["old_item"]
+
+    if kind not in {"use_only", "replace_use"}:
+        raise ValueError("Invalid checkpoint payload.")
+    if not isinstance(new_item, str):
+        raise ValueError("Invalid checkpoint payload.")
+
+    if kind == "use_only":
+        if old_item is not None:
+            raise ValueError("Invalid checkpoint payload.")
+        return PendingReplacement(kind=kind, new_item=new_item, old_item=None)
+
+    if not isinstance(old_item, str):
+        raise ValueError("Invalid checkpoint payload.")
+    return PendingReplacement(kind=kind, new_item=new_item, old_item=old_item)
 
 
 def _sanitize_premise_value(value: str) -> str:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -116,6 +116,146 @@ def test_import_json_rejects_non_string_policy_keys() -> None:
         create_engine(state=payload)  # type: ignore[arg-type]
 
 
+def test_export_checkpoint_contains_version_authoritative_state_and_pending_none() -> None:
+    engine = create_engine()
+    engine.step("set premise concise")
+    engine.step("use docker")
+
+    checkpoint = engine.export_checkpoint()
+
+    assert checkpoint == {
+        "checkpoint_version": 1,
+        "authoritative_state": {
+            "premise": "concise",
+            "policies": {"docker": "use"},
+            "version": 2,
+        },
+        "pending": None,
+    }
+
+
+def test_export_checkpoint_json_round_trip_preserves_authoritative_and_pending_state() -> None:
+    source = create_engine()
+    source.step("use kubectl instead of docker")
+
+    payload = source.export_checkpoint_json()
+    target = create_engine()
+    target.import_checkpoint_json(payload)
+
+    assert target.export_checkpoint() == source.export_checkpoint()
+
+
+def test_export_checkpoint_serializes_pending_replacement_state_for_exact_resume() -> None:
+    engine = create_engine()
+    clarify = engine.step("use kubectl instead of docker")
+    assert clarify["kind"] == "clarify"
+
+    checkpoint = engine.export_checkpoint()
+    assert checkpoint["pending"] == {
+        "kind": "replacement",
+        "replacement": {
+            "kind": "use_only",
+            "new_item": "kubectl",
+            "old_item": None,
+        },
+        "prompt_to_user": (
+            'No exact policy found for "docker".\n'
+            "Replacement requires an exact policy match.\n"
+            'Confirm to use "kubectl" and keep existing policies?'
+        ),
+    }
+
+
+def test_import_checkpoint_restores_pending_clarification_and_resolves_yes() -> None:
+    source = create_engine()
+    source.step("use kubectl instead of docker")
+    checkpoint = source.export_checkpoint()
+
+    target = create_engine()
+    target.import_checkpoint(checkpoint)
+    decision = target.step("yes")
+
+    assert decision["kind"] == "update"
+    assert target.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
+
+
+def test_import_checkpoint_invalid_json_and_invalid_object_payload_are_rejected() -> None:
+    engine = create_engine()
+
+    with pytest.raises(ValueError, match="Invalid JSON payload"):
+        engine.import_checkpoint_json("{")
+
+    with pytest.raises(ValueError, match="Invalid checkpoint payload"):
+        engine.import_checkpoint(  # type: ignore[arg-type]
+            {
+                "checkpoint_version": 1,
+                "authoritative_state": {"premise": None, "policies": {}, "version": 2},
+            }
+        )
+
+
+def test_import_checkpoint_rejects_unsupported_checkpoint_version() -> None:
+    engine = create_engine()
+    with pytest.raises(ValueError, match="Unsupported checkpoint version"):
+        engine.import_checkpoint(  # type: ignore[arg-type]
+            {
+                "checkpoint_version": 2,
+                "authoritative_state": {"premise": None, "policies": {}, "version": 2},
+                "pending": None,
+            }
+        )
+
+
+def test_import_checkpoint_is_all_or_nothing_when_pending_is_invalid() -> None:
+    engine = create_engine()
+    engine.step("set premise baseline")
+    before = engine.state
+
+    with pytest.raises(ValueError, match="Invalid checkpoint payload"):
+        engine.import_checkpoint(  # type: ignore[arg-type]
+            {
+                "checkpoint_version": 1,
+                "authoritative_state": {
+                    "premise": "new premise",
+                    "policies": {"pytest": "use"},
+                    "version": 2,
+                },
+                "pending": {
+                    "kind": "replacement",
+                    "replacement": {
+                        "kind": "use_only",
+                        "new_item": "kubectl",
+                        "old_item": "docker",
+                    },
+                    "prompt_to_user": "confirm?",
+                },
+            }
+        )
+
+    assert engine.state == before
+
+
+def test_import_checkpoint_with_pending_none_clears_existing_pending() -> None:
+    engine = create_engine()
+    engine.step("use kubectl instead of docker")
+
+    engine.import_checkpoint(
+        {
+            "checkpoint_version": 1,
+            "authoritative_state": {
+                "premise": "baseline",
+                "policies": {"pytest": "use"},
+                "version": 2,
+            },
+            "pending": None,
+        }
+    )
+
+    yes_decision = engine.step("yes")
+    assert yes_decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert engine.state == {"premise": "baseline", "policies": {"pytest": "use"}, "version": 2}
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -145,6 +145,20 @@ def test_export_checkpoint_json_round_trip_preserves_authoritative_and_pending_s
     assert target.export_checkpoint() == source.export_checkpoint()
 
 
+def test_export_checkpoint_json_is_canonical_sorted_and_compact() -> None:
+    engine = create_engine()
+    engine.step("set premise concise")
+    engine.step("use zeta")
+    engine.step("use alpha")
+
+    payload = engine.export_checkpoint_json()
+
+    assert payload == (
+        '{"authoritative_state":{"policies":{"alpha":"use","zeta":"use"},'
+        '"premise":"concise","version":2},"checkpoint_version":1,"pending":null}'
+    )
+
+
 def test_export_checkpoint_serializes_pending_replacement_state_for_exact_resume() -> None:
     engine = create_engine()
     clarify = engine.step("use kubectl instead of docker")
@@ -164,6 +178,80 @@ def test_export_checkpoint_serializes_pending_replacement_state_for_exact_resume
             'Confirm to use "kubectl" and keep existing policies?'
         ),
     }
+
+
+def test_export_checkpoint_serializes_replace_use_pending_and_round_trips() -> None:
+    source = create_engine()
+    source.step("use docker")
+    source.step("prohibit kubectl")
+    clarify = source.step("use kubectl instead of docker")
+    assert clarify["kind"] == "clarify"
+
+    checkpoint = source.export_checkpoint()
+    assert checkpoint["pending"] == {
+        "kind": "replacement",
+        "replacement": {
+            "kind": "replace_use",
+            "new_item": "kubectl",
+            "old_item": "docker",
+        },
+        "prompt_to_user": (
+            '"kubectl" is currently prohibited. Did you mean to remove "docker" '
+            'and use "kubectl" instead?'
+        ),
+    }
+
+    yes_target = create_engine()
+    yes_target.import_checkpoint(checkpoint)
+    yes_decision = yes_target.step("yes")
+    assert yes_decision["kind"] == "update"
+    assert yes_target.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
+
+    no_target = create_engine()
+    no_target.import_checkpoint(checkpoint)
+    before_no = no_target.state
+    no_decision = no_target.step("no")
+    assert no_decision == {"kind": "update", "state": before_no, "prompt_to_user": None}
+    assert no_target.state == {
+        "premise": None,
+        "policies": {"docker": "use", "kubectl": "prohibit"},
+        "version": 2,
+    }
+
+
+def test_import_checkpoint_restores_pending_clarification_and_unmatched_input_reuses_prompt() -> (
+    None
+):
+    source = create_engine()
+    first = source.step("use kubectl instead of docker")
+    assert first["kind"] == "clarify"
+    checkpoint = source.export_checkpoint()
+
+    target = create_engine()
+    target.import_checkpoint(checkpoint)
+    before = target.state
+    second = target.step("maybe")
+
+    assert second == first
+    assert target.state == before
+
+
+def test_export_checkpoint_json_object_and_restore_paths_are_behaviorally_equivalent() -> None:
+    source = create_engine()
+    source.step("use kubectl instead of docker")
+
+    checkpoint_obj = source.export_checkpoint()
+    checkpoint_json = source.export_checkpoint_json()
+    assert json.loads(checkpoint_json) == checkpoint_obj
+
+    via_obj = create_engine()
+    via_obj.import_checkpoint(checkpoint_obj)
+
+    via_json = create_engine()
+    via_json.import_checkpoint_json(checkpoint_json)
+
+    assert via_obj.step("yes") == via_json.step("yes")
+    assert via_obj.state == via_json.state
 
 
 def test_import_checkpoint_restores_pending_clarification_and_resolves_yes() -> None:
@@ -206,6 +294,20 @@ def test_import_checkpoint_rejects_unsupported_checkpoint_version() -> None:
         )
 
 
+def test_import_checkpoint_json_rejects_unsupported_checkpoint_version() -> None:
+    engine = create_engine()
+    with pytest.raises(ValueError, match="Unsupported checkpoint version"):
+        engine.import_checkpoint_json(
+            json.dumps(
+                {
+                    "checkpoint_version": 2,
+                    "authoritative_state": {"premise": None, "policies": {}, "version": 2},
+                    "pending": None,
+                }
+            )
+        )
+
+
 def test_import_checkpoint_is_all_or_nothing_when_pending_is_invalid() -> None:
     engine = create_engine()
     engine.step("set premise baseline")
@@ -232,6 +334,30 @@ def test_import_checkpoint_is_all_or_nothing_when_pending_is_invalid() -> None:
             }
         )
 
+    assert engine.state == before
+
+
+def test_import_checkpoint_is_all_or_nothing_when_authoritative_state_is_invalid() -> None:
+    engine = create_engine()
+    first = engine.step("use kubectl instead of docker")
+    assert first["kind"] == "clarify"
+    before = engine.state
+
+    with pytest.raises(ValueError, match="Invalid state payload"):
+        engine.import_checkpoint(  # type: ignore[arg-type]
+            {
+                "checkpoint_version": 1,
+                "authoritative_state": {
+                    "premise": None,
+                    "policies": [],
+                    "version": 2,
+                },
+                "pending": None,
+            }
+        )
+
+    second = engine.step("maybe")
+    assert second == first
     assert engine.state == before
 
 


### PR DESCRIPTION
## What changed
- Added checkpoint object APIs on Engine:
  - export_checkpoint() -> Checkpoint
  - import_checkpoint(payload: Checkpoint) -> None
- Added checkpoint JSON wrappers:
  - export_checkpoint_json() -> str
  - import_checkpoint_json(payload: str) -> None
- Added typed checkpoint contract export (Checkpoint) from package root.
- Implemented strict checkpoint validation with all-or-nothing restore semantics.
- Ensured authoritative state in checkpoint reuses existing authoritative import/export validation paths.
- Added checkpoint docs/spec updates in README.md, docs/DirectiveGrammarSpec.md, and milestone reflection in docs/DescriptionAndMilestones.md.
- Added user-facing checkpoint behavior tests for canonical JSON, replace_use pending round-trip, restore parity, unmatched-input continuation, unsupported version JSON path, and all-or-nothing invalid authoritative-state restore.

## Why this was needed
- Establishes a dedicated serialized continuation contract separate from authoritative-state-only transport.
- Supports deterministic resume of confirmation-required flows across process/session boundaries without changing core engine semantics.
