### PR TITLE
fix: align replacement-missing-policy prompt to spec

### DIFF
--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -333,25 +333,7 @@ class Engine:
             old_state = self._state[STATE_POLICIES].get(old_key)
             new_state = self._state[STATE_POLICIES].get(new_key)
             if old_key not in self._state[STATE_POLICIES]:
-                prompt_lines = [
-                    f'No exact policy found for "{action.old_item}".',
-                    "Replacement requires an exact policy match.",
-                ]
-                diagnostic_hints = _diagnostic_policy_contains_hints(
-                    self._state[STATE_POLICIES], action.old_item
-                )
-                if diagnostic_hints:
-                    prompt_lines.append(
-                        f"Existing policies containing that text: {diagnostic_hints}."
-                    )
-                    prompt_lines.append(
-                        f'Confirm to use "{action.new_item}" and keep {diagnostic_hints}?'
-                    )
-                else:
-                    prompt_lines.append(
-                        f'Confirm to use "{action.new_item}" and keep existing policies?'
-                    )
-                prompt = "\n".join(prompt_lines)
+                prompt = f'Did you mean to use "{action.new_item}" instead?'
                 self._pending_replacement = PendingReplacement(
                     kind="use_only",
                     new_item=action.new_item,
@@ -673,16 +655,6 @@ def _normalize_item(value: str) -> str:
     normalized = re.sub(r"\s+", " ", normalized).strip()
     normalized = re.sub(r"^(?:a|an|the)\b\s*", "", normalized)
     return normalized.strip()
-
-
-def _diagnostic_policy_contains_hints(policies: dict[str, PolicyValue], raw_item: str) -> str:
-    probe = _normalize_item(raw_item)
-    if probe == "":
-        return ""
-    matches = sorted(key for key in policies if probe in key)
-    if not matches:
-        return ""
-    return ", ".join(f'"{key}"' for key in matches)
 
 
 def _normalize_confirmation(text: str) -> str:

--- a/tests/fixtures/v2/step/008_replace_missing_source_clarify_prompt.json
+++ b/tests/fixtures/v2/step/008_replace_missing_source_clarify_prompt.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "clarify",
-      "prompt_to_user": "No exact policy found for \"docker\".\nReplacement requires an exact policy match.\nConfirm to use \"kubectl\" and keep existing policies?",
+      "prompt_to_user": "Did you mean to use \"kubectl\" instead?",
       "state": null
     },
     "state": {

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -237,11 +237,7 @@ def test_export_checkpoint_serializes_pending_replacement_state_for_exact_resume
             "new_item": "kubectl",
             "old_item": None,
         },
-        "prompt_to_user": (
-            'No exact policy found for "docker".\n'
-            "Replacement requires an exact policy match.\n"
-            'Confirm to use "kubectl" and keep existing policies?'
-        ),
+        "prompt_to_user": 'Did you mean to use "kubectl" instead?',
     }
 
 
@@ -1124,11 +1120,7 @@ def test_replace_use_identity_is_noop_update() -> None:
 
 def test_replace_use_missing_source_state_enters_replacement_intent_clarify() -> None:
     engine = create_engine()
