### PR TITLE
fix: standardize remaining clarify prompts

### DIFF
--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -247,12 +247,33 @@ Contradictions never silently overwrite state.
 
 When `Decision.kind = "clarify"`, prompt text is deterministic only for the cases listed below.
 
+- `set premise X` when premise already exists (Section 9 case 1):
+  `Premise already set.`
+  `Use 'change premise to <value>' to modify it.`
+- `change premise to X` when no premise exists (Section 9 case 2):
+  `No premise is set.`
+  `Use 'set premise <value>' to define one.`
+- `set premise X` with empty/whitespace-only payload (Section 9 case 3):
+  `Premise value cannot be empty.`
+  `Use 'set premise <value>' with a non-empty value.`
+- `change premise to X` with empty/whitespace-only payload (Section 9 case 4):
+  `Premise value cannot be empty.`
+  `Use 'change premise to <value>' with a non-empty value.`
+- `use ITEM` when that item is currently `"prohibit"` (Section 9 case 5):
+  `"<item>" is currently prohibited.`
+  `Remove or replace it before using it.`
+- `prohibit ITEM` when that item is currently `"use"` (Section 9 case 6):
+  `"<item>" is currently in use.`
+  `Remove or replace it before prohibiting it.`
 - `use X instead of Y` when `Y` does not exist in policies (Section 9 case 7):
   `Did you mean to use "X" instead?`
 - `use X instead of Y` when `Y` is currently `"prohibit"` (Section 9 case 8):
   `"Y" is currently prohibited. Did you mean to remove it and use "X" instead?`
 - `use X instead of Y` when `X` is currently `"prohibit"` (Section 9 case 9):
   `"X" is currently prohibited. Did you mean to remove "Y" and use "X" instead?`
+- `use X instead of Y` when `Y` exists but is not `"use"` and no replacement-intent clarify rule applies (Section 9 case 10):
+  `"<Y>" is not currently in use.`
+  `Replacement requires an active 'use' policy.`
 - Pending clarification unmatched input (Section 9 case 11):
   reuse the existing pending prompt unchanged.
 - `remove policy ITEM` with empty/whitespace-only payload (Section 9 case 12):
@@ -271,9 +292,6 @@ When `Decision.kind = "clarify"`, prompt text is deterministic only for the case
   `Did you mean 'set premise X'?`
 - Premise near-miss `change premise X` (Section 9 case 17):
   `Did you mean 'change premise to X'?`
-
-Clarify cases 1-6 and 10 must return `clarify` but do not require a standardized prompt string in this specification.
-Their exact prompt text is implementation-defined unless standardized in a later spec revision.
 
 ## 10. Pending Clarification
 

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -256,11 +256,11 @@ class Engine:
                 if action.kind == "set_premise":
                     return _clarify(
                         "Premise value cannot be empty.\n"
-                        "Use 'set premise ...' with a non-empty value."
+                        "Use 'set premise <value>' with a non-empty value."
                     )
                 return _clarify(
                     "Premise value cannot be empty.\n"
-                    "Use 'change premise to ...' with a non-empty value."
+                    "Use 'change premise to <value>' with a non-empty value."
                 )
 
         if action.kind == "set_premise_to_variant":
@@ -300,24 +300,17 @@ class Engine:
             )
 
         if action.kind == "set_premise" and self._state[STATE_PREMISE] is not None:
-            return _clarify(
-                "Premise already exists.\n"
-                "Use 'change premise to ...' to replace it.\n"
-                "Premise is a single slot.\n"
-                "To keep multiple ideas, rewrite them as one premise value."
-            )
+            return _clarify("Premise already set.\nUse 'change premise to <value>' to modify it.")
 
         if action.kind == "change_premise" and self._state[STATE_PREMISE] is None:
-            return _clarify("No premise exists yet. Use 'set premise ...' first.")
+            return _clarify("No premise is set.\nUse 'set premise <value>' to define one.")
 
         if action.kind == "use_item":
             assert action.item is not None
             item_key = _normalize_item(action.item)
             if self._state[STATE_POLICIES].get(item_key) == POLICY_PROHIBIT:
                 return _clarify(
-                    f"'{item_key}' is already prohibited.\n"
-                    "Only one policy per item is allowed.\n"
-                    "Use 'reset policies' to change it."
+                    f'"{item_key}" is currently prohibited.\nRemove or replace it before using it.'
                 )
 
         if action.kind == "prohibit_item":
