### PR TITLE
chore: bump release version to 0.6.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.7"
+version = "0.6.8"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.7"
+version = "0.6.8"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed
- Bumped package version from `0.6.7` to `0.6.8`.
- Updated version in:
  - `pyproject.toml`
  - `uv.lock`

## Why this was needed
- Prepare the next patch release with synchronized project and lock metadata.