-    expected_prompt = (
-        'No exact policy found for "docker".\n'
-        "Replacement requires an exact policy match.\n"
-        'Confirm to use "kubectl" and keep existing policies?'
-    )
+    expected_prompt = 'Did you mean to use "kubectl" instead?'
 
     d1 = engine.step("use kubectl instead of docker")
     assert d1 == {
@@ -1141,11 +1133,7 @@ def test_replace_use_missing_source_state_enters_replacement_intent_clarify() ->
 
 def test_replace_use_missing_source_yes_confirmation_applies_use_only() -> None:
     engine = create_engine()
-    expected_prompt = (
-        'No exact policy found for "docker".\n'
-        "Replacement requires an exact policy match.\n"
-        'Confirm to use "kubectl" and keep existing policies?'
-    )
+    expected_prompt = 'Did you mean to use "kubectl" instead?'
 
     first = engine.step("use kubectl instead of docker")
     assert first == {
@@ -1177,11 +1165,7 @@ def test_replace_use_missing_source_no_confirmation_has_no_mutation() -> None:
 def test_replace_use_missing_source_takes_priority_over_target_prohibit_prompt() -> None:
     engine = create_engine()
     engine.step("prohibit kubectl")
-    expected_prompt = (
-        'No exact policy found for "docker".\n'
-        "Replacement requires an exact policy match.\n"
-        'Confirm to use "kubectl" and keep existing policies?'
-    )
+    expected_prompt = 'Did you mean to use "kubectl" instead?'
 
     decision = engine.step("use kubectl instead of docker")
     assert decision == {
@@ -1196,12 +1180,11 @@ def test_replace_use_missing_source_prompt_includes_contains_diagnostic_hints() 
     engine.step("use python and docker")
 
     decision = engine.step("use kubectl instead of python")
-    assert decision["kind"] == "clarify"
-    prompt = decision["prompt_to_user"] or ""
-    assert 'No exact policy found for "python".' in prompt
-    assert "Replacement requires an exact policy match." in prompt
-    assert 'Existing policies containing that text: "python and docker".' in prompt
-    assert prompt.endswith('Confirm to use "kubectl" and keep "python and docker"?')
+    assert decision == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": 'Did you mean to use "kubectl" instead?',
+    }
 
 
 def test_replace_use_missing_source_prompt_lists_multiple_diagnostic_hints_sorted() -> None:
@@ -1210,16 +1193,11 @@ def test_replace_use_missing_source_prompt_lists_multiple_diagnostic_hints_sorte
     engine.step("prohibit python tooling")
 
     decision = engine.step("use kubectl instead of python")
-    assert decision["kind"] == "clarify"
-    prompt = decision["prompt_to_user"] or ""
-    assert 'No exact policy found for "python".' in prompt
-    assert "Replacement requires an exact policy match." in prompt
-    assert (
-        'Existing policies containing that text: "python and docker", "python tooling".' in prompt
-    )
-    assert prompt.endswith(
-        'Confirm to use "kubectl" and keep "python and docker", "python tooling"?'
-    )
+    assert decision == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": 'Did you mean to use "kubectl" instead?',
+    }
 
 
 def test_replace_use_missing_source_with_empty_normalized_probe_omits_diagnostic_hints() -> None:
@@ -1228,11 +1206,11 @@ def test_replace_use_missing_source_with_empty_normalized_probe_omits_diagnostic
     before = engine.state
 
     decision = engine.step("use kubectl instead of the")
-    assert decision["kind"] == "clarify"
-    prompt = decision["prompt_to_user"] or ""
-    assert 'No exact policy found for "the".' in prompt
-    assert "Replacement requires an exact policy match." in prompt
-    assert "Existing policies containing that text:" not in prompt
+    assert decision == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": 'Did you mean to use "kubectl" instead?',
+    }
     assert engine.state == before
 
 

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -205,7 +205,7 @@ def test_litellm_with_preprocessor_checkpoint_resume_yes_no_end_to_end(
             first_engine,
             session_key=session_key,
         )
-        assert "No exact policy found for" in clarify
+        assert clarify == 'Did you mean to use "kubectl" instead?'
         assert precompile_inputs == ["use kubectl instead of docker"]
         assert session_key in checkpoints
 

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -460,7 +460,7 @@ def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
         )
     )
     assert isinstance(clarify, str)
-    assert "No exact policy found for" in clarify
+    assert clarify == 'Did you mean to use "kubectl" instead?'
     assert heuristic_inputs == ["use kubectl instead of docker"]
 
     module._ENGINES_BY_CHAT_KEY.clear()

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -306,9 +306,7 @@ def test_repl_replacement_clarify_requires_confirmation_tokens_and_persists_unti
     None
 ):
     lines = _run_non_interactive_lines("use podman instead of docker\nmaybe\nyes please!!\nquit\n")
-    assert lines.count('confirm: No exact policy found for "docker".') == 2
-    assert lines.count("Replacement requires an exact policy match.") == 2
-    assert lines.count('Confirm to use "podman" and keep existing policies?') == 2
+    assert lines.count('confirm: Did you mean to use "podman" instead?') == 2
     assert _contains_subsequence(lines, ["updated", "premise: (none)", "policies:", "- use podman"])
 
 
@@ -322,9 +320,7 @@ def test_repl_interactive_prints_confirm_and_error_for_clarify_types() -> None:
     confirm_out = _TTYStringIO()
     run_repl(_TTYStringIO("use podman instead of docker\nquit\n"), confirm_out)
     confirm_lines = confirm_out.getvalue().splitlines()
