### PR TITLE
chore: bump version to 0.6.7 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ Notes:
 - checkpoint validation is all-or-nothing; invalid payloads raise and no partial restore occurs.
 - `checkpoint_version` is independent of authoritative state `version` and must be bumped when checkpoint contract shape changes (especially `pending`).
 
+When to use checkpoint APIs:
+
+- stateless host/integration boundaries where engine instances are short-lived.
+- resume after interruption without losing pending clarification flow.
+- preserve confirmation-required continuation state (`pending`) across process/request boundaries.
+
 ---
 
 ### When to use `premise`

--- a/docs/llm-preprocessor.md
+++ b/docs/llm-preprocessor.md
@@ -29,6 +29,13 @@ All preprocessor outputs, including heuristic outputs, must be validated with
 
 Raw heuristic/LLM outputs must not be passed directly to the compiler.
 
+Pending clarification rule:
+
+- If the engine has pending clarification state, bypass preprocessing and pass
+  raw user input directly to `engine.step(...)`.
+- This preserves deterministic continuation behavior because pending resolution
+  accepts only confirmation tokens until resolved.
+
 ## Limits
 
 The preprocessor is best-effort and intentionally conservative. Ambiguous,

--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -15,7 +15,7 @@ Runtime-validated on stock Docker Open WebUI with a real backend model provider.
 The minimal pipe path below is the easiest first-run flow and was runtime-validated in Docker via API flow with a real backend model.
 
 1. Import `open_webui_pipe.py` (recommended/default) as a Function by URL.
-2. Open WebUI installs `context-compiler>=0.6.6` from the function frontmatter requirements.
+2. Open WebUI installs `context-compiler>=0.6.7` from the function frontmatter requirements.
 3. Enable the function.
 4. Set `BASE_MODEL_ID` to a valid Open WebUI model id (required).
 5. Select the pipe model in chat.
@@ -48,8 +48,8 @@ If frontmatter dependency installs are disabled, offline, or unavailable:
 1. Open a shell in the Open WebUI container:
    - `docker exec -it <openwebui-container> sh`
 2. Install the package manually:
-   - Minimal pipe: `pip install "context-compiler>=0.6.6"`
-   - Preprocessor pipe: `pip install "context-compiler[experimental]>=0.6.6"`
+   - Minimal pipe: `pip install "context-compiler>=0.6.7"`
+   - Preprocessor pipe: `pip install "context-compiler[experimental]>=0.6.7"`
 3. Import and enable the function in Open WebUI, then configure valves.
 
 ### Finding valid model ids

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.6"
+version = "0.6.7"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## what changed
- bumped project version to `0.6.7` in package metadata and lockfile.
- updated README checkpoint documentation with a concise `when to use checkpoint` section.
- updated `docs/llm-preprocessor.md` with the pending-clarification bypass rule (`engine.step(...)` receives raw input while pending exists).
- updated stale OpenWebUI integration README install references from `>=0.6.6` to `>=0.6.7`.

## why this change was needed
- finalize 0.6.7 release metadata.
- ensure user-facing docs clearly distinguish authoritative state export/import from checkpoint continuation.
- document deterministic continuation behavior for preprocessor integrations while pending clarification exists.
- keep integration documentation aligned with checkpoint-capable release requirements.
