### PR TITLE
docs: harden structured fixture policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,3 +97,10 @@ Use the project's existing tooling:
 
 - Run commands via `uv run` when appropriate.
 - Development dependencies are installed with `uv sync --group dev`.
+
+## Structured Regression Fixtures
+- Deterministic engine behavior changes that affect `tests/fixtures/v3/structured/` outputs must update the corresponding fixtures.
+- Fixture updates must be intentional; do not regenerate fixtures casually or as a side effect of normal test runs.
+- If a PR changes structured fixtures, the PR description must explain:
+  - what behavioral contract changed
+  - why it changed

--- a/tests/fixtures/v3/structured/README.md
+++ b/tests/fixtures/v3/structured/README.md
@@ -56,3 +56,11 @@ These surfaces are tested separately because:
 - precompiler behavior is non-deterministic and outside the engine contract
 
 This fixture set is the **canonical engine-level conformance surface**, and may be reused by other implementations (e.g., TypeScript) to validate identical engine behavior.
+
+## Fixture Policy
+
+These fixtures are contract artifacts. Changes should be intentional and reviewed.
+
+If deterministic engine behavior changes, update the corresponding `v3/structured` fixtures in the same PR and explain the behavioral contract change.
+
+Fixture regeneration must be explicit and opt-in. Normal test runs are read-only and must fail on mismatches rather than rewriting fixtures.

--- a/tests/fixtures/v3/structured/README.md
+++ b/tests/fixtures/v3/structured/README.md
@@ -1,0 +1,58 @@
+# Structured Regression Fixtures
+
+These fixtures define deterministic, per-turn behavioral regression coverage for the Python engine.
+
+## Layout
+
+* `scenarios/`: input stimuli and optional setup (`initial_checkpoint`)
+* `expected/`: exact per-turn expected outputs
+
+Each scenario file in `scenarios/` must have a matching file in `expected/` with the same `id`.
+
+## Turn Result Schema
+
+Each expected turn uses:
+
+* `input`
+* `decision.kind`
+* `decision.prompt_to_user`
+* `checkpoint`
+
+`decision.state` is intentionally omitted because `checkpoint` is the authoritative resumable artifact.
+
+## Why Checkpoint Every Turn
+
+A full checkpoint is stored and compared on every turn so regressions are visible in:
+
+* authoritative state
+* pending continuation state
+
+## Prompt Matching
+
+`decision.prompt_to_user` is matched exactly, including clarify text.
+
+## Adding a Scenario
+
+1. Add a scenario input file under `scenarios/`.
+2. Add the matching expected per-turn golden file under `expected/`.
+3. Keep files JSON-only, deterministic, and easy to diff.
+
+### Scope Boundary
+
+These fixtures validate **deterministic engine behavior only**:
+
+- `engine.step(...)` outputs (`Decision.kind`, `prompt_to_user`)
+- post-turn checkpoint (`authoritative_state` + `pending`)
+
+They do **not** cover:
+
+- REPL / user-facing formatting
+- LLM integration behavior
+- precompiler / heuristic directive generation
+
+These surfaces are tested separately because:
+
+- REPL output may intentionally differ from the underlying state representation
+- precompiler behavior is non-deterministic and outside the engine contract
+
+This fixture set is the **canonical engine-level conformance surface**, and may be reused by other implementations (e.g., TypeScript) to validate identical engine behavior.

--- a/tests/fixtures/v3/structured/expected/contradiction_clarify.json
+++ b/tests/fixtures/v3/structured/expected/contradiction_clarify.json
@@ -1,0 +1,41 @@
+{
+  "id": "contradiction_clarify",
+  "turns": [
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "use docker"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "clarify",
+        "prompt_to_user": "\"docker\" is currently in use.\nRemove or replace it before prohibiting it."
+      },
+      "input": "prohibit docker"
+    }
+  ]
+}