@@ -325,9 +318,8 @@ class Engine:
             item_key = _normalize_item(action.item)
             if self._state[STATE_POLICIES].get(item_key) == POLICY_USE:
                 return _clarify(
-                    f"'{item_key}' is already in use.\n"
-                    "Only one policy per item is allowed.\n"
-                    "Use 'reset policies' to change it."
+                    f'"{item_key}" is currently in use.\n'
+                    "Remove or replace it before prohibiting it."
                 )
 
         if action.kind == "replace_use":
@@ -393,9 +385,8 @@ class Engine:
                 return _clarify(prompt)
             if old_state != POLICY_USE:
                 return _clarify(
-                    f"'{action.old_item}' is not a use policy.\n"
-                    "Replacement requires an existing use policy.\n"
-                    "Use 'reset policies' to change it."
+                    f'"{action.old_item}" is not currently in use.\n'
+                    "Replacement requires an active 'use' policy."
                 )
 
         return None

--- a/tests/test_demo_compaction.py
+++ b/tests/test_demo_compaction.py
@@ -17,9 +17,5 @@ def test_compaction_keeps_first_clarify_line_and_stops_replay() -> None:
     )
 
     assert compacted == ["prohibit docker"]
-    assert prompt == (
-        "'docker' is already in use.\n"
-        "Only one policy per item is allowed.\n"
-        "Use 'reset policies' to change it."
-    )
+    assert prompt == ('"docker" is currently in use.\nRemove or replace it before prohibiting it.')
     assert state == {"premise": None, "policies": {"docker": "use"}, "version": 2}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -541,9 +541,7 @@ def test_replace_use_clarifies_when_old_policy_is_not_use_in_invalid_internal_st
         "kind": "clarify",
         "state": None,
         "prompt_to_user": (
-            "'docker' is not a use policy.\n"
-            "Replacement requires an existing use policy.\n"
-            "Use 'reset policies' to change it."
+            "\"docker\" is not currently in use.\nReplacement requires an active 'use' policy."
         ),
     }
 
@@ -779,7 +777,11 @@ def test_set_premise_lifecycle_rules() -> None:
 
     before = engine.state
     d2 = engine.step("set premise new")
-    assert d2["kind"] == "clarify"
+    assert d2 == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": ("Premise already set.\nUse 'change premise to <value>' to modify it."),
+    }
     assert engine.state == before
 
 
@@ -787,7 +789,13 @@ def test_set_premise_empty_payload_clarifies_without_mutation() -> None:
     engine = create_engine()
     before = engine.state
     d1 = engine.step("set premise")
-    assert d1["kind"] == "clarify"
+    assert d1 == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": (
+            "Premise value cannot be empty.\nUse 'set premise <value>' with a non-empty value."
+        ),
+    }
     assert engine.state == before
 
 
@@ -795,7 +803,13 @@ def test_set_premise_whitespace_payload_clarifies_without_mutation() -> None:
     engine = create_engine()
     before = engine.state
     d1 = engine.step("set premise    ")
-    assert d1["kind"] == "clarify"
+    assert d1 == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": (
+            "Premise value cannot be empty.\nUse 'set premise <value>' with a non-empty value."
+        ),
+    }
     assert engine.state == before
 
 
@@ -816,7 +830,11 @@ def test_change_premise_requires_existing_premise() -> None:
     engine = create_engine()
 
     d1 = engine.step("change premise to concise")
-    assert d1["kind"] == "clarify"
+    assert d1 == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": "No premise is set.\nUse 'set premise <value>' to define one.",
+    }
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
     engine.step("set premise first")
@@ -831,7 +849,14 @@ def test_change_premise_to_empty_payload_clarifies_without_mutation() -> None:
     before = engine.state
 
     d1 = engine.step("change premise to")
-    assert d1["kind"] == "clarify"
+    assert d1 == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": (
+            "Premise value cannot be empty.\n"
+            "Use 'change premise to <value>' with a non-empty value."
+        ),
+    }
     assert engine.state == before
 
 
@@ -853,7 +878,8 @@ def test_change_premise_to_without_space_payload_clarifies_after_near_miss() -> 
         "kind": "clarify",
         "state": None,
         "prompt_to_user": (
-            "Premise value cannot be empty.\nUse 'change premise to ...' with a non-empty value."
+            "Premise value cannot be empty.\n"
+            "Use 'change premise to <value>' with a non-empty value."
         ),
     }
     assert engine.state == before
@@ -865,7 +891,14 @@ def test_change_premise_to_whitespace_payload_clarifies_without_mutation() -> No
     before = engine.state
 
     d1 = engine.step("change premise to    ")
