### PR TITLE
docs: add user-facing behavior test check to agents guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,24 @@ Before committing:
 
 Do not bypass pre-commit hooks.
 
+## Test coverage expectations
+Before opening a PR, consider:
+
+* Does this change affect any user-facing behavior?
+* If so, is that behavior covered by tests?
+
+User-facing behavior includes:
+
+* engine decision outcomes (`kind`, `prompt_to_user`)
+* checkpoint export/import and continuation behavior
+* clarify/confirmation flows (`yes` / `no`)
+* integration behavior (LiteLLM, OpenWebUI)
+* integration error-path normalization
+
+If a user-facing behavior is changed or introduced, add or update tests to cover it.
+
+Do not rely solely on coverage metrics.
+
 ## Scope of changes
 - Only modify files necessary for the requested task.
 - Do not refactor unrelated code.


### PR DESCRIPTION
## what changed
- Added a new `Test coverage expectations` section to `AGENTS.md`.
- Added a pre-PR check to confirm whether a change affects user-facing behavior and whether tests cover it.
- Listed user-facing areas to evaluate: engine decisions/prompts, checkpoint continuation behavior, clarify confirmation flows, LiteLLM/OpenWebUI integrations, and integration error-path normalization.
- Added guidance to add or update tests when user-facing behavior changes and to avoid relying only on coverage metrics.

## why the change was needed
- This makes test expectations explicit in contributor guidance so user-facing behavior changes are consistently protected by targeted tests before PRs are opened.