--- a/tests/fixtures/v3/structured/expected/pending_clarify_no.json
+++ b/tests/fixtures/v3/structured/expected/pending_clarify_no.json
@@ -1,0 +1,88 @@
+{
+  "id": "pending_clarify_no",
+  "turns": [
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "use docker"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use",
+            "kubectl": "prohibit"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "prohibit kubectl"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use",
+            "kubectl": "prohibit"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": {
+          "kind": "replacement",
+          "prompt_to_user": "\"kubectl\" is currently prohibited. Did you mean to remove \"docker\" and use \"kubectl\" instead?",
+          "replacement": {
+            "kind": "replace_use",
+            "new_item": "kubectl",
+            "old_item": "docker"
+          }
+        }
+      },
+      "decision": {
+        "kind": "clarify",
+        "prompt_to_user": "\"kubectl\" is currently prohibited. Did you mean to remove \"docker\" and use \"kubectl\" instead?"
+      },
+      "input": "use kubectl instead of docker"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use",
+            "kubectl": "prohibit"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "no"
+    }
+  ]
+}

--- a/tests/fixtures/v3/structured/expected/pending_clarify_unmatched.json
+++ b/tests/fixtures/v3/structured/expected/pending_clarify_unmatched.json
@@ -1,0 +1,96 @@
+{
+  "id": "pending_clarify_unmatched",
+  "turns": [
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "use docker"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use",
+            "kubectl": "prohibit"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "prohibit kubectl"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use",
+            "kubectl": "prohibit"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": {
+          "kind": "replacement",
+          "prompt_to_user": "\"kubectl\" is currently prohibited. Did you mean to remove \"docker\" and use \"kubectl\" instead?",
+          "replacement": {
+            "kind": "replace_use",
+            "new_item": "kubectl",
+            "old_item": "docker"
+          }
+        }
+      },
+      "decision": {
+        "kind": "clarify",
+        "prompt_to_user": "\"kubectl\" is currently prohibited. Did you mean to remove \"docker\" and use \"kubectl\" instead?"
+      },
+      "input": "use kubectl instead of docker"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use",
+            "kubectl": "prohibit"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": {
+          "kind": "replacement",
+          "prompt_to_user": "\"kubectl\" is currently prohibited. Did you mean to remove \"docker\" and use \"kubectl\" instead?",
+          "replacement": {
+            "kind": "replace_use",
+            "new_item": "kubectl",
+            "old_item": "docker"
+          }
+        }
+      },
+      "decision": {
+        "kind": "clarify",
+        "prompt_to_user": "\"kubectl\" is currently prohibited. Did you mean to remove \"docker\" and use \"kubectl\" instead?"
+      },
+      "input": "how about kubernetes?"
+    }
+  ]
+}

--- a/tests/fixtures/v3/structured/expected/pending_clarify_yes.json
+++ b/tests/fixtures/v3/structured/expected/pending_clarify_yes.json
@@ -1,0 +1,87 @@
+{
+  "id": "pending_clarify_yes",
+  "turns": [
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "use docker"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use",
+            "kubectl": "prohibit"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "prohibit kubectl"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "docker": "use",
+            "kubectl": "prohibit"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": {
+          "kind": "replacement",
+          "prompt_to_user": "\"kubectl\" is currently prohibited. Did you mean to remove \"docker\" and use \"kubectl\" instead?",
+          "replacement": {
+            "kind": "replace_use",
+            "new_item": "kubectl",
+            "old_item": "docker"
+          }
+        }
+      },
+      "decision": {
+        "kind": "clarify",
+        "prompt_to_user": "\"kubectl\" is currently prohibited. Did you mean to remove \"docker\" and use \"kubectl\" instead?"
+      },
+      "input": "use kubectl instead of docker"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {
+            "kubectl": "use"
+          },
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "yes"
+    }
+  ]
+}

