### PR TITLE
test: harden import_json empty-key state integrity coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ Notes:
 - `pending` is `null` when no continuation is waiting for confirmation.
 - `pending` captures confirmation-required operations (for example replacement flows).
 - `old_item` may be `null` for `"use_only"` when confirming “use X instead?” without an existing exact policy to replace.
+- imported policy keys are normalized during `import_json` / checkpoint authoritative-state restore.
+- if a policy key normalizes to `""`, the payload is invalid and is rejected.
+- this keeps import-time state integrity aligned with directive-time behavior where empty policy items are not allowed.
 - checkpoint restore is full and deterministic: authoritative state and pending continuation are restored together.
 - checkpoint validation is all-or-nothing; invalid payloads raise and no partial restore occurs.
 - `checkpoint_version` is independent of authoritative state `version` and must be bumped when checkpoint contract shape changes (especially `pending`).

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -327,6 +327,9 @@ JSON persistence boundary:
 
 - `engine.export_json()` serializes authoritative state.
 - `engine.import_json(payload)` validates/canonicalizes payload and replaces active state.
+- Policy keys are normalized during import validation/canonicalization.
+- If a policy key normalizes to `""`, the payload is invalid and must be rejected.
+- This aligns import-time state acceptance with directive-time behavior, where empty policy items are invalid.
 
 Checkpoint boundary:
 

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -587,7 +587,10 @@ def _load_state_obj(raw: object) -> State:
             raise ValueError("Invalid state payload.")
         if value not in {POLICY_USE, POLICY_PROHIBIT}:
             raise ValueError("Invalid state payload.")
-        normalized_policies[_normalize_item(key)] = value
+        normalized_key = _normalize_item(key)
+        if normalized_key == "":
+            raise ValueError("Invalid state payload.")
+        normalized_policies[normalized_key] = value
 
     return {
         STATE_PREMISE: None if premise is None else _sanitize_premise_value(premise),

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -118,6 +118,30 @@ def test_import_json_rejects_non_string_policy_keys() -> None:
         create_engine(state=payload)  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize(
+    "policies",
+    [
+        {"A": "use", "a": "use"},
+        {"a": "use"},
+        {"the": "use"},
+    ],
+)
+def test_import_json_rejects_policy_keys_that_normalize_to_empty(
+    policies: dict[str, str],
+) -> None:
+    engine = create_engine()
+    with pytest.raises(ValueError, match="Invalid state payload"):
+        engine.import_json(
+            json.dumps(
+                {
+                    "premise": None,
+                    "policies": policies,
+                    "version": 2,
+                }
+            )
+        )
+
+
 @pytest.mark.contract
 def test_export_checkpoint_contains_version_authoritative_state_and_pending_none() -> None:
     engine = create_engine()
@@ -289,6 +313,42 @@ def test_import_checkpoint_invalid_json_and_invalid_object_payload_are_rejected(
                 "checkpoint_version": 1,
                 "authoritative_state": {"premise": None, "policies": {}, "version": 2},
             }
+        )
+
+
+def test_import_checkpoint_rejects_authoritative_state_with_empty_normalized_policy_key() -> None:
+    engine = create_engine()
+    with pytest.raises(ValueError, match="Invalid state payload"):
+        engine.import_checkpoint(  # type: ignore[arg-type]
+            {
+                "checkpoint_version": 1,
+                "authoritative_state": {
+                    "premise": None,
+                    "policies": {"a": "use"},
+                    "version": 2,
+                },
+                "pending": None,
+            }
+        )
+
+
+def test_import_checkpoint_json_rejects_authoritative_state_with_empty_normalized_policy_key() -> (
+    None
+):
+    engine = create_engine()
+    with pytest.raises(ValueError, match="Invalid state payload"):
+        engine.import_checkpoint_json(
+            json.dumps(
+                {
+                    "checkpoint_version": 1,
+                    "authoritative_state": {
+                        "premise": None,
+                        "policies": {"a": "use"},
+                        "version": 2,
+                    },
+                    "pending": None,
+                }
+            )
         )
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -142,6 +142,41 @@ def test_import_json_rejects_policy_keys_that_normalize_to_empty(
         )
 
 
+def test_import_json_rejects_empty_normalized_key_atomically() -> None:
+    engine = create_engine()
+    engine.step("use kubectl")
+    before = engine.state
+
+    with pytest.raises(ValueError, match="Invalid state payload"):
+        engine.import_json(
+            json.dumps(
+                {
+                    "premise": None,
+                    "policies": {"Docker": "use", "a": "use"},
+                    "version": 2,
+                }
+            )
+        )
+
+    assert engine.state == before
+
+
+def test_import_json_accepts_valid_policy_key_and_normalizes_it() -> None:
+    engine = create_engine()
+
+    engine.import_json(
+        json.dumps(
+            {
+                "premise": None,
+                "policies": {"Docker": "use"},
+                "version": 2,
+            }
+        )
+    )
+
+    assert engine.state == {"premise": None, "policies": {"docker": "use"}, "version": 2}
+
+
 @pytest.mark.contract
 def test_export_checkpoint_contains_version_authoritative_state_and_pending_none() -> None:
     engine = create_engine()


### PR DESCRIPTION
## What changed
- Added focused engine tests to enforce rejection of imported policy keys that normalize to an empty string.
- Added an explicit atomicity test for mixed keys (Docker + a) to ensure failed imports do not partially apply state.
- Added an explicit valid normalization test to confirm Docker imports and normalizes to docker.

## Why this was needed
- Import-time payload handling must stay aligned with directive-time constraints so unreachable or invalid state is not accepted.
- The atomicity test protects state integrity by ensuring import failures are all-or-nothing.