-    assert 'confirm: No exact policy found for "docker".' in confirm_lines
-    assert "Replacement requires an exact policy match." in confirm_lines
-    assert 'Confirm to use "podman" and keep existing policies?' in confirm_lines
+    assert 'confirm: Did you mean to use "podman" instead?' in confirm_lines
 
 
 def test_repl_replacement_negative_confirmation_returns_update_unchanged_and_clears_pending() -> (
@@ -391,31 +387,23 @@ def test_repl_interactive_renders_updated_state_blocks_for_multiple_operations()
 
 def test_repl_interactive_confirmation_token_variants_resolve_pending_clarify() -> None:
     lines_yes = _run_interactive_lines("use podman instead of docker\nyeah\nquit\n")
-    assert 'confirm: No exact policy found for "docker".' in lines_yes
-    assert "Replacement requires an exact policy match." in lines_yes
-    assert 'Confirm to use "podman" and keep existing policies?' in lines_yes
+    assert 'confirm: Did you mean to use "podman" instead?' in lines_yes
     assert _contains_subsequence(
         lines_yes, ["updated", "premise: (none)", "policies:", "- use podman"]
     )
 
     lines_ok = _run_interactive_lines("use buildah instead of docker\nok\nquit\n")
-    assert 'confirm: No exact policy found for "docker".' in lines_ok
-    assert "Replacement requires an exact policy match." in lines_ok
-    assert 'Confirm to use "buildah" and keep existing policies?' in lines_ok
+    assert 'confirm: Did you mean to use "buildah" instead?' in lines_ok
     assert _contains_subsequence(
         lines_ok, ["updated", "premise: (none)", "policies:", "- use buildah"]
     )
 
     lines_nope = _run_interactive_lines("use nerdctl instead of docker\nnope\nquit\n")
-    assert 'confirm: No exact policy found for "docker".' in lines_nope
-    assert "Replacement requires an exact policy match." in lines_nope
-    assert 'Confirm to use "nerdctl" and keep existing policies?' in lines_nope
+    assert 'confirm: Did you mean to use "nerdctl" instead?' in lines_nope
     assert _contains_subsequence(lines_nope, ["updated", "premise: (none)", "policies: (none)"])
 
     lines_no_thanks = _run_interactive_lines("use helm instead of docker\nno thanks\nquit\n")
-    assert 'confirm: No exact policy found for "docker".' in lines_no_thanks
-    assert "Replacement requires an exact policy match." in lines_no_thanks
-    assert 'Confirm to use "helm" and keep existing policies?' in lines_no_thanks
+    assert 'confirm: Did you mean to use "helm" instead?' in lines_no_thanks
     assert _contains_subsequence(
         lines_no_thanks, ["updated", "premise: (none)", "policies: (none)"]
     )
@@ -443,9 +431,7 @@ def test_repl_interactive_confirm_vs_error_alignment_for_actual_clarify_behavior
     assert "Use 'change premise to <value>' to modify it." in lines
     assert ('error: "docker" is currently in use.') in lines
     assert "Remove or replace it before prohibiting it." in lines
-    assert 'confirm: No exact policy found for "buildx".' in lines
-    assert "Replacement requires an exact policy match." in lines
-    assert 'Confirm to use "podman" and keep existing policies?' in lines
+    assert 'confirm: Did you mean to use "podman" instead?' in lines
 
 
 def test_repl_interactive_passthrough_prints_passthrough_label() -> None:

--- a/tests/test_transcript_replay.py
+++ b/tests/test_transcript_replay.py
@@ -132,12 +132,7 @@ def test_transcript_stops_at_first_confirmable_clarify_even_if_later_yes_no_mess
         ]
     )
 
-    expected_prompt = (
-        'No exact policy found for "python".\n'
-        "Replacement requires an exact policy match.\n"
-        'Existing policies containing that text: "python and docker".\n'
-        'Confirm to use "kubectl" and keep "python and docker"?'
-    )
+    expected_prompt = 'Did you mean to use "kubectl" instead?'
     assert result == {"kind": "confirm", "prompt_to_user": expected_prompt}
 
 


### PR DESCRIPTION
## what changed
- Updated the case-7 clarify branch (`use X instead of Y` when `Y` is missing) to return the exact spec prompt: `Did you mean to use "X" instead?`
- Removed the previous implementation-specific multi-line diagnostic/confirm text for that case.
- Updated affected tests and fixture expectations that referenced the old wording.

## why the change was needed
- The implementation and tests had drifted from the spec for clarify case 7.
- This change restores strict prompt contract alignment across engine behavior, checkpoint/fixture expectations, REPL rendering, transcript replay, and integration resume tests.