--- a/tests/fixtures/v3/structured/expected/premise_lifecycle.json
+++ b/tests/fixtures/v3/structured/expected/premise_lifecycle.json
@@ -1,0 +1,85 @@
+{
+  "id": "premise_lifecycle",
+  "turns": [
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {},
+          "premise": "concise replies",
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "set premise concise replies"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {},
+          "premise": "concise replies",
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "clarify",
+        "prompt_to_user": "Premise already set.\nUse 'change premise to <value>' to modify it."
+      },
+      "input": "set premise formal replies"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {},
+          "premise": "concise bullet points",
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "change premise to concise bullet points"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {},
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "update",
+        "prompt_to_user": null
+      },
+      "input": "clear premise"
+    },
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {},
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": null
+      },
+      "decision": {
+        "kind": "clarify",
+        "prompt_to_user": "No premise is set.\nUse 'set premise <value>' to define one."
+      },
+      "input": "change premise to formal tone"
+    }
+  ]
+}

--- a/tests/fixtures/v3/structured/expected/replacement_clarify.json
+++ b/tests/fixtures/v3/structured/expected/replacement_clarify.json
@@ -1,0 +1,29 @@
+{
+  "id": "replacement_clarify",
+  "turns": [
+    {
+      "checkpoint": {
+        "authoritative_state": {
+          "policies": {},
+          "premise": null,
+          "version": 2
+        },
+        "checkpoint_version": 1,
+        "pending": {
+          "kind": "replacement",
+          "prompt_to_user": "Did you mean to use \"podman\" instead?",
+          "replacement": {
+            "kind": "use_only",
+            "new_item": "podman",
+            "old_item": null
+          }
+        }
+      },
+      "decision": {
+        "kind": "clarify",
+        "prompt_to_user": "Did you mean to use \"podman\" instead?"
+      },
+      "input": "use podman instead of docker"
+    }
+  ]
+}

--- a/tests/fixtures/v3/structured/scenarios/contradiction_clarify.json
+++ b/tests/fixtures/v3/structured/scenarios/contradiction_clarify.json
@@ -1,0 +1,9 @@
+{
+  "description": "Policy contradiction yields clarify with no mutation",
+  "id": "contradiction_clarify",
+  "initial_checkpoint": null,
+  "inputs": [
+    "use docker",
+    "prohibit docker"
+  ]
+}

--- a/tests/fixtures/v3/structured/scenarios/pending_clarify_no.json
+++ b/tests/fixtures/v3/structured/scenarios/pending_clarify_no.json
@@ -1,0 +1,11 @@
+{
+  "description": "Pending replacement resolves negatively",
+  "id": "pending_clarify_no",
+  "initial_checkpoint": null,
+  "inputs": [
+    "use docker",
+    "prohibit kubectl",
+    "use kubectl instead of docker",
+    "no"
+  ]
+}

--- a/tests/fixtures/v3/structured/scenarios/pending_clarify_unmatched.json
+++ b/tests/fixtures/v3/structured/scenarios/pending_clarify_unmatched.json
@@ -1,0 +1,11 @@
+{
+  "description": "Pending replacement repeats clarify on unmatched input",
+  "id": "pending_clarify_unmatched",
+  "initial_checkpoint": null,
+  "inputs": [
+    "use docker",
+    "prohibit kubectl",
+    "use kubectl instead of docker",
+    "how about kubernetes?"
+  ]
+}

--- a/tests/fixtures/v3/structured/scenarios/pending_clarify_yes.json
+++ b/tests/fixtures/v3/structured/scenarios/pending_clarify_yes.json
@@ -1,0 +1,11 @@
+{
+  "description": "Pending replacement resolves affirmatively",
+  "id": "pending_clarify_yes",
+  "initial_checkpoint": null,
+  "inputs": [
+    "use docker",
+    "prohibit kubectl",
+    "use kubectl instead of docker",
+    "yes"
+  ]
+}

--- a/tests/fixtures/v3/structured/scenarios/premise_lifecycle.json
+++ b/tests/fixtures/v3/structured/scenarios/premise_lifecycle.json
@@ -1,0 +1,12 @@
+{
+  "description": "Premise lifecycle updates and clarify gates",
+  "id": "premise_lifecycle",
+  "initial_checkpoint": null,
+  "inputs": [
+    "set premise concise replies",
+    "set premise formal replies",
+    "change premise to concise bullet points",
+    "clear premise",
+    "change premise to formal tone"
+  ]
+}

