### PR TITLE
feat: add minimal cli help and version flags

### DIFF
--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -1,12 +1,19 @@
 import sys
 from typing import TextIO
 
-from . import create_engine, get_policy_items, get_premise_value
+from . import __version__, create_engine, get_policy_items, get_premise_value
 from .engine import Decision, DecisionKind, State
 
 _EXIT_TOKENS = {"exit", "quit"}
 _HELP_TOKENS = {"help", "?"}
 _MULTI_COMMAND_PROMPT = "Multiple commands detected.\nEnter one command per line."
+_CLI_HELP_TEXT = """Usage:
+  context-compiler [--help] [--version]
+
+Options:
+  --help      Show this help message and exit.
+  --version   Show the installed context-compiler version and exit.
+"""
 
 
 def _is_interactive(in_stream: TextIO, out_stream: TextIO) -> bool:
@@ -127,8 +134,23 @@ def run_repl(in_stream: TextIO, out_stream: TextIO) -> None:
 
 
 def main() -> int:  # pragma: no cover
-    run_repl(sys.stdin, sys.stdout)
-    return 0
+    args = sys.argv[1:]
+    if not args:
+        run_repl(sys.stdin, sys.stdout)
+        return 0
+
+    if args == ["--help"]:
+        print(_CLI_HELP_TEXT, file=sys.stdout, end="")
+        return 0
+
+    if args == ["--version"]:
+        print(__version__, file=sys.stdout)
+        return 0
+
+    bad_arg = args[0]
+    print(f"error: unknown option '{bad_arg}'", file=sys.stderr)
+    print("Try 'context-compiler --help' for usage.", file=sys.stderr)
+    return 1
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,9 +1,11 @@
+import sys
 from io import StringIO
+from typing import TextIO
 
 import pytest
 
 import context_compiler.repl as repl_module
-from context_compiler import create_engine
+from context_compiler import __version__, create_engine
 from context_compiler.repl import run_repl
 
 pytestmark = pytest.mark.contract
@@ -60,6 +62,71 @@ def _contains_subsequence(lines: list[str], expected: list[str]) -> bool:
     if window == 0 or window > len(lines):
         return False
     return any(lines[i : i + window] == expected for i in range(len(lines) - window + 1))
+
+
+def test_main_help_flag_prints_usage_and_exits_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["context-compiler", "--help"])
+
+    result = repl_module.main()
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.out == (
+        "Usage:\n"
+        "  context-compiler [--help] [--version]\n"
+        "\n"
+        "Options:\n"
+        "  --help      Show this help message and exit.\n"
+        "  --version   Show the installed context-compiler version and exit.\n"
+    )
+    assert captured.err == ""
+
+
+def test_main_version_flag_prints_installed_version_and_exits_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["context-compiler", "--version"])
+
+    result = repl_module.main()
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.out == f"{__version__}\n"
+    assert captured.err == ""
+
+
+def test_main_without_args_runs_repl_as_before(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, object] = {}
+
+    def _fake_run_repl(in_stream: TextIO, out_stream: TextIO) -> None:
+        called["in_stream"] = in_stream
+        called["out_stream"] = out_stream
+
+    monkeypatch.setattr(repl_module, "run_repl", _fake_run_repl)
+    monkeypatch.setattr(sys, "argv", ["context-compiler"])
+
+    result = repl_module.main()
+
+    assert result == 0
+    assert called["in_stream"] is sys.stdin
+    assert called["out_stream"] is sys.stdout
+
+
+def test_main_unknown_flag_prints_error_hint_and_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["context-compiler", "--bogus"])
+
+    result = repl_module.main()
+    captured = capsys.readouterr()
+
+    assert result != 0
+    assert captured.out == ""
+    assert captured.err == (
+        "error: unknown option '--bogus'\nTry 'context-compiler --help' for usage.\n"
+    )
 
 
 def test_repl_update_flow() -> None:


### PR DESCRIPTION
What changed:
- Added explicit CLI handling for --help and --version in the existing context-compiler entry point.
- Preserved default no-argument behavior so context-compiler still launches the REPL.
- Added focused tests for help, version, no-args REPL path, and unknown-flag error behavior.

Why this was needed:
- This provides minimal CLI polish for 0.6.9 while keeping behavior explicit and scoped.
- Users can now discover usage and installed version directly from the CLI without introducing a CLI framework or changing engine/directive behavior.