### PR TITLE
fix: reject invalid policy imports and harden clean-env integration tests

### DIFF
--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook.py
@@ -12,7 +12,9 @@ from typing import Any
 try:
     from litellm.integrations.custom_logger import CustomLogger
 except ModuleNotFoundError:
-
+    # Keep this import path optional: CI/tests run without integration extras.
+    # A tiny fallback base class keeps module imports deterministic so coverage
+    # validates behavior instead of failing or silently skipping on missing litellm.
     class CustomLogger:  # type: ignore[no-redef]
         pass
 

--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook.py
@@ -9,7 +9,13 @@ Architecture:
 import logging
 from typing import Any
 
-from litellm.integrations.custom_logger import CustomLogger
+try:
+    from litellm.integrations.custom_logger import CustomLogger
+except ModuleNotFoundError:
+
+    class CustomLogger:  # type: ignore[no-redef]
+        pass
+
 
 from context_compiler import (
     State,

--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
@@ -15,7 +15,13 @@ from importlib.resources import as_file, files
 from importlib.resources.abc import Traversable
 from typing import Any, cast
 
-from litellm.integrations.custom_logger import CustomLogger
+try:
+    from litellm.integrations.custom_logger import CustomLogger
+except ModuleNotFoundError:
+
+    class CustomLogger:  # type: ignore[no-redef]
+        pass
+
 
 from context_compiler import (
     State,

--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
@@ -18,7 +18,9 @@ from typing import Any, cast
 try:
     from litellm.integrations.custom_logger import CustomLogger
 except ModuleNotFoundError:
-
+    # Keep this import path optional: CI/tests run without integration extras.
+    # A tiny fallback base class keeps module imports deterministic so coverage
+    # validates behavior instead of failing or silently skipping on missing litellm.
     class CustomLogger:  # type: ignore[no-redef]
         pass
 

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -27,7 +27,9 @@ from open_webui.utils.chat import generate_chat_completion  # type: ignore[impor
 try:
     from pydantic import BaseModel, Field
 except ModuleNotFoundError:
-
+    # Keep this import optional: CI/tests run without integration extras.
+    # These lightweight fallbacks keep import-time behavior deterministic so
+    # coverage exercises the pipe module without pydantic installed.
     class BaseModel:  # type: ignore[no-redef]
         def __init__(self, **kwargs: object) -> None:
             for key, value in kwargs.items():

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -23,7 +23,20 @@ from typing import Any
 from fastapi import Request  # type: ignore[import-not-found]
 from open_webui.models.users import Users  # type: ignore[import-not-found]
 from open_webui.utils.chat import generate_chat_completion  # type: ignore[import-not-found]
-from pydantic import BaseModel, Field
+
+try:
+    from pydantic import BaseModel, Field
+except ModuleNotFoundError:
+
+    class BaseModel:  # type: ignore[no-redef]
+        def __init__(self, **kwargs: object) -> None:
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    def Field(*, default: Any, description: str = "") -> Any:  # type: ignore[no-redef]
+        del description
+        return default
+
 
 from context_compiler import State, create_engine, get_policy_items, get_premise_value
 from context_compiler.engine import Engine

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -26,7 +26,20 @@ from fastapi import Request  # type: ignore[import-not-found]
 from open_webui.models.users import Users  # type: ignore[import-not-found]
 from open_webui.utils.chat import generate_chat_completion  # type: ignore[import-not-found]
 from open_webui.utils.models import get_all_models  # type: ignore[import-not-found]
-from pydantic import BaseModel, Field
+
+try:
+    from pydantic import BaseModel, Field
+except ModuleNotFoundError:
+
+    class BaseModel:  # type: ignore[no-redef]
+        def __init__(self, **kwargs: object) -> None:
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    def Field(*, default: Any, description: str = "") -> Any:  # type: ignore[no-redef]
+        del description
+        return default
+
 
 from context_compiler import State, create_engine, get_policy_items, get_premise_value
 from context_compiler.engine import Engine

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -30,7 +30,9 @@ from open_webui.utils.models import get_all_models  # type: ignore[import-not-fo
 try:
     from pydantic import BaseModel, Field
 except ModuleNotFoundError:
-
+    # Keep this import optional: CI/tests run without integration extras.
+    # These lightweight fallbacks keep import-time behavior deterministic so
+    # coverage exercises the pipe module without pydantic installed.
     class BaseModel:  # type: ignore[no-redef]
         def __init__(self, **kwargs: object) -> None:
             for key, value in kwargs.items():

--- a/tests/test_example_integrations_imports.py
+++ b/tests/test_example_integrations_imports.py
@@ -1,0 +1,118 @@
+import builtins
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATIONS_DIR = REPO_ROOT / "examples" / "integrations"
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_openwebui_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    fastapi_mod = types.ModuleType("fastapi")
+
+    class _Request:
+        pass
+
+    fastapi_mod.Request = _Request
+
+    open_webui_mod = types.ModuleType("open_webui")
+    open_webui_models_mod = types.ModuleType("open_webui.models")
+    open_webui_models_users_mod = types.ModuleType("open_webui.models.users")
+    open_webui_utils_mod = types.ModuleType("open_webui.utils")
+    open_webui_utils_chat_mod = types.ModuleType("open_webui.utils.chat")
+    open_webui_utils_models_mod = types.ModuleType("open_webui.utils.models")
+
+    class _Users:
+        @staticmethod
+        def get_user_by_id(user_id: object) -> dict[str, object]:
+            return {"id": user_id}
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        return {"choices": [{"message": {"content": payload.get("_mock_content", "")}}]}
+
+    async def _all_models(_: object, user: object = None) -> list[dict[str, str]]:
+        del user
+        return [{"id": "base-model"}, {"id": "prep-model"}, {"id": "pipe-model"}]
+
+    open_webui_models_users_mod.Users = _Users
+    open_webui_utils_chat_mod.generate_chat_completion = _chat_completion
+    open_webui_utils_models_mod.get_all_models = _all_models
+
+    monkeypatch.setitem(sys.modules, "fastapi", fastapi_mod)
+    monkeypatch.setitem(sys.modules, "open_webui", open_webui_mod)
+    monkeypatch.setitem(sys.modules, "open_webui.models", open_webui_models_mod)
+    monkeypatch.setitem(sys.modules, "open_webui.models.users", open_webui_models_users_mod)
+    monkeypatch.setitem(sys.modules, "open_webui.utils", open_webui_utils_mod)
+    monkeypatch.setitem(sys.modules, "open_webui.utils.chat", open_webui_utils_chat_mod)
+    monkeypatch.setitem(sys.modules, "open_webui.utils.models", open_webui_utils_models_mod)
+
+
+def _block_optional_imports(
+    monkeypatch: pytest.MonkeyPatch, blocked_prefixes: tuple[str, ...]
+) -> None:
+    real_import = builtins.__import__
+
+    def _guarded_import(
+        name: str,
+        globals_: dict[str, object] | None = None,
+        locals_: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in blocked_prefixes):
+            raise ModuleNotFoundError(f"No module named '{name}'")
+        return real_import(name, globals_, locals_, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _guarded_import)
+
+
+@pytest.mark.parametrize(
+    ("module_path", "blocked_prefixes", "needs_openwebui_stubs"),
+    [
+        (INTEGRATIONS_DIR / "litellm" / "basic.py", ("litellm",), False),
+        (INTEGRATIONS_DIR / "litellm" / "with_preprocessor.py", ("litellm",), False),
+        (
+            INTEGRATIONS_DIR / "litellm_proxy" / "context_compiler_precall_hook.py",
+            ("litellm",),
+            False,
+        ),
+        (
+            INTEGRATIONS_DIR
+            / "litellm_proxy"
+            / "context_compiler_precall_hook_with_preprocessor.py",
+            ("litellm",),
+            False,
+        ),
+        (INTEGRATIONS_DIR / "openwebui" / "open_webui_pipe.py", ("pydantic",), True),
+        (
+            INTEGRATIONS_DIR / "openwebui" / "open_webui_pipe_with_preprocessor.py",
+            ("pydantic",),
+            True,
+        ),
+    ],
+)
+def test_example_integration_modules_import_without_optional_dependencies(
+    module_path: Path,
+    blocked_prefixes: tuple[str, ...],
+    needs_openwebui_stubs: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if needs_openwebui_stubs:
+        _install_openwebui_stubs(monkeypatch)
+    _block_optional_imports(monkeypatch, blocked_prefixes)
+
+    module = _load_module(f"test_import_{module_path.stem}", module_path)
+    assert module is not None

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,3 +1,4 @@
+import ast
 import sys
 import types
 from contextlib import contextmanager
@@ -12,6 +13,25 @@ if str(REPO_ROOT) not in sys.path:
 
 import demos.llm_client as llm_client  # noqa: E402
 from demos.llm_client import DemoLLMError, LLMConfig, complete_messages  # noqa: E402
+
+
+def test_module_does_not_use_litellm_importorskip_guard() -> None:
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if not isinstance(node.func.value, ast.Name):
+            continue
+        if node.func.value.id != "pytest" or node.func.attr != "importorskip":
+            continue
+        if not node.args:
+            continue
+        first_arg = node.args[0]
+        if isinstance(first_arg, ast.Constant) and first_arg.value == "litellm":
+            pytest.fail("tests/test_llm_client.py must not use pytest.importorskip('litellm')")
 
 
 def _fake_config() -> LLMConfig:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,11 +1,10 @@
 import sys
+import types
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
-
-litellm = pytest.importorskip("litellm")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -77,6 +76,24 @@ class _FakeRateLimitError(RuntimeError):
             (),
             {"headers": {"retry-after": retry_after}},
         )()
+
+
+def _install_fake_litellm_module(monkeypatch: pytest.MonkeyPatch) -> type[Exception]:
+    # Avoid importorskip here: an import-time litellm dependency would skip this
+    # entire module in CI when extras are not installed. We stub litellm in
+    # sys.modules so tests stay deterministic, avoid optional dependency coupling,
+    # and still exercise the real wrapper's import/exception handling path.
+    class _FakeUnsupportedParamsError(Exception):
+        def __init__(self, message: str, model: str, llm_provider: str) -> None:
+            super().__init__(message)
+            self.message = message
+            self.model = model
+            self.llm_provider = llm_provider
+
+    litellm_mod = types.ModuleType("litellm")
+    litellm_mod.UnsupportedParamsError = _FakeUnsupportedParamsError
+    monkeypatch.setitem(sys.modules, "litellm", litellm_mod)
+    return _FakeUnsupportedParamsError
 
 
 def test_complete_messages_maps_model_not_found_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -407,6 +424,7 @@ def test_complete_messages_normal_path_uses_deterministic_decoding_first(
 def test_complete_messages_retries_once_without_temperature_on_unsupported_param(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    unsupported_error = _install_fake_litellm_module(monkeypatch)
     monkeypatch.setattr(llm_client, "load_config", _fake_config)
     monkeypatch.setenv("CONTEXT_COMPILER_DEMO_VERBOSE", "1")
     drop_params_scopes: list[bool] = []
@@ -419,7 +437,7 @@ def test_complete_messages_retries_once_without_temperature_on_unsupported_param
     monkeypatch.setattr(llm_client, "_temporary_litellm_drop_params", fake_drop_params_scope)
     fake_completion = _RecordingLiteLLMCompletion(
         [
-            litellm.UnsupportedParamsError(
+            unsupported_error(
                 message="temperature is not supported",
                 model="bad-model",
                 llm_provider="openai",
@@ -443,6 +461,7 @@ def test_complete_messages_retries_once_without_temperature_on_unsupported_param
 def test_complete_messages_fallback_failure_surfaces_existing_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    unsupported_error = _install_fake_litellm_module(monkeypatch)
     monkeypatch.setattr(llm_client, "load_config", _fake_config)
     drop_params_scopes: list[bool] = []
 
@@ -454,7 +473,7 @@ def test_complete_messages_fallback_failure_surfaces_existing_error(
     monkeypatch.setattr(llm_client, "_temporary_litellm_drop_params", fake_drop_params_scope)
     fake_completion = _RecordingLiteLLMCompletion(
         [
-            litellm.UnsupportedParamsError(
+            unsupported_error(
                 message="temperature is not supported",
                 model="bad-model",
                 llm_provider="openai",

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -1,0 +1,69 @@
+import builtins
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+MODULE_PATH = Path("examples/integrations/openwebui/open_webui_pipe.py")
+
+
+def _load_module_with_openwebui_stubs(module_name: str, monkeypatch):
+    fastapi_mod = types.ModuleType("fastapi")
+
+    class _Request:
+        pass
+
+    fastapi_mod.Request = _Request
+
+    open_webui_mod = types.ModuleType("open_webui")
+    open_webui_models_mod = types.ModuleType("open_webui.models")
+    open_webui_models_users_mod = types.ModuleType("open_webui.models.users")
+    open_webui_utils_mod = types.ModuleType("open_webui.utils")
+    open_webui_utils_chat_mod = types.ModuleType("open_webui.utils.chat")
+
+    class _Users:
+        @staticmethod
+        def get_user_by_id(user_id: object) -> dict[str, object]:
+            return {"id": user_id}
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        return {"choices": [{"message": {"content": payload.get("_mock_content", "")}}]}
+
+    open_webui_models_users_mod.Users = _Users
+    open_webui_utils_chat_mod.generate_chat_completion = _chat_completion
+
+    sys.modules["fastapi"] = fastapi_mod
+    sys.modules["open_webui"] = open_webui_mod
+    sys.modules["open_webui.models"] = open_webui_models_mod
+    sys.modules["open_webui.models.users"] = open_webui_models_users_mod
+    sys.modules["open_webui.utils"] = open_webui_utils_mod
+    sys.modules["open_webui.utils.chat"] = open_webui_utils_chat_mod
+
+    real_import = builtins.__import__
+
+    def _guarded_import(
+        name: str,
+        globals_: dict[str, object] | None = None,
+        locals_: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "pydantic":
+            raise ModuleNotFoundError("No module named 'pydantic'")
+        return real_import(name, globals_, locals_, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _guarded_import)
+
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_openwebui_pipe_imports_without_pydantic(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_no_pydantic", monkeypatch)
+    pipe = module.Pipe()
+    assert pipe.valves.BASE_MODEL_ID == ""

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -1,4 +1,5 @@
 import asyncio
+import builtins
 import importlib.util
 import sys
 import types
@@ -8,7 +9,9 @@ from typing import Any
 MODULE_PATH = Path("examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py")
 
 
-def _load_module_with_openwebui_stubs(module_name: str):
+def _load_module_with_openwebui_stubs(
+    module_name: str, monkeypatch, *, block_pydantic: bool = True
+):
     fastapi_mod = types.ModuleType("fastapi")
 
     class _Request:  # minimal placeholder for type import
@@ -22,7 +25,6 @@ def _load_module_with_openwebui_stubs(module_name: str):
     open_webui_utils_mod = types.ModuleType("open_webui.utils")
     open_webui_utils_chat_mod = types.ModuleType("open_webui.utils.chat")
     open_webui_utils_models_mod = types.ModuleType("open_webui.utils.models")
-    pydantic_mod = types.ModuleType("pydantic")
 
     class _Users:
         @staticmethod
@@ -42,18 +44,6 @@ def _load_module_with_openwebui_stubs(module_name: str):
     open_webui_utils_chat_mod.generate_chat_completion = _chat_completion
     open_webui_utils_models_mod.get_all_models = _all_models
 
-    class _BaseModel:
-        def __init__(self, **kwargs: object) -> None:
-            for key, value in kwargs.items():
-                setattr(self, key, value)
-
-    def _field(*, default: object, description: str = "") -> object:
-        del description
-        return default
-
-    pydantic_mod.BaseModel = _BaseModel
-    pydantic_mod.Field = _field
-
     sys.modules["fastapi"] = fastapi_mod
     sys.modules["open_webui"] = open_webui_mod
     sys.modules["open_webui.models"] = open_webui_models_mod
@@ -61,7 +51,21 @@ def _load_module_with_openwebui_stubs(module_name: str):
     sys.modules["open_webui.utils"] = open_webui_utils_mod
     sys.modules["open_webui.utils.chat"] = open_webui_utils_chat_mod
     sys.modules["open_webui.utils.models"] = open_webui_utils_models_mod
-    sys.modules["pydantic"] = pydantic_mod
+    if block_pydantic:
+        real_import = builtins.__import__
+
+        def _guarded_import(
+            name: str,
+            globals_: dict[str, object] | None = None,
+            locals_: dict[str, object] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> object:
+            if name == "pydantic":
+                raise ModuleNotFoundError("No module named 'pydantic'")
+            return real_import(name, globals_, locals_, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _guarded_import)
 
     spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
     assert spec is not None and spec.loader is not None
@@ -70,8 +74,8 @@ def _load_module_with_openwebui_stubs(module_name: str):
     return module
 
 
-def test_preprocessor_model_defaults_to_base_model() -> None:
-    module = _load_module_with_openwebui_stubs("owui_preproc_defaults")
+def test_preprocessor_model_defaults_to_base_model(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_defaults", monkeypatch)
     pipe = module.Pipe()
     pipe.valves.BASE_MODEL_ID = "base-model"
     pipe.valves.PREPROCESSOR_MODEL_ID = ""
@@ -79,8 +83,8 @@ def test_preprocessor_model_defaults_to_base_model() -> None:
     assert pipe._resolve_preprocessor_model_id("base-model") == "base-model"
 
 
-def test_preprocessor_model_can_be_overridden() -> None:
-    module = _load_module_with_openwebui_stubs("owui_preproc_override")
+def test_preprocessor_model_can_be_overridden(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_override", monkeypatch)
     pipe = module.Pipe()
     pipe.valves.BASE_MODEL_ID = "base-model"
     pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
@@ -88,8 +92,8 @@ def test_preprocessor_model_can_be_overridden() -> None:
     assert pipe._resolve_preprocessor_model_id("base-model") == "prep-model"
 
 
-def test_invalid_preprocessor_model_is_normalized() -> None:
-    module = _load_module_with_openwebui_stubs("owui_preproc_invalid")
+def test_invalid_preprocessor_model_is_normalized(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_invalid", monkeypatch)
     pipe = module.Pipe()
 
     async def _models(_: object, user: object = None) -> list[dict[str, str]]:
@@ -113,8 +117,8 @@ def test_invalid_preprocessor_model_is_normalized() -> None:
     )
 
 
-def test_preprocessor_fallback_uses_preprocessor_model_only() -> None:
-    module = _load_module_with_openwebui_stubs("owui_preproc_routing")
+def test_preprocessor_fallback_uses_preprocessor_model_only(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_routing", monkeypatch)
     pipe = module.Pipe()
 
     calls: list[str] = []
@@ -157,8 +161,8 @@ def test_preprocessor_fallback_uses_preprocessor_model_only() -> None:
     assert calls == ["prep-model", "base-model"]
 
 
-def test_recursion_guard_for_preprocessor_model() -> None:
-    module = _load_module_with_openwebui_stubs("owui_preproc_recursion")
+def test_recursion_guard_for_preprocessor_model(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_recursion", monkeypatch)
     pipe = module.Pipe()
     pipe.valves.BASE_MODEL_ID = "base-model"
     pipe.valves.PREPROCESSOR_MODEL_ID = "pipe-model"

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -22,6 +22,7 @@ def _load_module_with_openwebui_stubs(module_name: str):
     open_webui_utils_mod = types.ModuleType("open_webui.utils")
     open_webui_utils_chat_mod = types.ModuleType("open_webui.utils.chat")
     open_webui_utils_models_mod = types.ModuleType("open_webui.utils.models")
+    pydantic_mod = types.ModuleType("pydantic")
 
     class _Users:
         @staticmethod
@@ -41,6 +42,18 @@ def _load_module_with_openwebui_stubs(module_name: str):
     open_webui_utils_chat_mod.generate_chat_completion = _chat_completion
     open_webui_utils_models_mod.get_all_models = _all_models
 
+    class _BaseModel:
+        def __init__(self, **kwargs: object) -> None:
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    def _field(*, default: object, description: str = "") -> object:
+        del description
+        return default
+
+    pydantic_mod.BaseModel = _BaseModel
+    pydantic_mod.Field = _field
+
     sys.modules["fastapi"] = fastapi_mod
     sys.modules["open_webui"] = open_webui_mod
     sys.modules["open_webui.models"] = open_webui_models_mod
@@ -48,6 +61,7 @@ def _load_module_with_openwebui_stubs(module_name: str):
     sys.modules["open_webui.utils"] = open_webui_utils_mod
     sys.modules["open_webui.utils.chat"] = open_webui_utils_chat_mod
     sys.modules["open_webui.utils.models"] = open_webui_utils_models_mod
+    sys.modules["pydantic"] = pydantic_mod
 
     spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
     assert spec is not None and spec.loader is not None


### PR DESCRIPTION
## What changed
- Fixed state integrity on import by rejecting policy keys that normalize to an empty string.
- Added focused engine regression coverage for invalid normalized keys, atomic import behavior, and valid key normalization.
- Clarified import behavior in docs for empty-normalized policy key rejection.
- Removed import-time LiteLLM test dependency in tests/test_llm_client.py and replaced it with local module stubs.
- Added regression guard to prevent reintroducing pytest.importorskip for litellm in that test module.
- Hardened OpenWebUI example pipes to import safely without pydantic installed.
- Hardened LiteLLM proxy example hooks to import safely without litellm installed.
- Added integration import coverage tests across all example integration modules under missing optional dependencies.
- Added concise comments at optional-dependency fallback sites to document boundary intent.

## Why this was needed
- Clean environments that install only dev dependencies should not fail or silently skip integration coverage due to optional package import-time coupling.
- Import-time state loading now stays aligned with directive-time constraints by rejecting unreachable invalid policy state.
- The added tests make this behavior explicit and guard against regressions across engine and example integrations.