--- a/tests/fixtures/v3/structured/scenarios/replacement_clarify.json
+++ b/tests/fixtures/v3/structured/scenarios/replacement_clarify.json
@@ -1,0 +1,8 @@
+{
+  "description": "Replacement from missing old item creates pending clarify",
+  "id": "replacement_clarify",
+  "initial_checkpoint": null,
+  "inputs": [
+    "use podman instead of docker"
+  ]
+}

--- a/tests/test_structured_regression.py
+++ b/tests/test_structured_regression.py
@@ -1,0 +1,76 @@
+import difflib
+import json
+from pathlib import Path
+
+import pytest
+
+from context_compiler import create_engine
+
+_STRUCTURED_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "v3" / "structured"
+_SCENARIOS_DIR = _STRUCTURED_FIXTURES_DIR / "scenarios"
+_EXPECTED_DIR = _STRUCTURED_FIXTURES_DIR / "expected"
+
+
+def _json_files(dir_path: Path) -> list[Path]:
+    return sorted(dir_path.glob("*.json"))
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _checkpoint_diff(expected: object, actual: object) -> str:
+    expected_lines = json.dumps(expected, indent=2, sort_keys=True).splitlines()
+    actual_lines = json.dumps(actual, indent=2, sort_keys=True).splitlines()
+    return "\n".join(
+        difflib.unified_diff(
+            expected_lines,
+            actual_lines,
+            fromfile="expected_checkpoint",
+            tofile="actual_checkpoint",
+            lineterm="",
+        )
+    )
+
+
+@pytest.mark.contract
+def test_structured_regression_scenarios() -> None:
+    for scenario_path in _json_files(_SCENARIOS_DIR):
+        scenario = _load_json(scenario_path)
+        scenario_id = scenario["id"]
+        expected_path = _EXPECTED_DIR / f"{scenario_id}.json"
+        expected = _load_json(expected_path)
+
+        assert expected["id"] == scenario_id, f"scenario_id_mismatch: {scenario_id}"
+
+        engine = create_engine()
+
+        initial_checkpoint = scenario.get("initial_checkpoint")
+        if initial_checkpoint is not None:
+            engine.import_checkpoint(initial_checkpoint)
+
+        inputs = scenario["inputs"]
+        expected_turns = expected["turns"]
+        assert len(inputs) == len(expected_turns), f"turn_count_mismatch: {scenario_id}"
+
+        for turn_index, user_input in enumerate(inputs):
+            decision = engine.step(user_input)
+            checkpoint = engine.export_checkpoint()
+            expected_turn = expected_turns[turn_index]
+
+            context = f"scenario={scenario_id} turn={turn_index} input={user_input!r}"
+
+            assert expected_turn["input"] == user_input, f"{context} input_mismatch"
+
+            expected_decision = expected_turn["decision"]
+            assert decision["kind"] == expected_decision["kind"], (
+                f"{context} decision_kind_mismatch"
+            )
+            assert decision["prompt_to_user"] == expected_decision["prompt_to_user"], (
+                f"{context} prompt_to_user_mismatch"
+            )
+
+            expected_checkpoint = expected_turn["checkpoint"]
+            if checkpoint != expected_checkpoint:
+                diff = _checkpoint_diff(expected_checkpoint, checkpoint)
+                pytest.fail(f"{context} checkpoint_mismatch\n{diff}")


### PR DESCRIPTION
## What changed
- Added a Fixture Policy section to tests/fixtures/v3/structured/README.md
- Added a Structured Regression Fixtures policy section to AGENTS.md
- Clarified that structured fixture updates are intentional contract changes and that normal test runs are read-only

## Why this was needed
- Treat v3 structured fixtures as a reviewed engine-conformance contract surface
- Prevent casual or side-effect fixture regeneration
- Require explicit PR rationale when structured fixture outputs change