-    assert d1["kind"] == "clarify"
+    assert d1 == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": (
+            "Premise value cannot be empty.\n"
+            "Use 'change premise to <value>' with a non-empty value."
+        ),
+    }
     assert engine.state == before
 
 
@@ -921,9 +954,7 @@ def test_policy_directives_and_idempotent_update() -> None:
     d3 = engine.step("prohibit docker")
     assert d3["kind"] == "clarify"
     assert d3["prompt_to_user"] == (
-        "'docker' is already in use.\n"
-        "Only one policy per item is allowed.\n"
-        "Use 'reset policies' to change it."
+        '"docker" is currently in use.\nRemove or replace it before prohibiting it.'
     )
     assert engine.state["policies"] == {"docker": "use"}
 
@@ -936,9 +967,7 @@ def test_policy_directives_and_idempotent_update() -> None:
     d5 = engine2.step("use docker")
     assert d5["kind"] == "clarify"
     assert d5["prompt_to_user"] == (
-        "'docker' is already prohibited.\n"
-        "Only one policy per item is allowed.\n"
-        "Use 'reset policies' to change it."
+        '"docker" is currently prohibited.\nRemove or replace it before using it.'
     )
     assert engine2.state["policies"] == {"docker": "prohibit"}
 

--- a/tests/test_examples_behavior.py
+++ b/tests/test_examples_behavior.py
@@ -1,0 +1,161 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES_DIR = REPO_ROOT / "examples"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(EXAMPLES_DIR) not in sys.path:
+    sys.path.insert(0, str(EXAMPLES_DIR))
+
+pytestmark = pytest.mark.contract
+
+
+def _load_example_module(filename: str) -> ModuleType:
+    module_name = f"test_examples_behavior_{filename[:-3]}"
+    module_path = EXAMPLES_DIR / filename
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_example_03_clarify_gate_blocks_llm_and_allows_later_update(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _load_example_module("03_ambiguity_with_clarification.py")
+    decision_kinds: list[str] = []
+    llm_calls: list[str] = []
+
+    def capture_decision_summary(decision: object) -> None:
+        assert isinstance(decision, dict)
+        kind = decision.get("kind")
+        assert isinstance(kind, str)
+        decision_kinds.append(kind)
+
+    def fake_llm(user_input: str) -> str:
+        llm_calls.append(user_input)
+        return "[test llm output]"
+
+    monkeypatch.setattr(module, "print_decision_summary", capture_decision_summary)
+    monkeypatch.setattr(module, "fake_llm", fake_llm)
+
+    module.main()
+    output = capsys.readouterr().out
+
+    assert decision_kinds == ["update", "clarify", "update"]
+    assert "Host behavior: clarification pending, do NOT call LLM." in output
+    assert llm_calls == []
+
+
+def test_example_04_tool_governance_blocks_and_allows_expected_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_example_module("04_tool_governance_denylist.py")
+    blocked_tools: list[str] = []
+    allowed_tools: list[str] = []
+
+    def capture_block(tool: object) -> None:
+        assert hasattr(tool, "name")
+        blocked_tools.append(str(tool.name))
+
+    def capture_allow(tool: object) -> None:
+        assert hasattr(tool, "name")
+        allowed_tools.append(str(tool.name))
+
+    monkeypatch.setattr(module, "block_tool", capture_block)
+    monkeypatch.setattr(module, "allow_tool", capture_allow)
+
+    module.main()
+
+    assert blocked_tools == ["docker"]
+    assert allowed_tools == ["kubectl"]
+
+
+def test_example_05_dispatches_passthrough_update_and_clarify_correctly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_example_module("05_llm_integration_pattern.py")
+    engine = module.create_engine()
+    decision_kinds: list[str] = []
+    llm_calls: list[tuple[object, str]] = []
+
+    def capture_decision_summary(decision: object) -> None:
+        assert isinstance(decision, dict)
+        kind = decision.get("kind")
+        assert isinstance(kind, str)
+        decision_kinds.append(kind)
+
+    def capture_fake_llm(state: object, user_input: str) -> str:
+        llm_calls.append((state, user_input))
+        return "[test llm output]"
+
+    monkeypatch.setattr(module, "print_decision_summary", capture_decision_summary)
+    monkeypatch.setattr(module, "fake_llm", capture_fake_llm)
+
+    module.handle_turn("hello there", engine)  # passthrough
+    module.handle_turn("set premise concise replies", engine)  # update
+    calls_before_clarify = len(llm_calls)
+    module.handle_turn("set premise verbose replies", engine)  # clarify
+
+    assert decision_kinds == ["passthrough", "update", "clarify"]
+    assert len(llm_calls) == calls_before_clarify
+    assert llm_calls[0][0] is None
+    assert llm_calls[0][1] == "hello there"
+    assert llm_calls[1][0] is not None
+    assert llm_calls[1][1] == "set premise concise replies"
+
+
+def test_example_06_wires_compile_and_apply_replay_entry_points(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _load_example_module("06_transcript_replay.py")
+    original_compile = module.compile_transcript
+    original_create_engine = module.create_engine
+    compile_calls: list[list[dict[str, str]]] = []
+    apply_calls: list[list[dict[str, str]]] = []
+    replay_result_kinds: list[str] = []
+
+    def compile_wrapper(transcript: list[dict[str, str]]) -> object:
+        compile_calls.append(transcript)
+        result = original_compile(transcript)
+        assert isinstance(result, dict)
+        kind = result.get("kind")
+        assert isinstance(kind, str)
+        replay_result_kinds.append(kind)
+        return result
+
+    def create_engine_wrapper() -> object:
+        engine = original_create_engine()
+        original_apply = engine.apply_transcript
+
+        def apply_wrapper(transcript: list[dict[str, str]]) -> object:
+            apply_calls.append(transcript)
+            result = original_apply(transcript)
+            assert isinstance(result, dict)
+            kind = result.get("kind")
+            assert isinstance(kind, str)
+            replay_result_kinds.append(kind)
+            return result
+
+        engine.apply_transcript = apply_wrapper  # type: ignore[assignment]
+        return engine
+
+    monkeypatch.setattr(module, "compile_transcript", compile_wrapper)
+    monkeypatch.setattr(module, "create_engine", create_engine_wrapper)
+
+    module.main()
+    output = capsys.readouterr().out
+
+    assert "Replay from fresh engine (compile_transcript):" in output
+    assert "Replay onto current engine (engine.apply_transcript):" in output
+    assert len(compile_calls) == 1
+    assert len(apply_calls) == 1
+    assert replay_result_kinds == ["state", "state"]

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.contract
             "03_ambiguity_with_clarification.py",
             (
                 "Host behavior: clarification pending, do NOT call LLM.",
-                "Use 'reset policies' to change it.",
+                "Remove or replace it before using it.",
             ),
         ),
         (

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -229,9 +229,8 @@ def test_repl_contradiction_clarify_is_not_pending_confirmable() -> None:
     assert _contains_subsequence(
         lines,
         [
-            "error: 'docker' is already in use.",
-            "Only one policy per item is allowed.",
-            "Use 'reset policies' to change it.",
+            'error: "docker" is currently in use.',
+            "Remove or replace it before prohibiting it.",
             "passthrough",
         ],
     )
@@ -251,9 +250,8 @@ def test_repl_interactive_prints_confirm_and_error_for_clarify_types() -> None:
     error_out = _TTYStringIO()
     run_repl(_TTYStringIO("use docker\nprohibit docker\nquit\n"), error_out)
     error_lines = error_out.getvalue().splitlines()
-    assert "error: 'docker' is already in use." in error_lines
-    assert "Only one policy per item is allowed." in error_lines
-    assert "Use 'reset policies' to change it." in error_lines
+    assert 'error: "docker" is currently in use.' in error_lines
+    assert "Remove or replace it before prohibiting it." in error_lines
 
     confirm_out = _TTYStringIO()
     run_repl(_TTYStringIO("use podman instead of docker\nquit\n"), confirm_out)
@@ -306,10 +304,8 @@ def test_repl_premise_lifecycle_outputs_expected_state_shape() -> None:
     assert _contains_subsequence(
         lines,
         [
-            "error: Premise already exists.",
-            "Use 'change premise to ...' to replace it.",
-            "Premise is a single slot.",
-            "To keep multiple ideas, rewrite them as one premise value.",
+            "error: Premise already set.",
+            "Use 'change premise to <value>' to modify it.",
         ],
     )
     assert _contains_subsequence(
@@ -377,13 +373,10 @@ def test_repl_interactive_confirm_vs_error_alignment_for_actual_clarify_behavior
         "quit\n"
     )
 
-    assert ("error: Premise already exists.") in lines
-    assert "Use 'change premise to ...' to replace it." in lines
-    assert "Premise is a single slot." in lines
-    assert "To keep multiple ideas, rewrite them as one premise value." in lines
-    assert ("error: 'docker' is already in use.") in lines
-    assert "Only one policy per item is allowed." in lines
-    assert "Use 'reset policies' to change it." in lines
+    assert ("error: Premise already set.") in lines
+    assert "Use 'change premise to <value>' to modify it." in lines
+    assert ('error: "docker" is currently in use.') in lines
+    assert "Remove or replace it before prohibiting it." in lines
     assert 'confirm: No exact policy found for "buildx".' in lines
     assert "Replacement requires an exact policy match." in lines
     assert 'Confirm to use "podman" and keep existing policies?' in lines
@@ -424,7 +417,7 @@ def test_repl_interactive_prints_blank_line_before_error_decision() -> None:
     run_repl(_TTYStringIO("set premise concise\nset premise verbose\nquit\n"), out)
     text = out.getvalue()
 
-    assert "\n\nerror: Premise already exists.\n" in text
+    assert "\n\nerror: Premise already set.\n" in text
 
 
 def test_repl_interactive_state_renders_empty_state() -> None:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -2,6 +2,8 @@ from io import StringIO
 
 import pytest
 
+import context_compiler.repl as repl_module
+from context_compiler import create_engine
 from context_compiler.repl import run_repl
 
 pytestmark = pytest.mark.contract
@@ -232,6 +234,70 @@ def test_repl_contradiction_clarify_is_not_pending_confirmable() -> None:
             'error: "docker" is currently in use.',
             "Remove or replace it before prohibiting it.",
             "passthrough",
+        ],
+    )
+
+
+def test_repl_change_premise_without_existing_premise_renders_exact_error() -> None:
+    lines = _run_non_interactive_lines("change premise to concise\nquit\n")
+    assert _contains_subsequence(
+        lines,
+        [
+            "error: No premise is set.",
+            "Use 'set premise <value>' to define one.",
+        ],
+    )
+
+
+def test_repl_set_premise_empty_payload_renders_exact_error() -> None:
+    lines = _run_non_interactive_lines("set premise\nquit\n")
+    assert _contains_subsequence(
+        lines,
+        [
+            "error: Premise value cannot be empty.",
+            "Use 'set premise <value>' with a non-empty value.",
+        ],
+    )
+
+
+def test_repl_change_premise_empty_payload_renders_exact_error() -> None:
+    lines = _run_non_interactive_lines("change premise to\nquit\n")
+    assert _contains_subsequence(
+        lines,
+        [
+            "error: Premise value cannot be empty.",
+            "Use 'change premise to <value>' with a non-empty value.",
+        ],
+    )
+
+
+def test_repl_use_item_when_prohibited_renders_exact_error() -> None:
+    lines = _run_non_interactive_lines("prohibit docker\nuse docker\nquit\n")
+    assert _contains_subsequence(
+        lines,
+        [
+            'error: "docker" is currently prohibited.',
+            "Remove or replace it before using it.",
+        ],
+    )
+
+
+def test_repl_replace_use_when_old_policy_not_use_renders_exact_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = create_engine()
+    engine._state["policies"]["docker"] = "invalid"  # type: ignore[assignment]
+    monkeypatch.setattr(repl_module, "create_engine", lambda: engine)
+
+    out = StringIO()
+    run_repl(StringIO("use podman instead of docker\nquit\n"), out)
+    lines = [line for line in out.getvalue().splitlines() if line.strip()]
+
+    assert _contains_subsequence(
+        lines,
+        [
+            'error: "docker" is not currently in use.',
+            "Replacement requires an active 'use' policy.",
         ],
     )
 


### PR DESCRIPTION
## What changed
- Standardized the remaining clarify prompt_to_user strings in the directive spec for Section 9 cases 1-6 and 10.
- Aligned engine clarify outputs to those canonical strings without changing directive parsing, state transitions, or pending-clarification behavior.
- Updated exact-string tests for engine and REPL prompt rendering to match the standardized text.
- Added focused REPL assertions for missing canonical clarify pass-through cases.
- Added a new soft-regression behavioral examples test file for examples 03/04/05/06, using branch/call-level assertions rather than transcript snapshots.

## Why this change was needed
- Cases 1-6 and 10 were previously implementation-defined in the spec, which left prompt text non-canonical.
- Standardizing and asserting these prompts closes contract gaps between spec, engine output, and REPL/user-facing rendering.
- The added example behavior tests provide lightweight host-pattern regression protection without duplicating the full core conformance suite.