### PR TITLE
feat: add checkpoint continuation to example integrations

### DIFF
--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -16,6 +16,8 @@ pip install "context-compiler[integrations]"
 export OPENAI_API_KEY=...
 ```
 
+Checkpoint continuation in these integration examples requires `context-compiler>=0.6.7`.
+
 ### Run
 
 See the LiteLLM examples README for setup and usage:

--- a/examples/integrations/litellm/README.md
+++ b/examples/integrations/litellm/README.md
@@ -79,6 +79,9 @@ These files are importable integration references for host applications.
 - Optional serialized continuation checkpointing: pass `session_key=...` and
   let the example integration restore before first `engine.step(...)` and
   persist after `update`/`clarify` decisions.
+- In this example, checkpoint/session storage is in-memory only.
+  Continuation state is limited to the current process lifetime; real restart
+  continuity requires external persistence (DB/Redis/etc.).
 - Display the returned assistant text.
 
 ## Troubleshooting

--- a/examples/integrations/litellm/README.md
+++ b/examples/integrations/litellm/README.md
@@ -12,6 +12,8 @@ pip install "context-compiler[integrations]"
 export OPENAI_API_KEY=...
 ```
 
+Checkpoint continuation in these examples requires `context-compiler>=0.6.7`.
+
 For `with_preprocessor.py`:
 
 ```shell

--- a/examples/integrations/litellm/README.md
+++ b/examples/integrations/litellm/README.md
@@ -76,6 +76,9 @@ These files are importable integration references for host applications.
 - Import `handle_turn(...)` from either `basic.py` or `with_preprocessor.py`.
 - Create and retain an engine instance in host/session state.
 - Pass each user input through `handle_turn(user_input, engine)`.
+- Optional serialized continuation checkpointing: pass `session_key=...` and
+  let the example integration restore before first `engine.step(...)` and
+  persist after `update`/`clarify` decisions.
 - Display the returned assistant text.
 
 ## Troubleshooting

--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -21,6 +21,8 @@ from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 
 logger = logging.getLogger(__name__)
+_CHECKPOINTS_BY_SESSION_KEY: dict[str, str] = {}
+_RESTORED_ENGINE_BY_SESSION_KEY: dict[str, int] = {}
 
 
 class _LiteLLMCallKwargs(TypedDict, total=False):
@@ -110,14 +112,40 @@ def _call_litellm(messages: list[dict[str, str]]) -> str:
     return content
 
 
-def handle_turn(user_input: str, engine: Engine) -> str:
+def _restore_session_checkpoint_if_needed(engine: Engine, session_key: str | None) -> None:
+    if session_key is None:
+        return
+    engine_id = id(engine)
+    if _RESTORED_ENGINE_BY_SESSION_KEY.get(session_key) == engine_id:
+        return
+
+    checkpoint = _CHECKPOINTS_BY_SESSION_KEY.get(session_key)
+    if checkpoint is not None:
+        engine.import_checkpoint_json(checkpoint)
+    _RESTORED_ENGINE_BY_SESSION_KEY[session_key] = engine_id
+
+
+def _persist_session_checkpoint_if_needed(
+    engine: Engine, kind: str, session_key: str | None
+) -> None:
+    if session_key is None:
+        return
+    if kind not in {"update", "clarify"}:
+        return
+    _CHECKPOINTS_BY_SESSION_KEY[session_key] = engine.export_checkpoint_json()
+
+
+def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = None) -> str:
+    _restore_session_checkpoint_if_needed(engine, session_key)
     logger.debug("litellm_basic: engine_input=%s", f"user_input len={len(user_input)}")
     decision = engine.step(user_input)
     kind = cast(str, decision["kind"])
     logger.debug("litellm_basic: decision=%s", kind)
 
     if kind == "clarify":
+        _persist_session_checkpoint_if_needed(engine, kind, session_key)
         return decision["prompt_to_user"] or ""
+    _persist_session_checkpoint_if_needed(engine, kind, session_key)
 
     compiled_state = decision["state"] if decision["state"] is not None else engine.state
     messages = _build_messages(user_input, compiled_state)

--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -21,6 +21,10 @@ from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 
 logger = logging.getLogger(__name__)
+# Example-only in-memory checkpoint store.
+# This keeps continuation state only for the current process lifetime.
+# Real deployments should persist checkpoints externally (DB/Redis/etc.),
+# or restart continuity for pending flows will be lost.
 _CHECKPOINTS_BY_SESSION_KEY: dict[str, str] = {}
 _RESTORED_ENGINE_BY_SESSION_KEY: dict[str, int] = {}
 

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -34,6 +34,8 @@ from experimental.preprocessor import (
 logger = logging.getLogger(__name__)
 
 _PROMPTS_DIR = files("experimental.preprocessor").joinpath("prompts")
+_CHECKPOINTS_BY_SESSION_KEY: dict[str, str] = {}
+_RESTORED_ENGINE_BY_SESSION_KEY: dict[str, int] = {}
 
 
 class _LiteLLMCallKwargs(TypedDict, total=False):
@@ -202,7 +204,31 @@ def _precompile_user_input(message: str, state: State) -> str | None:
         return None
 
 
-def handle_turn(user_input: str, engine: Engine) -> str:
+def _restore_session_checkpoint_if_needed(engine: Engine, session_key: str | None) -> None:
+    if session_key is None:
+        return
+    engine_id = id(engine)
+    if _RESTORED_ENGINE_BY_SESSION_KEY.get(session_key) == engine_id:
+        return
+
+    checkpoint = _CHECKPOINTS_BY_SESSION_KEY.get(session_key)
+    if checkpoint is not None:
+        engine.import_checkpoint_json(checkpoint)
+    _RESTORED_ENGINE_BY_SESSION_KEY[session_key] = engine_id
+
+
+def _persist_session_checkpoint_if_needed(
+    engine: Engine, kind: str, session_key: str | None
+) -> None:
+    if session_key is None:
+        return
+    if kind not in {"update", "clarify"}:
+        return
+    _CHECKPOINTS_BY_SESSION_KEY[session_key] = engine.export_checkpoint_json()
+
+
+def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = None) -> str:
+    _restore_session_checkpoint_if_needed(engine, session_key)
     precompiled = _precompile_user_input(user_input, engine.state)
 
     compile_input = precompiled if precompiled else user_input
@@ -216,7 +242,9 @@ def handle_turn(user_input: str, engine: Engine) -> str:
     logger.debug("preprocessor: decision=%s", kind)
 
     if kind == "clarify":
+        _persist_session_checkpoint_if_needed(engine, kind, session_key)
         return decision["prompt_to_user"] or ""
+    _persist_session_checkpoint_if_needed(engine, kind, session_key)
 
     compiled_state = decision["state"] if decision["state"] is not None else engine.state
     messages = _build_messages(user_input, compiled_state)

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -34,6 +34,10 @@ from experimental.preprocessor import (
 logger = logging.getLogger(__name__)
 
 _PROMPTS_DIR = files("experimental.preprocessor").joinpath("prompts")
+# Example-only in-memory checkpoint store.
+# This keeps continuation state only for the current process lifetime.
+# Real deployments should persist checkpoints externally (DB/Redis/etc.),
+# or restart continuity for pending flows will be lost.
 _CHECKPOINTS_BY_SESSION_KEY: dict[str, str] = {}
 _RESTORED_ENGINE_BY_SESSION_KEY: dict[str, int] = {}
 

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -231,11 +231,18 @@ def _persist_session_checkpoint_if_needed(
     _CHECKPOINTS_BY_SESSION_KEY[session_key] = engine.export_checkpoint_json()
 
 
+def _has_pending_clarification(engine: Engine) -> bool:
+    return engine.export_checkpoint()["pending"] is not None
+
+
 def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = None) -> str:
     _restore_session_checkpoint_if_needed(engine, session_key)
-    precompiled = _precompile_user_input(user_input, engine.state)
-
-    compile_input = precompiled if precompiled else user_input
+    precompiled: str | None = None
+    if _has_pending_clarification(engine):
+        compile_input = user_input
+    else:
+        precompiled = _precompile_user_input(user_input, engine.state)
+        compile_input = precompiled if precompiled else user_input
     logger.debug(
         "preprocessor: engine_input=%s",
         "directive" if precompiled else f"user_input len={len(user_input)}",

--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -23,6 +23,8 @@ The minimal pipe path below is the easiest first-run flow and was runtime-valida
 Open WebUI is host-provided runtime infrastructure and must already be installed/configured separately.
 Open WebUI also needs at least one real backend model/provider configured (for example Ollama or OpenAI) so `BASE_MODEL_ID` resolves to an actual model.
 
+Checkpoint continuation in these examples requires `context-compiler>=0.6.7`.
+
 If using `open_webui_pipe_with_preprocessor.py`:
 - Install preprocessor support in the Open WebUI environment:
   - `pip install "context-compiler[experimental]"`

--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -57,7 +57,7 @@ Use the Open WebUI model picker/list to copy exact model ids for `BASE_MODEL_ID`
 
 ## Limitations
 
-- No persistence.
+- No durable external persistence (checkpoint continuation is in-process only).
 - No multi-worker or cross-process guarantees.
 - No Redis/DB/external storage.
 - No Filters or Pipelines.

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -3,8 +3,8 @@ title: Context Compiler Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.1
-requirements: context-compiler>=0.6.6
+version: 0.2
+requirements: context-compiler>=0.6.7
 
 Minimal Open WebUI Pipe integration for Context Compiler.
 

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -47,6 +47,10 @@ logger = logging.getLogger(__name__)
 
 _CC_MARKER = "[[cc_state]]"
 _ENGINES_BY_CHAT_KEY: dict[str, Engine] = {}
+# Example-only in-memory checkpoint store.
+# This keeps continuation state only for the current process lifetime.
+# Real deployments should persist checkpoints externally (DB/Redis/etc.),
+# or restart continuity for pending flows will be lost.
 _CHECKPOINTS_BY_CHAT_KEY: dict[str, str] = {}
 
 

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 
 _CC_MARKER = "[[cc_state]]"
 _ENGINES_BY_CHAT_KEY: dict[str, Engine] = {}
+_CHECKPOINTS_BY_CHAT_KEY: dict[str, str] = {}
 
 
 def _resolve_chat_key(
@@ -302,6 +303,9 @@ class Pipe:
         engine = _ENGINES_BY_CHAT_KEY.get(chat_key)
         if engine is None:
             engine = create_engine()
+            checkpoint = _CHECKPOINTS_BY_CHAT_KEY.get(chat_key)
+            if checkpoint is not None:
+                engine.import_checkpoint_json(checkpoint)
             _ENGINES_BY_CHAT_KEY[chat_key] = engine
 
         logger.debug("pipe: engine_input=%r", latest_user_text)
@@ -310,10 +314,12 @@ class Pipe:
         logger.debug("pipe: decision=%s", kind)
 
         if kind == "clarify":
+            _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
             return decision["prompt_to_user"] or ""
         if kind == "passthrough":
             return await self._forward_passthrough(body, __user__, __request__)
         if kind == "update":
+            _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
             return await self._forward_update(body, __user__, __request__, engine.state)
 
         return await self._forward_passthrough(body, __user__, __request__)

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -57,6 +57,7 @@ logger = logging.getLogger(__name__)
 
 _CC_MARKER = "[[cc_state]]"
 _ENGINES_BY_CHAT_KEY: dict[str, Engine] = {}
+_CHECKPOINTS_BY_CHAT_KEY: dict[str, str] = {}
 _PROMPTS_DIR = files("experimental.preprocessor").joinpath("prompts")
 
 
@@ -479,6 +480,9 @@ class Pipe:
         engine = _ENGINES_BY_CHAT_KEY.get(chat_key)
         if engine is None:
             engine = create_engine()
+            checkpoint = _CHECKPOINTS_BY_CHAT_KEY.get(chat_key)
+            if checkpoint is not None:
+                engine.import_checkpoint_json(checkpoint)
             _ENGINES_BY_CHAT_KEY[chat_key] = engine
 
         precompiled, precompile_error = await self._precompile_user_input(
@@ -503,6 +507,7 @@ class Pipe:
         logger.debug("preprocessor: decision=%s", kind)
 
         if kind == "clarify":
+            _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
             return decision["prompt_to_user"] or ""
         if kind == "passthrough":
             return await self._forward_passthrough(
@@ -512,6 +517,7 @@ class Pipe:
                 base_model_id=base_model_id,
             )
         if kind == "update":
+            _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
             return await self._forward_update(
                 body,
                 __user__,

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -3,8 +3,8 @@ title: Context Compiler Preprocessor Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.1
-requirements: context-compiler[experimental]>=0.6.6
+version: 0.2
+requirements: context-compiler[experimental]>=0.6.7
 
 Open WebUI integration with Context Compiler preprocessor.
 

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -57,6 +57,10 @@ logger = logging.getLogger(__name__)
 
 _CC_MARKER = "[[cc_state]]"
 _ENGINES_BY_CHAT_KEY: dict[str, Engine] = {}
+# Example-only in-memory checkpoint store.
+# This keeps continuation state only for the current process lifetime.
+# Real deployments should persist checkpoints externally (DB/Redis/etc.),
+# or restart continuity for pending flows will be lost.
 _CHECKPOINTS_BY_CHAT_KEY: dict[str, str] = {}
 _PROMPTS_DIR = files("experimental.preprocessor").joinpath("prompts")
 

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -144,6 +144,10 @@ def _replace_compiler_system_message(
     ]
 
 
+def _has_pending_clarification(engine: Engine) -> bool:
+    return engine.export_checkpoint()["pending"] is not None
+
+
 def _extract_completion_content(response: object) -> str | None:
     choices_attr = getattr(response, "choices", None)
     if isinstance(choices_attr, list) and choices_attr:
@@ -489,16 +493,19 @@ class Pipe:
                 engine.import_checkpoint_json(checkpoint)
             _ENGINES_BY_CHAT_KEY[chat_key] = engine
 
-        precompiled, precompile_error = await self._precompile_user_input(
-            latest_user_text,
-            engine.state,
-            request=__request__,
-            user_payload=__user__,
-            prompt_profile=self.valves.PREPROCESSOR_PROMPT_PROFILE,
-            model_id=preprocessor_model_id,
-        )
-        if precompile_error is not None:
-            return precompile_error
+        precompiled: str | None = None
+        precompile_error: str | None = None
+        if not _has_pending_clarification(engine):
+            precompiled, precompile_error = await self._precompile_user_input(
+                latest_user_text,
+                engine.state,
+                request=__request__,
+                user_payload=__user__,
+                prompt_profile=self.valves.PREPROCESSOR_PROMPT_PROFILE,
+                model_id=preprocessor_model_id,
+            )
+            if precompile_error is not None:
+                return precompile_error
 
         logger.debug("preprocessor: precompiled=%r", precompiled)
         # Preserve core behavior: if precompile yields no directive, use raw user

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -5,7 +5,7 @@ import re
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Literal, TypedDict
+from typing import Literal, NotRequired, TypedDict
 from unicodedata import normalize as unicode_normalize
 
 from .const import (
@@ -43,7 +43,7 @@ class CheckpointPending(TypedDict):
 class Checkpoint(TypedDict):
     checkpoint_version: Literal[1]
     authoritative_state: State
-    pending: CheckpointPending | None
+    pending: NotRequired[CheckpointPending | None]
 
 
 class DecisionKind(StrEnum):
@@ -603,7 +603,11 @@ def _load_checkpoint_obj(raw: object) -> tuple[State, PendingReplacement | None,
     if not isinstance(raw, dict):
         raise ValueError("Invalid checkpoint payload.")
 
-    if set(raw.keys()) != {"checkpoint_version", "authoritative_state", "pending"}:
+    keys = set(raw.keys())
+    if keys not in (
+        {"checkpoint_version", "authoritative_state"},
+        {"checkpoint_version", "authoritative_state", "pending"},
+    ):
         raise ValueError("Invalid checkpoint payload.")
 
     checkpoint_version = raw["checkpoint_version"]
@@ -611,7 +615,7 @@ def _load_checkpoint_obj(raw: object) -> tuple[State, PendingReplacement | None,
         raise ValueError(f"Unsupported checkpoint version: {checkpoint_version!r}")
 
     authoritative_state = _load_state_obj(raw["authoritative_state"])
-    pending_replacement, pending_prompt = _load_checkpoint_pending_obj(raw["pending"])
+    pending_replacement, pending_prompt = _load_checkpoint_pending_obj(raw.get("pending"))
     return authoritative_state, pending_replacement, pending_prompt
 
 
@@ -649,6 +653,8 @@ def _load_checkpoint_replacement_obj(raw: object) -> PendingReplacement:
         raise ValueError("Invalid checkpoint payload.")
     if not isinstance(new_item, str):
         raise ValueError("Invalid checkpoint payload.")
+    if _normalize_item(new_item) == "":
+        raise ValueError("Invalid checkpoint payload.")
 
     if kind == "use_only":
         if old_item is not None:
@@ -656,6 +662,8 @@ def _load_checkpoint_replacement_obj(raw: object) -> PendingReplacement:
         return PendingReplacement(kind=kind, new_item=new_item, old_item=None)
 
     if not isinstance(old_item, str):
+        raise ValueError("Invalid checkpoint payload.")
+    if _normalize_item(old_item) == "":
         raise ValueError("Invalid checkpoint payload.")
     return PendingReplacement(kind=kind, new_item=new_item, old_item=old_item)
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -346,7 +346,7 @@ def test_import_checkpoint_invalid_json_and_invalid_object_payload_are_rejected(
         engine.import_checkpoint(  # type: ignore[arg-type]
             {
                 "checkpoint_version": 1,
-                "authoritative_state": {"premise": None, "policies": {}, "version": 2},
+                "pending": None,
             }
         )
 
@@ -568,6 +568,81 @@ def test_import_checkpoint_with_pending_none_clears_existing_pending() -> None:
     yes_decision = engine.step("yes")
     assert yes_decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": "baseline", "policies": {"pytest": "use"}, "version": 2}
+
+
+@pytest.mark.contract
+def test_import_checkpoint_with_pending_absent_clears_existing_pending() -> None:
+    engine = create_engine()
+    engine.step("use kubectl instead of docker")
+
+    engine.import_checkpoint(
+        {
+            "checkpoint_version": 1,
+            "authoritative_state": {
+                "premise": "baseline",
+                "policies": {"pytest": "use"},
+                "version": 2,
+            },
+        }
+    )
+
+    yes_decision = engine.step("yes")
+    assert yes_decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert engine.state == {"premise": "baseline", "policies": {"pytest": "use"}, "version": 2}
+
+
+@pytest.mark.parametrize("new_item", ["", "   ", "the", "an", "a"])
+def test_import_checkpoint_rejects_pending_use_only_with_invalid_new_item(new_item: str) -> None:
+    engine = create_engine()
+    with pytest.raises(ValueError, match="Invalid checkpoint payload"):
+        engine.import_checkpoint(  # type: ignore[arg-type]
+            {
+                "checkpoint_version": 1,
+                "authoritative_state": {"premise": None, "policies": {}, "version": 2},
+                "pending": {
+                    "kind": "replacement",
+                    "replacement": {"kind": "use_only", "new_item": new_item, "old_item": None},
+                    "prompt_to_user": "confirm?",
+                },
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("new_item", "old_item"),
+    [
+        ("", "docker"),
+        ("kubectl", ""),
+        ("the", "docker"),
+        ("kubectl", "an"),
+        ("  ", "docker"),
+        ("kubectl", "   "),
+    ],
+)
+def test_import_checkpoint_rejects_pending_replace_use_with_invalid_items(
+    new_item: str, old_item: str
+) -> None:
+    engine = create_engine()
+    with pytest.raises(ValueError, match="Invalid checkpoint payload"):
+        engine.import_checkpoint(  # type: ignore[arg-type]
+            {
+                "checkpoint_version": 1,
+                "authoritative_state": {
+                    "premise": None,
+                    "policies": {"docker": "use"},
+                    "version": 2,
+                },
+                "pending": {
+                    "kind": "replacement",
+                    "replacement": {
+                        "kind": "replace_use",
+                        "new_item": new_item,
+                        "old_item": old_item,
+                    },
+                    "prompt_to_user": "confirm?",
+                },
+            }
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -1,8 +1,11 @@
 import importlib.util
+import json
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
+
+from context_compiler import create_engine
 
 
 class _FakeEngine:
@@ -158,3 +161,65 @@ def test_litellm_with_preprocessor_bypasses_precompile_while_pending(confirmatio
 
     assert result == "ok"
     assert engine.step_inputs == [confirmation]
+
+
+@pytest.mark.parametrize(
+    ("confirmation", "expected_policies"),
+    [
+        ("yes", {"kubectl": "use"}),
+        ("no", {}),
+    ],
+)
+def test_litellm_with_preprocessor_checkpoint_resume_yes_no_end_to_end(
+    confirmation: str, expected_policies: dict[str, str]
+) -> None:
+    module = _load_module(
+        "litellm_with_preprocessor_checkpoint_resume_e2e",
+        Path("examples/integrations/litellm/with_preprocessor.py"),
+    )
+    checkpoints = cast(dict[str, str], module._CHECKPOINTS_BY_SESSION_KEY)
+    restored = cast(dict[str, int], module._RESTORED_ENGINE_BY_SESSION_KEY)
+    checkpoints.clear()
+    restored.clear()
+
+    call_litellm = cast(Any, module._call_litellm)
+    precompile_user_input = cast(Any, module._precompile_user_input)
+
+    precompile_inputs: list[str] = []
+
+    def _precompile_before_pending(text: str, _state: dict[str, object]) -> None:
+        precompile_inputs.append(text)
+        return None
+
+    def _fail_precompile(_text: str, _state: dict[str, object]) -> None:
+        raise AssertionError("precompile should be bypassed while pending is restored")
+
+    module._call_litellm = lambda _messages: "ok"
+    module._precompile_user_input = _precompile_before_pending
+    session_key = "resume-e2e"
+
+    try:
+        first_engine = create_engine()
+        clarify = module.handle_turn(
+            "use kubectl instead of docker",
+            first_engine,
+            session_key=session_key,
+        )
+        assert "No exact policy found for" in clarify
+        assert precompile_inputs == ["use kubectl instead of docker"]
+        assert session_key in checkpoints
+
+        module._precompile_user_input = _fail_precompile
+        second_engine = create_engine()
+        resumed = module.handle_turn(confirmation, second_engine, session_key=session_key)
+        assert resumed == "ok"
+        assert second_engine.state == {
+            "premise": None,
+            "policies": expected_policies,
+            "version": 2,
+        }
+        resumed_checkpoint = json.loads(checkpoints[session_key])
+        assert resumed_checkpoint["pending"] is None
+    finally:
+        module._call_litellm = call_litellm
+        module._precompile_user_input = precompile_user_input

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -2,12 +2,15 @@ import importlib.util
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
+
 
 class _FakeEngine:
-    def __init__(self, kind: str, checkpoint_out: str) -> None:
+    def __init__(self, kind: str, checkpoint_out: str, *, has_pending: bool = False) -> None:
         self.kind = kind
         self.state: dict[str, object] = {"premise": None, "policies": {}, "version": 2}
         self._checkpoint_out = checkpoint_out
+        self._has_pending = has_pending
         self.imported: list[str] = []
         self.step_calls = 0
         self.export_calls = 0
@@ -18,6 +21,20 @@ class _FakeEngine:
     def export_checkpoint_json(self) -> str:
         self.export_calls += 1
         return self._checkpoint_out
+
+    def export_checkpoint(self) -> dict[str, object]:
+        pending: object = None
+        if self._has_pending:
+            pending = {
+                "kind": "replacement",
+                "replacement": {"kind": "use_only", "new_item": "kubectl", "old_item": None},
+                "prompt_to_user": "confirm?",
+            }
+        return {
+            "checkpoint_version": 1,
+            "authoritative_state": self.state,
+            "pending": pending,
+        }
 
     def step(self, _text: str) -> dict[str, object]:
         self.step_calls += 1
@@ -86,3 +103,58 @@ def test_litellm_with_preprocessor_checkpoint_restore_and_persist_points() -> No
         Path("examples/integrations/litellm/with_preprocessor.py"),
     )
     _assert_checkpoint_behavior(module)
+
+
+@pytest.mark.parametrize("confirmation", ["yes", "no"])
+def test_litellm_with_preprocessor_bypasses_precompile_while_pending(confirmation: str) -> None:
+    module = _load_module(
+        "litellm_with_preprocessor_pending_bypass",
+        Path("examples/integrations/litellm/with_preprocessor.py"),
+    )
+
+    class _PendingEngine:
+        def __init__(self) -> None:
+            self.state: dict[str, object] = {"premise": None, "policies": {}, "version": 2}
+            self.pending = True
+            self.step_inputs: list[str] = []
+
+        def export_checkpoint(self) -> dict[str, object]:
+            pending: object = None
+            if self.pending:
+                pending = {
+                    "kind": "replacement",
+                    "replacement": {"kind": "use_only", "new_item": "kubectl", "old_item": None},
+                    "prompt_to_user": "confirm?",
+                }
+            return {
+                "checkpoint_version": 1,
+                "authoritative_state": self.state,
+                "pending": pending,
+            }
+
+        def step(self, text: str) -> dict[str, object]:
+            self.step_inputs.append(text)
+            if self.pending and text in {"yes", "no"}:
+                self.pending = False
+                return {"kind": "update", "state": self.state}
+            if self.pending:
+                return {"kind": "clarify", "state": None, "prompt_to_user": "confirm?"}
+            return {"kind": "passthrough", "state": None}
+
+    call_litellm = cast(Any, module._call_litellm)
+    precompile_user_input = cast(Any, module._precompile_user_input)
+
+    def _fail_precompile(_text: str, _state: dict[str, object]) -> None:
+        raise AssertionError("should not precompile")
+
+    module._call_litellm = lambda _messages: "ok"
+    module._precompile_user_input = _fail_precompile
+    try:
+        engine = _PendingEngine()
+        result = module.handle_turn(confirmation, engine)
+    finally:
+        module._call_litellm = call_litellm
+        module._precompile_user_input = precompile_user_input
+
+    assert result == "ok"
+    assert engine.step_inputs == [confirmation]

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -1,0 +1,88 @@
+import importlib.util
+from pathlib import Path
+from typing import Any, cast
+
+
+class _FakeEngine:
+    def __init__(self, kind: str, checkpoint_out: str) -> None:
+        self.kind = kind
+        self.state: dict[str, object] = {"premise": None, "policies": {}, "version": 2}
+        self._checkpoint_out = checkpoint_out
+        self.imported: list[str] = []
+        self.step_calls = 0
+        self.export_calls = 0
+
+    def import_checkpoint_json(self, payload: str) -> None:
+        self.imported.append(payload)
+
+    def export_checkpoint_json(self) -> str:
+        self.export_calls += 1
+        return self._checkpoint_out
+
+    def step(self, _text: str) -> dict[str, object]:
+        self.step_calls += 1
+        if self.kind == "clarify":
+            return {"kind": "clarify", "state": None, "prompt_to_user": "confirm?"}
+        return {"kind": self.kind, "state": self.state}
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _assert_checkpoint_behavior(module: object) -> None:
+    checkpoints = cast(dict[str, str], module._CHECKPOINTS_BY_SESSION_KEY)
+    restored = cast(dict[str, int], module._RESTORED_ENGINE_BY_SESSION_KEY)
+    checkpoints.clear()
+    restored.clear()
+
+    call_litellm = cast(Any, module._call_litellm)
+    module._call_litellm = lambda _messages: "ok"
+    if hasattr(module, "_precompile_user_input"):
+        module._precompile_user_input = lambda _text, _state: None
+
+    try:
+        checkpoints["s1"] = "ckpt-in"
+        passthrough_engine = _FakeEngine("passthrough", "ckpt-passthrough")
+        result = module.handle_turn("hello", passthrough_engine, session_key="s1")
+        assert result == "ok"
+        assert passthrough_engine.imported == ["ckpt-in"]
+        assert passthrough_engine.export_calls == 0
+        assert checkpoints["s1"] == "ckpt-in"
+
+        update_engine = _FakeEngine("update", "ckpt-update")
+        result = module.handle_turn("use docker", update_engine, session_key="s1")
+        assert result == "ok"
+        assert update_engine.imported == ["ckpt-in"]
+        assert update_engine.export_calls == 1
+        assert checkpoints["s1"] == "ckpt-update"
+
+        clarify_engine = _FakeEngine("clarify", "ckpt-clarify")
+        result = module.handle_turn(
+            "use kubectl instead of docker", clarify_engine, session_key="s1"
+        )
+        assert result == "confirm?"
+        assert clarify_engine.imported == ["ckpt-update"]
+        assert clarify_engine.export_calls == 1
+        assert checkpoints["s1"] == "ckpt-clarify"
+    finally:
+        module._call_litellm = call_litellm
+
+
+def test_litellm_basic_checkpoint_restore_and_persist_points() -> None:
+    module = _load_module(
+        "litellm_basic_checkpoint", Path("examples/integrations/litellm/basic.py")
+    )
+    _assert_checkpoint_behavior(module)
+
+
+def test_litellm_with_preprocessor_checkpoint_restore_and_persist_points() -> None:
+    module = _load_module(
+        "litellm_with_preprocessor_checkpoint",
+        Path("examples/integrations/litellm/with_preprocessor.py"),
+    )
+    _assert_checkpoint_behavior(module)

--- a/tests/test_litellm_integration_error_paths.py
+++ b/tests/test_litellm_integration_error_paths.py
@@ -1,0 +1,138 @@
+import importlib.util
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from context_compiler import create_engine
+
+LITELLM_BASIC_PATH = Path("examples/integrations/litellm/basic.py")
+LITELLM_WITH_PREPROC_PATH = Path("examples/integrations/litellm/with_preprocessor.py")
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _patch_completion_loader(monkeypatch, module: object, completion_fn: Any) -> None:
+    if hasattr(module, "_get_litellm_completion"):
+        monkeypatch.setattr(module, "_get_litellm_completion", lambda: completion_fn)
+        return
+
+    module_proxy = types.SimpleNamespace(completion=completion_fn)
+    monkeypatch.setattr(module, "import_module", lambda _: module_proxy)  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("module_name", "path"),
+    [
+        ("litellm_basic_error_paths", LITELLM_BASIC_PATH),
+        ("litellm_with_preproc_error_paths", LITELLM_WITH_PREPROC_PATH),
+    ],
+)
+def test_call_litellm_requires_api_key(monkeypatch, module_name: str, path: Path) -> None:
+    module = _load_module(module_name, path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    _patch_completion_loader(monkeypatch, module, lambda **_: {})
+
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY is required"):
+        module._call_litellm([{"role": "user", "content": "hello"}])
+
+
+@pytest.mark.parametrize(
+    ("module_name", "path"),
+    [
+        ("litellm_basic_missing_dep", LITELLM_BASIC_PATH),
+        ("litellm_with_preproc_missing_dep", LITELLM_WITH_PREPROC_PATH),
+    ],
+)
+def test_call_litellm_requires_litellm_dependency(
+    monkeypatch, module_name: str, path: Path
+) -> None:
+    module = _load_module(module_name, path)
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    def _raise_module_not_found() -> Any:
+        raise ModuleNotFoundError
+
+    if hasattr(module, "_get_litellm_completion"):
+        monkeypatch.setattr(module, "_get_litellm_completion", _raise_module_not_found)
+    else:
+        monkeypatch.setattr(
+            module,
+            "import_module",
+            lambda _: _raise_module_not_found(),
+        )
+
+    with pytest.raises(RuntimeError, match="litellm is required"):
+        module._call_litellm([{"role": "user", "content": "hello"}])
+
+
+@pytest.mark.parametrize(
+    ("module_name", "path"),
+    [
+        ("litellm_basic_malformed_response", LITELLM_BASIC_PATH),
+        ("litellm_with_preproc_malformed_response", LITELLM_WITH_PREPROC_PATH),
+    ],
+)
+def test_call_litellm_rejects_missing_content_shape(
+    monkeypatch, module_name: str, path: Path
+) -> None:
+    module = _load_module(module_name, path)
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    def _completion(**_: Any) -> dict[str, object]:
+        return {"choices": [{"message": {"content": None}}]}
+
+    _patch_completion_loader(monkeypatch, module, _completion)
+
+    with pytest.raises(
+        RuntimeError, match="LiteLLM response missing choices\\[0\\]\\.message\\.content"
+    ):
+        module._call_litellm([{"role": "user", "content": "hello"}])
+
+
+def test_with_preprocessor_fallback_failure_preserves_basic_behavior(monkeypatch) -> None:
+    module = _load_module("litellm_with_preproc_fallback_failure", LITELLM_WITH_PREPROC_PATH)
+
+    seen_precompile_inputs: list[str] = []
+
+    def _heuristic(_text: str) -> dict[str, object]:
+        return {"outcome": "no_directive", "directive": None}
+
+    def _fallback(_message: str, _state: dict[str, object]) -> str | None:
+        seen_precompile_inputs.append("called")
+        raise RuntimeError("fallback failed")
+
+    seen_engine_inputs: list[str] = []
+
+    class _ProxyEngine:
+        def __init__(self) -> None:
+            self._engine = create_engine()
+
+        @property
+        def state(self) -> dict[str, object]:
+            return self._engine.state
+
+        def export_checkpoint(self) -> dict[str, object]:
+            return self._engine.export_checkpoint()
+
+        def step(self, text: str) -> dict[str, object]:
+            seen_engine_inputs.append(text)
+            return self._engine.step(text)
+
+    monkeypatch.setattr(module, "precompile_heuristic", _heuristic)
+    monkeypatch.setattr(module, "_llm_fallback_precompile", _fallback)
+    monkeypatch.setattr(module, "_call_litellm", lambda _messages: "ok")
+
+    engine = _ProxyEngine()
+    result = module.handle_turn("hello world", engine)
+
+    assert result == "ok"
+    assert seen_precompile_inputs == ["called"]
+    assert seen_engine_inputs == ["hello world"]

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -1,3 +1,4 @@
+import asyncio
 import builtins
 import importlib.util
 import sys
@@ -67,3 +68,71 @@ def test_openwebui_pipe_imports_without_pydantic(monkeypatch) -> None:
     module = _load_module_with_openwebui_stubs("owui_pipe_no_pydantic", monkeypatch)
     pipe = module.Pipe()
     assert pipe.valves.BASE_MODEL_ID == ""
+
+
+def test_pipe_restore_and_persist_checkpoint_points(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_checkpoint", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY["chat-1"] = "ckpt-in"
+
+    class _FakeEngine:
+        def __init__(self, kind: str, checkpoint_out: str) -> None:
+            self.kind = kind
+            self.state = {"premise": None, "policies": {}, "version": 2}
+            self.imported: list[str] = []
+            self._checkpoint_out = checkpoint_out
+            self.export_calls = 0
+
+        def import_checkpoint_json(self, payload: str) -> None:
+            self.imported.append(payload)
+
+        def export_checkpoint_json(self) -> str:
+            self.export_calls += 1
+            return self._checkpoint_out
+
+        def step(self, _text: str) -> dict[str, object]:
+            if self.kind == "clarify":
+                return {"kind": "clarify", "prompt_to_user": "confirm?", "state": None}
+            return {"kind": self.kind, "state": self.state}
+
+    created: list[_FakeEngine] = []
+
+    def _create_engine():
+        engine = _FakeEngine("clarify", "ckpt-clarify")
+        created.append(engine)
+        return engine
+
+    monkeypatch.setattr(module, "create_engine", _create_engine)
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "test"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-1",
+        )
+    )
+    assert result == "confirm?"
+    assert created[0].imported == ["ckpt-in"]
+    assert module._CHECKPOINTS_BY_CHAT_KEY["chat-1"] == "ckpt-clarify"
+    assert created[0].export_calls == 1
+
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] = "ckpt-keep"
+
+    passthrough_engine = _FakeEngine("passthrough", "ckpt-new")
+    monkeypatch.setattr(module, "create_engine", lambda: passthrough_engine)
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-2",
+        )
+    )
+    assert isinstance(result, dict)
+    assert passthrough_engine.imported == ["ckpt-keep"]
+    assert passthrough_engine.export_calls == 0
+    assert module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] == "ckpt-keep"

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -136,3 +136,95 @@ def test_pipe_restore_and_persist_checkpoint_points(monkeypatch) -> None:
     assert passthrough_engine.imported == ["ckpt-keep"]
     assert passthrough_engine.export_calls == 0
     assert module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] == "ckpt-keep"
+
+
+def test_pipe_requires_base_model_id(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_requires_base", monkeypatch)
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = ""
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+        )
+    )
+
+    assert result == "Context Compiler pipe misconfigured: BASE_MODEL_ID is required."
+
+
+def test_pipe_blocks_recursive_base_model_id(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_recursion_guard", monkeypatch)
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "pipe-model"
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+        )
+    )
+
+    assert result == (
+        "Context Compiler pipe misconfigured: BASE_MODEL_ID must not match "
+        "the selected pipe model id to avoid recursive routing."
+    )
+
+
+def test_pipe_normalizes_model_not_found_response(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_model_not_found_response", monkeypatch)
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        del payload
+        return {"error": {"message": "MODEL NOT FOUND"}}
+
+    module.generate_chat_completion = _chat_completion
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+        )
+    )
+
+    assert result == (
+        "Context Compiler pipe misconfigured: BASE_MODEL_ID was not found in Open WebUI models."
+    )
+
+
+def test_pipe_normalizes_model_not_found_exception(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_model_not_found_exception", monkeypatch)
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+
+    class _ForwardError(Exception):
+        def __init__(self) -> None:
+            super().__init__("forward failed")
+            self.detail = {"error": {"message": "model not found"}}
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        del payload
+        raise _ForwardError()
+
+    module.generate_chat_completion = _chat_completion
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+        )
+    )
+
+    assert result == (
+        "Context Compiler pipe misconfigured: BASE_MODEL_ID was not found in Open WebUI models."
+    )

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -1,10 +1,11 @@
 import asyncio
 import builtins
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -333,3 +334,70 @@ def test_preprocessor_pipe_bypasses_precompile_while_pending(
 
     assert isinstance(result, dict)
     assert engine.step_inputs == [confirmation]
+
+
+@pytest.mark.parametrize(
+    ("confirmation", "expected_policies"),
+    [
+        ("yes", {"kubectl": "use"}),
+        ("no", {}),
+    ],
+)
+def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
+    monkeypatch, confirmation: str, expected_policies: dict[str, str]
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_resume_e2e", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    heuristic_inputs: list[str] = []
+
+    def _heuristic(text: str) -> dict[str, object]:
+        if text in {"yes", "no"}:
+            raise AssertionError("heuristic precompile should be bypassed while pending")
+        heuristic_inputs.append(text)
+        return {"outcome": "no_directive", "directive": None}
+
+    monkeypatch.setattr(module, "precompile_heuristic", _heuristic)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+
+    chat_key = "chat-resume-e2e"
+    clarify = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "use kubectl instead of docker"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_key,
+        )
+    )
+    assert isinstance(clarify, str)
+    assert "No exact policy found for" in clarify
+    assert heuristic_inputs == ["use kubectl instead of docker"]
+
+    module._ENGINES_BY_CHAT_KEY.clear()
+    resumed = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": confirmation}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_key,
+        )
+    )
+    assert isinstance(resumed, dict)
+    resumed_engine = cast(Any, module._ENGINES_BY_CHAT_KEY[chat_key])
+    assert resumed_engine.state == {
+        "premise": None,
+        "policies": expected_policies,
+        "version": 2,
+    }
+    resumed_checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
+    assert resumed_checkpoint["pending"] is None

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -6,6 +6,8 @@ import types
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 MODULE_PATH = Path("examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py")
 
 
@@ -188,9 +190,10 @@ def test_preprocessor_pipe_restore_and_persist_checkpoint_points(monkeypatch) ->
     module._CHECKPOINTS_BY_CHAT_KEY["chat-1"] = "ckpt-in"
 
     class _FakeEngine:
-        def __init__(self, kind: str, checkpoint_out: str) -> None:
+        def __init__(self, kind: str, checkpoint_out: str, *, has_pending: bool = False) -> None:
             self.kind = kind
             self.state = {"premise": None, "policies": {}, "version": 2}
+            self.has_pending = has_pending
             self.imported: list[str] = []
             self._checkpoint_out = checkpoint_out
             self.export_calls = 0
@@ -201,6 +204,20 @@ def test_preprocessor_pipe_restore_and_persist_checkpoint_points(monkeypatch) ->
         def export_checkpoint_json(self) -> str:
             self.export_calls += 1
             return self._checkpoint_out
+
+        def export_checkpoint(self) -> dict[str, object]:
+            pending: object = None
+            if self.has_pending:
+                pending = {
+                    "kind": "replacement",
+                    "replacement": {"kind": "use_only", "new_item": "kubectl", "old_item": None},
+                    "prompt_to_user": "confirm?",
+                }
+            return {
+                "checkpoint_version": 1,
+                "authoritative_state": self.state,
+                "pending": pending,
+            }
 
         def step(self, _text: str) -> dict[str, object]:
             if self.kind == "clarify":
@@ -251,3 +268,68 @@ def test_preprocessor_pipe_restore_and_persist_checkpoint_points(monkeypatch) ->
     assert passthrough_engine.imported == ["ckpt-keep"]
     assert passthrough_engine.export_calls == 0
     assert module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] == "ckpt-keep"
+
+
+@pytest.mark.parametrize("confirmation", ["yes", "no"])
+def test_preprocessor_pipe_bypasses_precompile_while_pending(
+    monkeypatch, confirmation: str
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_pending_bypass", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    class _PendingEngine:
+        def __init__(self) -> None:
+            self.state = {"premise": None, "policies": {}, "version": 2}
+            self.pending = True
+            self.step_inputs: list[str] = []
+
+        def export_checkpoint(self) -> dict[str, object]:
+            pending: object = None
+            if self.pending:
+                pending = {
+                    "kind": "replacement",
+                    "replacement": {"kind": "use_only", "new_item": "kubectl", "old_item": None},
+                    "prompt_to_user": "confirm?",
+                }
+            return {
+                "checkpoint_version": 1,
+                "authoritative_state": self.state,
+                "pending": pending,
+            }
+
+        def export_checkpoint_json(self) -> str:
+            return "ckpt-out"
+
+        def step(self, text: str) -> dict[str, object]:
+            self.step_inputs.append(text)
+            if self.pending and text in {"yes", "no"}:
+                self.pending = False
+                return {"kind": "update", "state": self.state}
+            if self.pending:
+                return {"kind": "clarify", "state": None, "prompt_to_user": "confirm?"}
+            return {"kind": "passthrough", "state": None}
+
+    engine = _PendingEngine()
+    monkeypatch.setattr(module, "create_engine", lambda: engine)
+
+    def _fail_precompile(_: str) -> dict[str, object]:
+        raise AssertionError("should not precompile")
+
+    monkeypatch.setattr(module, "precompile_heuristic", _fail_precompile)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": confirmation}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-pending",
+        )
+    )
+
+    assert isinstance(result, dict)
+    assert engine.step_inputs == [confirmation]

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -179,3 +179,75 @@ def test_recursion_guard_for_preprocessor_model(monkeypatch) -> None:
         "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID must not "
         "match the selected pipe model id to avoid recursive routing."
     )
+
+
+def test_preprocessor_pipe_restore_and_persist_checkpoint_points(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_checkpoint", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY["chat-1"] = "ckpt-in"
+
+    class _FakeEngine:
+        def __init__(self, kind: str, checkpoint_out: str) -> None:
+            self.kind = kind
+            self.state = {"premise": None, "policies": {}, "version": 2}
+            self.imported: list[str] = []
+            self._checkpoint_out = checkpoint_out
+            self.export_calls = 0
+
+        def import_checkpoint_json(self, payload: str) -> None:
+            self.imported.append(payload)
+
+        def export_checkpoint_json(self) -> str:
+            self.export_calls += 1
+            return self._checkpoint_out
+
+        def step(self, _text: str) -> dict[str, object]:
+            if self.kind == "clarify":
+                return {"kind": "clarify", "prompt_to_user": "confirm?", "state": None}
+            return {"kind": self.kind, "state": self.state}
+
+    created: list[_FakeEngine] = []
+
+    def _create_engine():
+        engine = _FakeEngine("clarify", "ckpt-clarify")
+        created.append(engine)
+        return engine
+
+    monkeypatch.setattr(module, "create_engine", _create_engine)
+    monkeypatch.setattr(module, "precompile_heuristic", lambda _text: {"outcome": "no_directive"})
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda _value: None)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "test"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-1",
+        )
+    )
+    assert result == "confirm?"
+    assert created[0].imported == ["ckpt-in"]
+    assert module._CHECKPOINTS_BY_CHAT_KEY["chat-1"] == "ckpt-clarify"
+    assert created[0].export_calls == 1
+
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] = "ckpt-keep"
+
+    passthrough_engine = _FakeEngine("passthrough", "ckpt-new")
+    monkeypatch.setattr(module, "create_engine", lambda: passthrough_engine)
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-2",
+        )
+    )
+    assert isinstance(result, dict)
+    assert passthrough_engine.imported == ["ckpt-keep"]
+    assert passthrough_engine.export_calls == 0
+    assert module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] == "ckpt-keep"

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -86,6 +86,26 @@ def test_preprocessor_model_defaults_to_base_model(monkeypatch) -> None:
     assert pipe._resolve_preprocessor_model_id("base-model") == "base-model"
 
 
+def test_pipe_requires_base_model_id_when_debug_disabled(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_requires_base", monkeypatch)
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = ""
+    pipe.valves.ALLOW_MISSING_BASE_MODEL_FOR_DEBUG = False
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hi"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+        )
+    )
+
+    assert result == (
+        "Context Compiler pipe misconfigured: BASE_MODEL_ID is required "
+        "(or set ALLOW_MISSING_BASE_MODEL_FOR_DEBUG=true for testing)."
+    )
+
+
 def test_preprocessor_model_can_be_overridden(monkeypatch) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_override", monkeypatch)
     pipe = module.Pipe()
@@ -181,6 +201,69 @@ def test_recursion_guard_for_preprocessor_model(monkeypatch) -> None:
     assert result == (
         "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID must not "
         "match the selected pipe model id to avoid recursive routing."
+    )
+
+
+def test_pipe_normalizes_preprocessor_model_not_found_response(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_model_not_found_response", monkeypatch)
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+
+    async def _chat_completion(_: object, payload: dict[str, Any], __: object) -> dict[str, object]:
+        if payload.get("model") == "prep-model":
+            return {"error": {"message": "model not found"}}
+        return {"ok": True}
+
+    module.generate_chat_completion = _chat_completion
+    module.precompile_heuristic = lambda _text: {"outcome": "no_directive", "directive": None}
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+        )
+    )
+
+    assert result == (
+        "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID was not found "
+        "in Open WebUI models."
+    )
+
+
+def test_pipe_normalizes_preprocessor_model_not_found_exception(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs(
+        "owui_preproc_model_not_found_exception", monkeypatch
+    )
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+
+    class _PreprocessorError(Exception):
+        def __init__(self) -> None:
+            super().__init__("preprocessor failed")
+            self.detail = {"error": {"message": "model not found"}}
+
+    async def _chat_completion(_: object, payload: dict[str, Any], __: object) -> dict[str, object]:
+        if payload.get("model") == "prep-model":
+            raise _PreprocessorError()
+        return {"ok": True}
+
+    module.generate_chat_completion = _chat_completion
+    module.precompile_heuristic = lambda _text: {"outcome": "no_directive", "directive": None}
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+        )
+    )
+
+    assert result == (
+        "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID was not found "
+        "in Open WebUI models."
     )
 
 


### PR DESCRIPTION
## What changed
- Added checkpoint restore and persist behavior to LiteLLM example integrations (`basic.py` and `with_preprocessor.py`).
- Added checkpoint restore and persist behavior to OpenWebUI example integrations (`open_webui_pipe.py` and `open_webui_pipe_with_preprocessor.py`).
- Applied persistence rule in examples: write checkpoint on `update` and `clarify`; do not rewrite on `passthrough`.
- Added focused tests for restore-before-first-step and persist points in LiteLLM and OpenWebUI integration flows.
- Added concise in-code comments documenting example checkpoint storage limitations.
- Added README clarifications for in-memory-only checkpoint storage and restart limitation.
- Added README notes that checkpoint continuation in these examples requires `context-compiler >= 0.6.7`.
- Bumped OpenWebUI function frontmatter requirements to `context-compiler >= 0.6.7` and `context-compiler[experimental] >= 0.6.7`.
- Bumped OpenWebUI function frontmatter version from `0.1` to `0.2` in both pipe files.

### Follow-up fixes included in this branch
- Enforced pending-clarification continuation semantics in preprocessor integrations:
  - while pending exists, bypass preprocessor and pass raw user input directly to `engine.step(...)`.
- Hardened checkpoint import validation in engine:
  - `pending` may be absent or `null` (both treated as no pending continuation).
  - semantically invalid pending replacement items are rejected at import (empty / normalize-empty items).
- Added focused engine tests for pending absent/null import and invalid pending replacement item rejection.
- Added end-to-end integration checkpoint resume tests (`yes`/`no`) for preprocessor variants (LiteLLM + OpenWebUI).
- Added focused integration error-path tests for main example integrations:
  - LiteLLM examples: missing API key, missing dependency, malformed provider response shape, preprocessor fallback failure no-op behavior.
  - OpenWebUI examples: required `BASE_MODEL_ID`, recursion guard, and model-not-found response/exception normalization paths.

## Why this was needed
- Example integrations needed explicit serialized continuation behavior without changing core engine semantics.
- Pending clarification behavior had to remain deterministic and spec-aligned across restored/live continuation paths.
- Checkpoint import needed stricter contract handling and semantic validation for externally supplied pending payloads.
- Added tests lock key user-facing failure-path behavior in the primary copyable integration examples.
