### PR TITLE
fix: harden precompiler classification and conformance

### DIFF
--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -25,7 +25,6 @@ from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
     PRECOMPILE_OUTCOME_DIRECTIVE,
-    is_safe_fallback_directive_rewrite,
     parse_precompiler_output,
     precompile_heuristic,
     render_prompt,
@@ -178,10 +177,8 @@ def _llm_fallback_precompile(message: str, state: State) -> str | None:
     except Exception:
         return None
 
-    parsed = parse_precompiler_output(raw_output)
+    parsed = parse_precompiler_output(raw_output, source_input=message)
     if parsed is None:
-        return None
-    if not is_safe_fallback_directive_rewrite(message, parsed):
         return None
     return parsed
 

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -25,7 +25,6 @@ from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
     PRECOMPILE_OUTCOME_DIRECTIVE,
-    PRECOMPILER_NO_DIRECTIVE_SENTINEL,
     parse_precompiler_output,
     precompile_heuristic,
     render_prompt,
@@ -179,7 +178,7 @@ def _llm_fallback_precompile(message: str, state: State) -> str | None:
         return None
 
     parsed = parse_precompiler_output(raw_output)
-    if parsed is None or parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+    if parsed is None:
         return None
     return parsed
 
@@ -195,7 +194,7 @@ def _precompile_user_input(message: str, state: State) -> str | None:
         ):
             parsed = parse_precompiler_output(heuristic_result["directive"])
             logger.debug("preprocessor: heuristic_directive=%r", heuristic_result["directive"])
-            if parsed is not None and parsed != PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+            if parsed is not None:
                 return parsed
     except Exception:
         logger.debug("preprocessor: heuristic_exception", exc_info=True)

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -25,6 +25,7 @@ from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
     PRECOMPILE_OUTCOME_DIRECTIVE,
+    is_safe_fallback_directive_rewrite,
     parse_precompiler_output,
     precompile_heuristic,
     render_prompt,
@@ -179,6 +180,8 @@ def _llm_fallback_precompile(message: str, state: State) -> str | None:
 
     parsed = parse_precompiler_output(raw_output)
     if parsed is None:
+        return None
+    if not is_safe_fallback_directive_rewrite(message, parsed):
         return None
     return parsed
 

--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
@@ -34,7 +34,6 @@ from context_compiler import (
 )
 from experimental.preprocessor import (
     PRECOMPILE_OUTCOME_DIRECTIVE,
-    is_safe_fallback_directive_rewrite,
     parse_precompiler_output,
     precompile_heuristic,
     render_prompt,
@@ -181,10 +180,8 @@ def _llm_fallback_precompile(message: str, state: State) -> str | None:
     except Exception:
         return None
 
-    parsed = parse_precompiler_output(raw_output)
+    parsed = parse_precompiler_output(raw_output, source_input=message)
     if parsed is None:
-        return None
-    if not is_safe_fallback_directive_rewrite(message, parsed):
         return None
     return parsed
 

--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
@@ -34,6 +34,7 @@ from context_compiler import (
 )
 from experimental.preprocessor import (
     PRECOMPILE_OUTCOME_DIRECTIVE,
+    is_safe_fallback_directive_rewrite,
     parse_precompiler_output,
     precompile_heuristic,
     render_prompt,
@@ -182,6 +183,8 @@ def _llm_fallback_precompile(message: str, state: State) -> str | None:
 
     parsed = parse_precompiler_output(raw_output)
     if parsed is None:
+        return None
+    if not is_safe_fallback_directive_rewrite(message, parsed):
         return None
     return parsed
 

--- a/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
+++ b/examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py
@@ -34,7 +34,6 @@ from context_compiler import (
 )
 from experimental.preprocessor import (
     PRECOMPILE_OUTCOME_DIRECTIVE,
-    PRECOMPILER_NO_DIRECTIVE_SENTINEL,
     parse_precompiler_output,
     precompile_heuristic,
     render_prompt,
@@ -182,7 +181,7 @@ def _llm_fallback_precompile(message: str, state: State) -> str | None:
         return None
 
     parsed = parse_precompiler_output(raw_output)
-    if parsed is None or parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+    if parsed is None:
         return None
     return parsed
 
@@ -205,7 +204,7 @@ def _precompile_last_user_message(message: str, state: State | None) -> str | No
             and heuristic_result["directive"]
         ):
             parsed = parse_precompiler_output(heuristic_result["directive"])
-            if parsed is not None and parsed != PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+            if parsed is not None:
                 return parsed
     except Exception:
         logger.debug("litellm_proxy: heuristic_exception", exc_info=True)

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -47,7 +47,6 @@ from context_compiler import State, create_engine, get_policy_items, get_premise
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
     PRECOMPILE_OUTCOME_DIRECTIVE,
-    PRECOMPILER_NO_DIRECTIVE_SENTINEL,
     parse_precompiler_output,
     precompile_heuristic,
     render_prompt,
@@ -331,7 +330,7 @@ class Pipe:
 
         raw_output = _extract_completion_content(response)
         parsed = parse_precompiler_output(raw_output)
-        if parsed is None or parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+        if parsed is None:
             return None, None
         return parsed, None
 
@@ -354,7 +353,7 @@ class Pipe:
             and heuristic_result["directive"]
         ):
             parsed = parse_precompiler_output(heuristic_result["directive"])
-            if parsed is not None and parsed != PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+            if parsed is not None:
                 return parsed, None
 
         return await self._llm_fallback_precompile(

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -47,6 +47,7 @@ from context_compiler import State, create_engine, get_policy_items, get_premise
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
     PRECOMPILE_OUTCOME_DIRECTIVE,
+    is_safe_fallback_directive_rewrite,
     parse_precompiler_output,
     precompile_heuristic,
     render_prompt,
@@ -331,6 +332,8 @@ class Pipe:
         raw_output = _extract_completion_content(response)
         parsed = parse_precompiler_output(raw_output)
         if parsed is None:
+            return None, None
+        if not is_safe_fallback_directive_rewrite(message, parsed):
             return None, None
         return parsed, None
 

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -47,7 +47,6 @@ from context_compiler import State, create_engine, get_policy_items, get_premise
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
     PRECOMPILE_OUTCOME_DIRECTIVE,
-    is_safe_fallback_directive_rewrite,
     parse_precompiler_output,
     precompile_heuristic,
     render_prompt,
@@ -330,10 +329,8 @@ class Pipe:
             return None, normalized_error
 
         raw_output = _extract_completion_content(response)
-        parsed = parse_precompiler_output(raw_output)
+        parsed = parse_precompiler_output(raw_output, source_input=message)
         if parsed is None:
-            return None, None
-        if not is_safe_fallback_directive_rewrite(message, parsed):
             return None, None
         return parsed, None
 

--- a/experimental/preprocessor/README.md
+++ b/experimental/preprocessor/README.md
@@ -24,10 +24,17 @@ than using repo-relative preprocessor paths.
 
 Public validator entry point:
 
-- `parse_precompiler_output(raw_output: object) -> str | None`
+- `parse_precompiler_output(raw_output: object, *, source_input: str | None = None) -> str | None`
+- `validate_precompiler_output(raw_output: object, *, source_input: str | None = None) -> dict`
 
 All preprocessor outputs (heuristic or LLM) must be validated with
 `parse_precompiler_output(...)` before being applied.
+
+`source_input` is optional at the API level for backward compatibility.
+For integration behavior, it is required for LLM fallback validation calls:
+pass `source_input=<original user text>` so source-aware reject rules can
+block unsafe rewrites (for example, engine-owned premise near-miss
+canonicalization).
 
 Raw preprocessor/LLM outputs must not be passed directly to the compiler.
 
@@ -37,7 +44,8 @@ Raw preprocessor/LLM outputs must not be passed directly to the compiler.
 2. If a heuristic candidate directive exists, validate it with
    `parse_precompiler_output(...)`.
 3. If no valid directive was produced, run LLM fallback precompile.
-4. Validate fallback output with `parse_precompiler_output(...)`.
+4. Validate fallback output with
+   `parse_precompiler_output(..., source_input=message)`.
 5. If a valid directive is produced, pass it through a normal compiler input path.
    For session-owned integrations, use `engine.step(...)`.
    For transcript-based integrations that receive full chat history each turn:

--- a/experimental/preprocessor/__init__.py
+++ b/experimental/preprocessor/__init__.py
@@ -8,7 +8,11 @@ from .constants import (
     PrecompileOutcome,
 )
 from .heuristic_precompiler import PrecompileResult, precompile_heuristic
-from .output_validation import parse_precompiler_output, validate_precompiler_output
+from .output_validation import (
+    is_safe_fallback_directive_rewrite,
+    parse_precompiler_output,
+    validate_precompiler_output,
+)
 from .prompt_utils import render_prompt
 
 __all__ = [
@@ -19,6 +23,7 @@ __all__ = [
     "PrecompileResult",
     "PrecompileOutcome",
     "parse_precompiler_output",
+    "is_safe_fallback_directive_rewrite",
     "precompile_heuristic",
     "render_prompt",
     "validate_precompiler_output",

--- a/experimental/preprocessor/__init__.py
+++ b/experimental/preprocessor/__init__.py
@@ -8,7 +8,7 @@ from .constants import (
     PrecompileOutcome,
 )
 from .heuristic_precompiler import PrecompileResult, precompile_heuristic
-from .output_validation import parse_precompiler_output
+from .output_validation import parse_precompiler_output, validate_precompiler_output
 from .prompt_utils import render_prompt
 
 __all__ = [
@@ -21,4 +21,5 @@ __all__ = [
     "parse_precompiler_output",
     "precompile_heuristic",
     "render_prompt",
+    "validate_precompiler_output",
 ]

--- a/experimental/preprocessor/__init__.py
+++ b/experimental/preprocessor/__init__.py
@@ -9,7 +9,6 @@ from .constants import (
 )
 from .heuristic_precompiler import PrecompileResult, precompile_heuristic
 from .output_validation import (
-    is_safe_fallback_directive_rewrite,
     parse_precompiler_output,
     validate_precompiler_output,
 )
@@ -23,7 +22,6 @@ __all__ = [
     "PrecompileResult",
     "PrecompileOutcome",
     "parse_precompiler_output",
-    "is_safe_fallback_directive_rewrite",
     "precompile_heuristic",
     "render_prompt",
     "validate_precompiler_output",

--- a/experimental/preprocessor/heuristic_precompiler.py
+++ b/experimental/preprocessor/heuristic_precompiler.py
@@ -58,6 +58,10 @@ _NEAR_MISS_ALIAS_CASES = {
     "use podman not docker",
     "wipe policies",
 }
+_ADMIN_NEAR_MISS_CASES = {
+    "reset policy",
+    "remove policies docker",
+}
 
 _REPORTING_BRACKET_MARKERS = (
     "in my notes",
@@ -79,6 +83,7 @@ _DIRECTIVE_CUE_PATTERN = re.compile(
     r"\b(set premise|change premise|use|prohibit|remove policy|clear premise|"
     r"reset policies|clear state)\b"
 )
+_MALFORMED_REPLACEMENT_PATTERN = re.compile(r"\buse\b.*\binstead\b")
 _MULTI_CANDIDATE_DIRECTIVE_PATTERN = re.compile(
     r"(?:\band\b|\bthen\b|;|,)\s*(?:set premise\b|change premise\b|use\b|"
     r"prohibit\b|remove policy\b|clear premise\b|reset policies\b|clear state\b)"
@@ -126,6 +131,13 @@ def _normalize_candidate(message: str) -> str:
     no_punct = _strip_terminal_punctuation(stripped)
     unwrapped = _strip_exact_wrapper(no_punct)
     return re.sub(r"\s+", " ", unwrapped).strip().lower()
+
+
+def _is_quoted_or_backtick_wrapped(message: str) -> bool:
+    stripped = message.strip()
+    if len(stripped) < 2:
+        return False
+    return (stripped[0], stripped[-1]) in {('"', '"'), ("'", "'"), ("`", "`")}
 
 
 def precompile_heuristic(message: str) -> PrecompileResult:
@@ -188,6 +200,13 @@ def precompile_heuristic(message: str) -> PrecompileResult:
             "rule_id": "reject.quoted_reported_bracket",
         }
 
+    if _is_quoted_or_backtick_wrapped(message):
+        return {
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
+            "directive": None,
+            "rule_id": "reject.quoted_exact",
+        }
+
     if normalized in _QUOTED_OR_REPORTED_CASES:
         return {
             "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
@@ -202,6 +221,23 @@ def precompile_heuristic(message: str) -> PrecompileResult:
             "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
             "directive": None,
             "rule_id": "reject.near_miss_alias",
+        }
+
+    if normalized in _ADMIN_NEAR_MISS_CASES:
+        return {
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
+            "directive": None,
+            "rule_id": "reject.admin_near_miss_alias",
+        }
+
+    if (
+        _MALFORMED_REPLACEMENT_PATTERN.search(normalized_candidate)
+        and " instead of " not in normalized_candidate
+    ) or (" in stead of " in normalized_candidate):
+        return {
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
+            "directive": None,
+            "rule_id": "reject.malformed_replacement_syntax",
         }
 
     if _MULTI_CANDIDATE_DIRECTIVE_PATTERN.search(normalized_candidate):

--- a/experimental/preprocessor/heuristic_precompiler.py
+++ b/experimental/preprocessor/heuristic_precompiler.py
@@ -77,6 +77,14 @@ _MULTI_SEGMENT_PATTERN = re.compile(
     r".*\b(?:because|then continue|and)\b"
 )
 _PUNCTUATION_TRIM_PATTERN = re.compile(r"[.!]+\s*$")
+_DIRECTIVE_CUE_PATTERN = re.compile(
+    r"\b(set premise|change premise|use|prohibit|remove policy|clear premise|"
+    r"reset policies|clear state)\b"
+)
+_MULTI_CANDIDATE_DIRECTIVE_PATTERN = re.compile(
+    r"(?:\band\b|\bthen\b|;|,)\s*(?:set premise\b|change premise\b|use\b|"
+    r"prohibit\b|remove policy\b|clear premise\b|reset policies\b|clear state\b)"
+)
 _WRAPPER_PAIRS = {
     ('"', '"'),
     ("'", "'"),
@@ -138,54 +146,53 @@ def precompile_heuristic(message: str) -> PrecompileResult:
         This pass is precision-first and intentionally narrow. It may abstain
         on ambiguous or mixed-intent inputs.
     """
-    # Precision-first hard rejection for question-like inputs.
-    if "?" in message:
-        return {
-            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
-            "directive": None,
-            "rule_id": "reject.question_mark",
-        }
-
     if _LIST_MARKER_PATTERN.match(message):
         return {
-            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
             "directive": None,
             "rule_id": "reject.list_or_enumeration",
         }
 
     normalized = _normalized_for_match(message)
 
+    if "?" in message and _DIRECTIVE_CUE_PATTERN.search(normalized):
+        return {
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
+            "directive": None,
+            "rule_id": "reject.question_form",
+        }
+
     if _META_PREFIX_PATTERN.match(normalized):
         return {
-            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
             "directive": None,
             "rule_id": "reject.meta_or_reporting",
         }
 
     if _MULTI_SEGMENT_PATTERN.match(normalized):
         return {
-            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
             "directive": None,
             "rule_id": "reject.multi_segment_or_mixed_prose",
         }
 
     if normalized in _MULTI_INSTRUCTION_CASES:
         return {
-            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
             "directive": None,
             "rule_id": "reject.multi_instruction",
         }
 
     if _contains_reporting_bracket_mention(message):
         return {
-            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
             "directive": None,
             "rule_id": "reject.quoted_reported_bracket",
         }
 
     if normalized in _QUOTED_OR_REPORTED_CASES:
         return {
-            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
             "directive": None,
             "rule_id": "reject.quoted_reported",
         }
@@ -216,9 +223,16 @@ def precompile_heuristic(message: str) -> PrecompileResult:
 
     if normalized in _NEAR_MISS_ALIAS_CASES:
         return {
-            "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
             "directive": None,
             "rule_id": "reject.near_miss_alias",
+        }
+
+    if _MULTI_CANDIDATE_DIRECTIVE_PATTERN.search(normalized_candidate):
+        return {
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
+            "directive": None,
+            "rule_id": "reject.multi_candidate_directive",
         }
 
     if normalized_candidate in CANONICAL_DIRECTIVE_EXACT:
@@ -236,4 +250,15 @@ def precompile_heuristic(message: str) -> PrecompileResult:
                 "rule_id": "canonical.full_match",
             }
 
-    return {"outcome": PRECOMPILE_OUTCOME_UNKNOWN, "directive": None, "rule_id": None}
+    if _DIRECTIVE_CUE_PATTERN.search(normalized_candidate):
+        return {
+            "outcome": PRECOMPILE_OUTCOME_UNKNOWN,
+            "directive": None,
+            "rule_id": "reject.directive_adjacent_unsafe",
+        }
+
+    return {
+        "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+        "directive": None,
+        "rule_id": "reject.confident_non_directive",
+    }

--- a/experimental/preprocessor/heuristic_precompiler.py
+++ b/experimental/preprocessor/heuristic_precompiler.py
@@ -65,8 +65,6 @@ _REPORTING_BRACKET_MARKERS = (
     "i wrote down",
 )
 
-_SET_PREMISE_TO_PATTERN = re.compile(r"^set premise to\s+(.+\S)\s*$")
-_CHANGE_PREMISE_MISSING_TO_PATTERN = re.compile(r"^change premise\s+(?!to\b)(.+\S)\s*$")
 _LIST_MARKER_PATTERN = re.compile(r"^\s*(?:\d+[.)]|[-*])\s+\S")
 _META_PREFIX_PATTERN = re.compile(
     r"^\s*(?:example:|for example\b|the command is\b|(?:i|he|she|they) said\b)"
@@ -198,28 +196,6 @@ def precompile_heuristic(message: str) -> PrecompileResult:
         }
 
     normalized_candidate = _normalize_candidate(message)
-
-    set_premise_to_match = _SET_PREMISE_TO_PATTERN.fullmatch(normalized_candidate)
-    if set_premise_to_match is not None:
-        payload = set_premise_to_match.group(1).strip()
-        if payload:
-            return {
-                "outcome": PRECOMPILE_OUTCOME_DIRECTIVE,
-                "directive": f"set premise {payload}",
-                "rule_id": "canonical.structural_set_premise_to",
-            }
-
-    change_premise_missing_to_match = _CHANGE_PREMISE_MISSING_TO_PATTERN.fullmatch(
-        normalized_candidate
-    )
-    if change_premise_missing_to_match is not None:
-        payload = change_premise_missing_to_match.group(1).strip()
-        if payload:
-            return {
-                "outcome": PRECOMPILE_OUTCOME_DIRECTIVE,
-                "directive": f"change premise to {payload}",
-                "rule_id": "canonical.structural_change_premise_missing_to",
-            }
 
     if normalized in _NEAR_MISS_ALIAS_CASES:
         return {

--- a/experimental/preprocessor/output_validation.py
+++ b/experimental/preprocessor/output_validation.py
@@ -1,75 +1,47 @@
 """Shared precompiler output normalization and validation helpers.
 
 Public API:
+- validate_precompiler_output
 - parse_precompiler_output
 
 Internal helpers are implementation details and may change.
 """
 
+import json
 import re
+from typing import TypedDict
 
 from .constants import (
     CANONICAL_DIRECTIVE_EXACT,
     CANONICAL_DIRECTIVE_PATTERNS,
     PRECOMPILER_NO_DIRECTIVE_SENTINEL,
+    PrecompileOutcome,
 )
 
-__all__ = ["parse_precompiler_output"]
-
-_MALFORMED_SENTINEL_TAGS = {
-    "<NO_DIRECTIPLE>",
-    "<NO_DIRECTITIVE>",
-    "<NO_DIRECT_DIRECTIVE>",
-}
-_MALFORMED_SENTINEL_TAG_PATTERN = re.compile(r"^<NO_DIRECTDIRECTIVE[A-Z_]*>$", re.IGNORECASE)
+__all__ = ["parse_precompiler_output", "validate_precompiler_output"]
 
 
-def _normalize_abstain_tag(tag: str) -> str | None:
-    upper_tag = tag.strip().upper()
-    if upper_tag == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
-        return PRECOMPILER_NO_DIRECTIVE_SENTINEL
-    if upper_tag in _MALFORMED_SENTINEL_TAGS:
-        return PRECOMPILER_NO_DIRECTIVE_SENTINEL
-    if _MALFORMED_SENTINEL_TAG_PATTERN.fullmatch(upper_tag):
-        return PRECOMPILER_NO_DIRECTIVE_SENTINEL
-    return None
+class PrecompilerValidationResult(TypedDict):
+    classification: PrecompileOutcome
+    output: str | None
 
 
-def _extract_leading_tag(text: str) -> str | None:
-    if not text.startswith("<"):
-        return None
-    close = text.find(">")
-    if close <= 0:
-        return None
-    return text[: close + 1]
+_MULTI_CANDIDATE_DIRECTIVE_PATTERN = re.compile(
+    r"(?:\band\b|\bthen\b|;|,)\s*(?:set premise\b|change premise\b|use\b|"
+    r"prohibit\b|remove policy\b|clear premise\b|reset policies\b|clear state\b)"
+)
 
 
-def _normalize_precompiler_output(raw_output: object) -> str | None:
-    if not isinstance(raw_output, str):
-        return None
+def _unknown() -> PrecompilerValidationResult:
+    return {"classification": "unknown", "output": None}
 
-    stripped = raw_output.strip()
-    if not stripped:
-        return stripped
 
-    normalized = _normalize_abstain_tag(stripped)
-    if normalized is not None:
-        return normalized
+def _directive(output: str) -> PrecompilerValidationResult:
+    return {"classification": "directive", "output": output}
 
-    leading_tag = _extract_leading_tag(stripped)
-    if leading_tag is not None:
-        normalized = _normalize_abstain_tag(leading_tag)
-        if normalized is not None:
-            return normalized
 
-    non_empty_lines = [line.strip() for line in raw_output.splitlines() if line.strip()]
-    if non_empty_lines:
-        last_line = non_empty_lines[-1]
-        normalized = _normalize_abstain_tag(last_line)
-        if normalized is not None:
-            return normalized
-
-    return stripped
+def _no_directive() -> PrecompilerValidationResult:
+    return {"classification": "no_directive", "output": None}
 
 
 def _is_allowed_directive(text: str) -> bool:
@@ -78,25 +50,99 @@ def _is_allowed_directive(text: str) -> bool:
     return any(pattern.fullmatch(text) for pattern in CANONICAL_DIRECTIVE_PATTERNS)
 
 
+def _contains_multiple_candidate_directives(text: str) -> bool:
+    normalized = re.sub(r"\s+", " ", text.strip().lower())
+    return bool(_MULTI_CANDIDATE_DIRECTIVE_PATTERN.search(normalized))
+
+
+def _validate_structured_output(raw_output: object) -> PrecompilerValidationResult:
+    if not isinstance(raw_output, dict):
+        return _unknown()
+
+    if set(raw_output.keys()) != {"classification", "output"}:
+        return _unknown()
+
+    classification = raw_output.get("classification")
+    output = raw_output.get("output")
+    if not isinstance(classification, str):
+        return _unknown()
+
+    if classification == "directive":
+        if not isinstance(output, str):
+            return _unknown()
+        normalized_output = output.strip()
+        if not normalized_output:
+            return _unknown()
+        if _contains_multiple_candidate_directives(normalized_output):
+            return _unknown()
+        if not _is_allowed_directive(normalized_output):
+            return _unknown()
+        return _directive(normalized_output)
+
+    if classification == "no_directive":
+        if output is not None:
+            return _unknown()
+        return _no_directive()
+
+    if classification == "unknown":
+        if output is not None:
+            return _unknown()
+        return _unknown()
+
+    return _unknown()
+
+
+def _validate_text_output(raw_output: str) -> PrecompilerValidationResult:
+    stripped = raw_output.strip()
+    if not stripped:
+        return _unknown()
+
+    if stripped.upper() == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
+        return _no_directive()
+
+    if _contains_multiple_candidate_directives(stripped):
+        return _unknown()
+
+    if _is_allowed_directive(stripped):
+        return _directive(stripped)
+
+    if stripped[0] in {"{", "["}:
+        try:
+            parsed_json = json.loads(stripped)
+        except json.JSONDecodeError:
+            return _unknown()
+        return _validate_structured_output(parsed_json)
+
+    return _unknown()
+
+
+def validate_precompiler_output(raw_output: object) -> PrecompilerValidationResult:
+    """Validate raw precompiler output into a strict classification/output result.
+
+    Contract:
+        - directive: output is a canonical directive string
+        - no_directive: output is None
+        - unknown: output is None
+    """
+    if isinstance(raw_output, str):
+        return _validate_text_output(raw_output)
+    return _validate_structured_output(raw_output)
+
+
 def parse_precompiler_output(raw_output: object) -> str | None:
-    """Validate and normalize precompiler output.
+    """Compatibility wrapper returning only validated directive output.
 
     Args:
         raw_output: Raw value produced by heuristic or LLM preprocessing.
 
     Returns:
-        PRECOMPILER_NO_DIRECTIVE_SENTINEL for abstain output, a canonical
-        directive string when valid, or None when output is invalid/rejected.
+        Canonical directive string when valid, else None.
 
     Notes:
         This is the public validation boundary. Preprocessor outputs must be
         passed through this function before being applied to compiler paths.
     """
-    normalized = _normalize_precompiler_output(raw_output)
-    if normalized is None:
-        return None
-    if normalized == PRECOMPILER_NO_DIRECTIVE_SENTINEL:
-        return normalized
-    if _is_allowed_directive(normalized):
-        return normalized
+    validated = validate_precompiler_output(raw_output)
+    if validated["classification"] == "directive":
+        return validated["output"]
     return None

--- a/experimental/preprocessor/output_validation.py
+++ b/experimental/preprocessor/output_validation.py
@@ -142,7 +142,9 @@ def _validate_text_output(raw_output: str) -> PrecompilerValidationResult:
     return _unknown()
 
 
-def validate_precompiler_output(raw_output: object) -> PrecompilerValidationResult:
+def validate_precompiler_output(
+    raw_output: object, *, source_input: str | None = None
+) -> PrecompilerValidationResult:
     """Validate raw precompiler output into a strict classification/output result.
 
     Contract:
@@ -151,11 +153,22 @@ def validate_precompiler_output(raw_output: object) -> PrecompilerValidationResu
         - unknown: output is None
     """
     if isinstance(raw_output, str):
-        return _validate_text_output(raw_output)
-    return _validate_structured_output(raw_output)
+        validated = _validate_text_output(raw_output)
+    else:
+        validated = _validate_structured_output(raw_output)
+
+    if (
+        source_input is not None
+        and validated["classification"] == "directive"
+        and isinstance(validated["output"], str)
+        and not is_safe_fallback_directive_rewrite(source_input, validated["output"])
+    ):
+        return _unknown()
+
+    return validated
 
 
-def parse_precompiler_output(raw_output: object) -> str | None:
+def parse_precompiler_output(raw_output: object, *, source_input: str | None = None) -> str | None:
     """Compatibility wrapper returning only validated directive output.
 
     Args:
@@ -168,7 +181,7 @@ def parse_precompiler_output(raw_output: object) -> str | None:
         This is the public validation boundary. Preprocessor outputs must be
         passed through this function before being applied to compiler paths.
     """
-    validated = validate_precompiler_output(raw_output)
+    validated = validate_precompiler_output(raw_output, source_input=source_input)
     if validated["classification"] == "directive":
         return validated["output"]
     return None

--- a/experimental/preprocessor/output_validation.py
+++ b/experimental/preprocessor/output_validation.py
@@ -18,7 +18,11 @@ from .constants import (
     PrecompileOutcome,
 )
 
-__all__ = ["parse_precompiler_output", "validate_precompiler_output"]
+__all__ = [
+    "is_safe_fallback_directive_rewrite",
+    "parse_precompiler_output",
+    "validate_precompiler_output",
+]
 
 
 class PrecompilerValidationResult(TypedDict):
@@ -30,6 +34,8 @@ _MULTI_CANDIDATE_DIRECTIVE_PATTERN = re.compile(
     r"(?:\band\b|\bthen\b|;|,)\s*(?:set premise\b|change premise\b|use\b|"
     r"prohibit\b|remove policy\b|clear premise\b|reset policies\b|clear state\b)"
 )
+_SET_PREMISE_TO_NEAR_MISS_PATTERN = re.compile(r"^set premise to\s+(.+\S)\s*$")
+_CHANGE_PREMISE_MISSING_TO_NEAR_MISS_PATTERN = re.compile(r"^change premise\s+(?!to\b)(.+\S)\s*$")
 
 
 def _unknown() -> PrecompilerValidationResult:
@@ -53,6 +59,26 @@ def _is_allowed_directive(text: str) -> bool:
 def _contains_multiple_candidate_directives(text: str) -> bool:
     normalized = re.sub(r"\s+", " ", text.strip().lower())
     return bool(_MULTI_CANDIDATE_DIRECTIVE_PATTERN.search(normalized))
+
+
+def is_safe_fallback_directive_rewrite(source_input: str, directive_output: str) -> bool:
+    """Reject fallback rewrites that bypass engine-owned premise clarify behavior."""
+    source = re.sub(r"\s+", " ", source_input.strip().lower())
+    directive = re.sub(r"\s+", " ", directive_output.strip().lower())
+
+    set_premise_to_match = _SET_PREMISE_TO_NEAR_MISS_PATTERN.fullmatch(source)
+    if set_premise_to_match is not None:
+        payload = set_premise_to_match.group(1).strip()
+        if directive == f"set premise {payload}":
+            return False
+
+    change_premise_missing_to_match = _CHANGE_PREMISE_MISSING_TO_NEAR_MISS_PATTERN.fullmatch(source)
+    if change_premise_missing_to_match is not None:
+        payload = change_premise_missing_to_match.group(1).strip()
+        if directive == f"change premise to {payload}":
+            return False
+
+    return True
 
 
 def _validate_structured_output(raw_output: object) -> PrecompilerValidationResult:

--- a/experimental/preprocessor/output_validation.py
+++ b/experimental/preprocessor/output_validation.py
@@ -19,7 +19,6 @@ from .constants import (
 )
 
 __all__ = [
-    "is_safe_fallback_directive_rewrite",
     "parse_precompiler_output",
     "validate_precompiler_output",
 ]
@@ -61,7 +60,7 @@ def _contains_multiple_candidate_directives(text: str) -> bool:
     return bool(_MULTI_CANDIDATE_DIRECTIVE_PATTERN.search(normalized))
 
 
-def is_safe_fallback_directive_rewrite(source_input: str, directive_output: str) -> bool:
+def _is_safe_fallback_directive_rewrite(source_input: str, directive_output: str) -> bool:
     """Reject fallback rewrites that bypass engine-owned premise clarify behavior."""
     source = re.sub(r"\s+", " ", source_input.strip().lower())
     directive = re.sub(r"\s+", " ", directive_output.strip().lower())
@@ -161,7 +160,7 @@ def validate_precompiler_output(
         source_input is not None
         and validated["classification"] == "directive"
         and isinstance(validated["output"], str)
-        and not is_safe_fallback_directive_rewrite(source_input, validated["output"])
+        and not _is_safe_fallback_directive_rewrite(source_input, validated["output"])
     ):
         return _unknown()
 

--- a/tests/fixtures/precompiler/admin-alias-remove-policies-unknown.json
+++ b/tests/fixtures/precompiler/admin-alias-remove-policies-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "admin-alias-remove-policies-unknown",
+  "input": "remove policies docker",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/admin-alias-reset-policy-unknown.json
+++ b/tests/fixtures/precompiler/admin-alias-reset-policy-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "admin-alias-reset-policy-unknown",
+  "input": "reset policy",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/ambiguous-directive-adjacent.json
+++ b/tests/fixtures/precompiler/ambiguous-directive-adjacent.json
@@ -1,0 +1,8 @@
+{
+  "name": "ambiguous-directive-adjacent",
+  "input": "could we maybe use uv later",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/canonical-directive-clear-state.json
+++ b/tests/fixtures/precompiler/canonical-directive-clear-state.json
@@ -1,0 +1,8 @@
+{
+  "name": "canonical-directive-clear-state",
+  "input": "clear state",
+  "expected": {
+    "classification": "directive",
+    "output": "clear state"
+  }
+}

--- a/tests/fixtures/precompiler/canonical-directive-prohibit-peanuts.json
+++ b/tests/fixtures/precompiler/canonical-directive-prohibit-peanuts.json
@@ -1,0 +1,8 @@
+{
+  "name": "canonical-directive-prohibit-peanuts",
+  "input": "prohibit peanuts",
+  "expected": {
+    "classification": "directive",
+    "output": "prohibit peanuts"
+  }
+}

--- a/tests/fixtures/precompiler/canonicalize-set-premise-to.json
+++ b/tests/fixtures/precompiler/canonicalize-set-premise-to.json
@@ -1,0 +1,8 @@
+{
+  "name": "canonicalize-set-premise-to",
+  "input": "set premise to concise replies",
+  "expected": {
+    "classification": "directive",
+    "output": "set premise concise replies"
+  }
+}

--- a/tests/fixtures/precompiler/canonicalize-set-premise-to.json
+++ b/tests/fixtures/precompiler/canonicalize-set-premise-to.json
@@ -1,8 +1,0 @@
-{
-  "name": "canonicalize-set-premise-to",
-  "input": "set premise to concise replies",
-  "expected": {
-    "classification": "directive",
-    "output": "set premise concise replies"
-  }
-}

--- a/tests/fixtures/precompiler/malformed-replacement-instead-docker-unknown.json
+++ b/tests/fixtures/precompiler/malformed-replacement-instead-docker-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "malformed-replacement-instead-docker-unknown",
+  "input": "use podman instead docker",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/mixed-intent-unknown.json
+++ b/tests/fixtures/precompiler/mixed-intent-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "mixed-intent-unknown",
+  "input": "use docker and then continue with the answer",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/modal-please-clear-state-unknown.json
+++ b/tests/fixtures/precompiler/modal-please-clear-state-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "modal-please-clear-state-unknown",
+  "input": "please clear state",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/natural-language-dont-use-unknown.json
+++ b/tests/fixtures/precompiler/natural-language-dont-use-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "natural-language-dont-use-unknown",
+  "input": "don't use peanuts",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/near-miss-change-premise-missing-to-unknown.json
+++ b/tests/fixtures/precompiler/near-miss-change-premise-missing-to-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-change-premise-missing-to-unknown",
+  "input": "change premise concise replies",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/near-miss-change-premise-to-empty-unknown.json
+++ b/tests/fixtures/precompiler/near-miss-change-premise-to-empty-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-change-premise-to-empty-unknown",
+  "input": "change premise to",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/near-miss-prohibit-empty-unknown.json
+++ b/tests/fixtures/precompiler/near-miss-prohibit-empty-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-prohibit-empty-unknown",
+  "input": "prohibit",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/near-miss-remove-policy-empty-unknown.json
+++ b/tests/fixtures/precompiler/near-miss-remove-policy-empty-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-remove-policy-empty-unknown",
+  "input": "remove policy",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/near-miss-set-premise-empty-unknown.json
+++ b/tests/fixtures/precompiler/near-miss-set-premise-empty-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-set-premise-empty-unknown",
+  "input": "set premise",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/near-miss-set-premise-to-unknown.json
+++ b/tests/fixtures/precompiler/near-miss-set-premise-to-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-set-premise-to-unknown",
+  "input": "set premise to concise replies",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/near-miss-use-empty-unknown.json
+++ b/tests/fixtures/precompiler/near-miss-use-empty-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-use-empty-unknown",
+  "input": "use",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/near-miss-use-instead-of-missing-new-item-unknown.json
+++ b/tests/fixtures/precompiler/near-miss-use-instead-of-missing-new-item-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-use-instead-of-missing-new-item-unknown",
+  "input": "use instead of docker",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/near-miss-use-instead-of-missing-old-item-unknown.json
+++ b/tests/fixtures/precompiler/near-miss-use-instead-of-missing-old-item-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-use-instead-of-missing-old-item-unknown",
+  "input": "use podman instead of",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/ordinary-non-directive.json
+++ b/tests/fixtures/precompiler/ordinary-non-directive.json
@@ -1,0 +1,8 @@
+{
+  "name": "ordinary-non-directive",
+  "input": "thanks for the help today",
+  "expected": {
+    "classification": "no_directive",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/question-use-docker-unknown.json
+++ b/tests/fixtures/precompiler/question-use-docker-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "question-use-docker-unknown",
+  "input": "use docker?",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/quoted-exact-use-docker-backtick-unknown.json
+++ b/tests/fixtures/precompiler/quoted-exact-use-docker-backtick-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "quoted-exact-use-docker-backtick-unknown",
+  "input": "`use docker`",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/quoted-exact-use-docker-single-unknown.json
+++ b/tests/fixtures/precompiler/quoted-exact-use-docker-single-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "quoted-exact-use-docker-single-unknown",
+  "input": "'use docker'",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/quoted-exact-use-docker-unknown.json
+++ b/tests/fixtures/precompiler/quoted-exact-use-docker-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "quoted-exact-use-docker-unknown",
+  "input": "\"use docker\"",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/quoted-reported-unknown.json
+++ b/tests/fixtures/precompiler/quoted-reported-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "quoted-reported-unknown",
+  "input": "he said \"use docker\".",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/precompiler/unsupported-alias-unknown.json
+++ b/tests/fixtures/precompiler/unsupported-alias-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "unsupported-alias-unknown",
+  "input": "allow docker",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/test_litellm_preprocessor_model_config.py
+++ b/tests/test_litellm_preprocessor_model_config.py
@@ -50,7 +50,7 @@ def test_litellm_preprocessor_model_defaults_to_model(monkeypatch):
 
     monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
     monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
-    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
 
     result = module._llm_fallback_precompile("please use docker", None)
 
@@ -73,7 +73,7 @@ def test_litellm_preprocessor_model_override(monkeypatch):
 
     monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
     monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
-    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
 
     result = module._llm_fallback_precompile("please use docker", None)
 
@@ -98,7 +98,7 @@ def test_litellm_proxy_preprocessor_model_defaults_to_model(monkeypatch):
 
     monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
     monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
-    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
 
     result = module._llm_fallback_precompile("please use docker", None)
 
@@ -123,7 +123,7 @@ def test_litellm_proxy_preprocessor_model_override(monkeypatch):
 
     monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
     monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
-    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
 
     result = module._llm_fallback_precompile("please use docker", None)
 
@@ -146,7 +146,6 @@ def test_litellm_fallback_rejects_premise_near_miss_rewrite(monkeypatch):
 
     monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
     monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
-    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
 
     result = module._llm_fallback_precompile("set premise to concise replies", None)
     assert result is None
@@ -167,7 +166,6 @@ def test_litellm_proxy_fallback_rejects_premise_near_miss_rewrite(monkeypatch):
 
     monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
     monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
-    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
 
     result = module._llm_fallback_precompile("change premise concise replies", None)
     assert result is None

--- a/tests/test_litellm_preprocessor_model_config.py
+++ b/tests/test_litellm_preprocessor_model_config.py
@@ -129,3 +129,45 @@ def test_litellm_proxy_preprocessor_model_override(monkeypatch):
 
     assert result == "use docker"
     assert seen["model"] == "openai/preprocessor-model"
+
+
+def test_litellm_fallback_rejects_premise_near_miss_rewrite(monkeypatch):
+    module = _load_module(
+        "litellm_with_preproc_cfg_reject_premise_rewrite", LITELLM_WITH_PREPROC_PATH
+    )
+
+    def _completion(**kwargs):
+        del kwargs
+        return {"choices": [{"message": {"content": "set premise concise replies"}}]}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("MODEL", "openai/main-model")
+    monkeypatch.delenv("PREPROCESSOR_MODEL", raising=False)
+
+    monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
+    monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
+
+    result = module._llm_fallback_precompile("set premise to concise replies", None)
+    assert result is None
+
+
+def test_litellm_proxy_fallback_rejects_premise_near_miss_rewrite(monkeypatch):
+    module = _load_litellm_proxy_module_with_stubs(
+        monkeypatch, "litellm_proxy_with_preproc_cfg_reject_premise_rewrite"
+    )
+
+    def _completion(**kwargs):
+        del kwargs
+        return {"choices": [{"message": {"content": "change premise to concise replies"}}]}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("MODEL", "openai/main-model")
+    monkeypatch.delenv("PREPROCESSOR_MODEL", raising=False)
+
+    monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
+    monkeypatch.setattr(module, "render_prompt", lambda *_: "prompt")
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value: value)
+
+    result = module._llm_fallback_precompile("change premise concise replies", None)
+    assert result is None

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -184,6 +184,33 @@ def test_preprocessor_fallback_uses_preprocessor_model_only(monkeypatch) -> None
     assert calls == ["prep-model", "base-model"]
 
 
+def test_preprocessor_fallback_rejects_premise_near_miss_rewrite(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_reject_premise_rewrite", monkeypatch)
+    pipe = module.Pipe()
+
+    async def _chat_completion(_: object, payload: dict[str, Any], __: object) -> dict[str, object]:
+        del payload
+        return {"choices": [{"message": {"content": "set premise concise replies"}}]}
+
+    module.generate_chat_completion = _chat_completion
+    module.render_prompt = lambda *_: "prompt"
+    module.parse_precompiler_output = lambda value: value
+
+    directive, error = asyncio.run(
+        pipe._llm_fallback_precompile(
+            "set premise to concise replies",
+            {"premise": None, "policies": {}, "version": 2},
+            request=object(),
+            user_payload={"id": "u1"},
+            prompt_profile="default",
+            model_id="prep-model",
+        )
+    )
+
+    assert directive is None
+    assert error is None
+
+
 def test_recursion_guard_for_preprocessor_model(monkeypatch) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_recursion", monkeypatch)
     pipe = module.Pipe()

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -194,7 +194,6 @@ def test_preprocessor_fallback_rejects_premise_near_miss_rewrite(monkeypatch) ->
 
     module.generate_chat_completion = _chat_completion
     module.render_prompt = lambda *_: "prompt"
-    module.parse_precompiler_output = lambda value: value
 
     directive, error = asyncio.run(
         pipe._llm_fallback_precompile(
@@ -344,7 +343,7 @@ def test_preprocessor_pipe_restore_and_persist_checkpoint_points(monkeypatch) ->
 
     monkeypatch.setattr(module, "create_engine", _create_engine)
     monkeypatch.setattr(module, "precompile_heuristic", lambda _text: {"outcome": "no_directive"})
-    monkeypatch.setattr(module, "parse_precompiler_output", lambda _value: None)
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda _value, **_kwargs: None)
 
     pipe = module.Pipe()
     pipe.valves.BASE_MODEL_ID = "base-model"

--- a/tests/test_precompiler_conformance.py
+++ b/tests/test_precompiler_conformance.py
@@ -3,10 +3,7 @@ import re
 from pathlib import Path
 
 from experimental.preprocessor.heuristic_precompiler import precompile_heuristic
-from experimental.preprocessor.output_validation import (
-    is_safe_fallback_directive_rewrite,
-    validate_precompiler_output,
-)
+from experimental.preprocessor.output_validation import validate_precompiler_output
 
 _PRECOMPILER_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "precompiler"
 
@@ -37,17 +34,6 @@ def _normalize_result(message: str) -> dict[str, object]:
         assert validated["output"] is None
 
     return normalized
-
-
-def _fallback_validate_candidate(source_input: str, candidate_output: str) -> dict[str, object]:
-    validated = validate_precompiler_output(candidate_output)
-    if (
-        validated["classification"] == "directive"
-        and isinstance(validated["output"], str)
-        and not is_safe_fallback_directive_rewrite(source_input, validated["output"])
-    ):
-        return {"classification": "unknown", "output": None}
-    return validated
 
 
 def _derived_risky_rewrite_candidates(source_input: str) -> list[str]:
@@ -100,5 +86,5 @@ def test_engine_owned_near_misses_are_reject_only_for_fallback_rewrites() -> Non
             continue
 
         for candidate in _derived_risky_rewrite_candidates(input_text):
-            validated = _fallback_validate_candidate(input_text, candidate)
+            validated = validate_precompiler_output(candidate, source_input=input_text)
             assert validated["classification"] != "directive", fixture_name

--- a/tests/test_precompiler_conformance.py
+++ b/tests/test_precompiler_conformance.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+from experimental.preprocessor.heuristic_precompiler import precompile_heuristic
+from experimental.preprocessor.output_validation import validate_precompiler_output
+
+_PRECOMPILER_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "precompiler"
+
+
+def _fixture_paths() -> list[Path]:
+    return sorted(_PRECOMPILER_FIXTURES_DIR.glob("*.json"))
+
+
+def _load_fixture(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_result(message: str) -> dict[str, object]:
+    result = precompile_heuristic(message)
+    output = result["directive"] if result["outcome"] == "directive" else None
+    normalized = {
+        "classification": result["outcome"],
+        "output": output,
+    }
+
+    # Enforce the validation boundary: only validated directive output may pass.
+    validated = validate_precompiler_output(output)
+    if normalized["classification"] == "directive":
+        assert validated["classification"] == "directive"
+        assert validated["output"] == output
+    else:
+        assert output is None
+        assert validated["output"] is None
+
+    return normalized
+
+
+def test_precompiler_conformance_fixtures() -> None:
+    for path in _fixture_paths():
+        fixture = _load_fixture(path)
+        expected = fixture["expected"]
+        input_text = fixture["input"]
+        fixture_name = fixture["name"]
+
+        assert isinstance(expected, dict), fixture_name
+        assert isinstance(input_text, str), fixture_name
+
+        # Deterministic replay check.
+        first = _normalize_result(input_text)
+        second = _normalize_result(input_text)
+        assert first == second, fixture_name
+        assert first == expected, fixture_name

--- a/tests/test_precompiler_conformance.py
+++ b/tests/test_precompiler_conformance.py
@@ -1,8 +1,12 @@
 import json
+import re
 from pathlib import Path
 
 from experimental.preprocessor.heuristic_precompiler import precompile_heuristic
-from experimental.preprocessor.output_validation import validate_precompiler_output
+from experimental.preprocessor.output_validation import (
+    is_safe_fallback_directive_rewrite,
+    validate_precompiler_output,
+)
 
 _PRECOMPILER_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "precompiler"
 
@@ -35,6 +39,34 @@ def _normalize_result(message: str) -> dict[str, object]:
     return normalized
 
 
+def _fallback_validate_candidate(source_input: str, candidate_output: str) -> dict[str, object]:
+    validated = validate_precompiler_output(candidate_output)
+    if (
+        validated["classification"] == "directive"
+        and isinstance(validated["output"], str)
+        and not is_safe_fallback_directive_rewrite(source_input, validated["output"])
+    ):
+        return {"classification": "unknown", "output": None}
+    return validated
+
+
+def _derived_risky_rewrite_candidates(source_input: str) -> list[str]:
+    normalized = re.sub(r"\s+", " ", source_input.strip().lower())
+    candidates: list[str] = []
+
+    set_premise_to_match = re.fullmatch(r"set premise to\s+(.+\S)", normalized)
+    if set_premise_to_match is not None:
+        payload = set_premise_to_match.group(1).strip()
+        candidates.append(f"set premise {payload}")
+
+    change_premise_missing_to_match = re.fullmatch(r"change premise\s+(?!to\b)(.+\S)", normalized)
+    if change_premise_missing_to_match is not None:
+        payload = change_premise_missing_to_match.group(1).strip()
+        candidates.append(f"change premise to {payload}")
+
+    return candidates
+
+
 def test_precompiler_conformance_fixtures() -> None:
     for path in _fixture_paths():
         fixture = _load_fixture(path)
@@ -50,3 +82,23 @@ def test_precompiler_conformance_fixtures() -> None:
         second = _normalize_result(input_text)
         assert first == second, fixture_name
         assert first == expected, fixture_name
+
+
+def test_engine_owned_near_misses_are_reject_only_for_fallback_rewrites() -> None:
+    # Engine-owned near-misses must not be canonicalized by the precompiler and
+    # must remain unknown even if fallback proposes a plausible canonical rewrite.
+    for path in _fixture_paths():
+        fixture = _load_fixture(path)
+        expected = fixture["expected"]
+        input_text = fixture["input"]
+        fixture_name = fixture["name"]
+
+        assert isinstance(expected, dict), fixture_name
+        assert isinstance(input_text, str), fixture_name
+
+        if expected.get("classification") != "unknown" or expected.get("output") is not None:
+            continue
+
+        for candidate in _derived_risky_rewrite_candidates(input_text):
+            validated = _fallback_validate_candidate(input_text, candidate)
+            assert validated["classification"] != "directive", fixture_name

--- a/tests/test_precompiler_heuristic.py
+++ b/tests/test_precompiler_heuristic.py
@@ -45,8 +45,6 @@ def test_heuristic_accepts_trailing_period_or_bang_for_whole_message_directives(
 
 def test_heuristic_allows_exact_full_message_wrappers_for_directives() -> None:
     cases = [
-        ("`use docker`", "use docker"),
-        ('"clear state"', "clear state"),
         ("(reset policies)", "reset policies"),
         ("[prohibit peanuts]", "prohibit peanuts"),
     ]
@@ -55,6 +53,20 @@ def test_heuristic_allows_exact_full_message_wrappers_for_directives() -> None:
             "outcome": "directive",
             "directive": expected,
             "rule_id": "canonical.full_match",
+        }
+
+
+def test_heuristic_rejects_quoted_or_backticked_exact_directives() -> None:
+    cases = [
+        "`use docker`",
+        '"clear state"',
+        "'reset policies'",
+    ]
+    for message in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "unknown",
+            "directive": None,
+            "rule_id": "reject.quoted_exact",
         }
 
 
@@ -134,6 +146,32 @@ def test_heuristic_rejects_multi_segment_or_mixed_prose_inputs() -> None:
             "outcome": "unknown",
             "directive": None,
             "rule_id": "reject.multi_segment_or_mixed_prose",
+        }
+
+
+def test_heuristic_rejects_malformed_replacement_syntax() -> None:
+    cases = [
+        "use podman instead docker",
+        "use podman in stead of docker",
+    ]
+    for message in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "unknown",
+            "directive": None,
+            "rule_id": "reject.malformed_replacement_syntax",
+        }
+
+
+def test_heuristic_rejects_admin_near_miss_aliases() -> None:
+    cases = [
+        "reset policy",
+        "remove policies docker",
+    ]
+    for message in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "unknown",
+            "directive": None,
+            "rule_id": "reject.admin_near_miss_alias",
         }
 
 

--- a/tests/test_precompiler_heuristic.py
+++ b/tests/test_precompiler_heuristic.py
@@ -24,7 +24,7 @@ def test_heuristic_rejects_consistent_high_risk_non_directives() -> None:
 
     for message in cases:
         result = precompile_heuristic(message)
-        assert result["outcome"] == "no_directive"
+        assert result["outcome"] == "unknown"
         assert result["directive"] is None
         assert result["rule_id"] is not None
 
@@ -72,18 +72,25 @@ def test_heuristic_case_normalizes_exact_command_shapes() -> None:
         }
 
 
-def test_heuristic_rejects_any_question_mark() -> None:
+def test_heuristic_question_mark_only_non_directive_is_confident() -> None:
+    assert precompile_heuristic("can you help with lunch?") == {
+        "outcome": "no_directive",
+        "directive": None,
+        "rule_id": "reject.confident_non_directive",
+    }
+
+
+def test_heuristic_rejects_directive_adjacent_question_mark_as_unknown() -> None:
     cases = [
         "use docker?",
         "clear state?",
         "can you use pytest instead of unittest?",
     ]
     for message in cases:
-        assert precompile_heuristic(message) == {
-            "outcome": "no_directive",
-            "directive": None,
-            "rule_id": "reject.question_mark",
-        }
+        result = precompile_heuristic(message)
+        assert result["outcome"] == "unknown"
+        assert result["directive"] is None
+        assert result["rule_id"] is not None
 
 
 def test_heuristic_rejects_meta_reporting_or_example_prefixes() -> None:
@@ -96,7 +103,7 @@ def test_heuristic_rejects_meta_reporting_or_example_prefixes() -> None:
     ]
     for message in cases:
         assert precompile_heuristic(message) == {
-            "outcome": "no_directive",
+            "outcome": "unknown",
             "directive": None,
             "rule_id": "reject.meta_or_reporting",
         }
@@ -110,7 +117,7 @@ def test_heuristic_rejects_list_or_enumeration_inputs() -> None:
     ]
     for message in cases:
         assert precompile_heuristic(message) == {
-            "outcome": "no_directive",
+            "outcome": "unknown",
             "directive": None,
             "rule_id": "reject.list_or_enumeration",
         }
@@ -124,7 +131,7 @@ def test_heuristic_rejects_multi_segment_or_mixed_prose_inputs() -> None:
     ]
     for message in cases:
         assert precompile_heuristic(message) == {
-            "outcome": "no_directive",
+            "outcome": "unknown",
             "directive": None,
             "rule_id": "reject.multi_segment_or_mixed_prose",
         }
@@ -138,7 +145,7 @@ def test_heuristic_rejects_notes_and_reporting_with_bracketed_mentions() -> None
     ]
     for message in cases:
         assert precompile_heuristic(message) == {
-            "outcome": "no_directive",
+            "outcome": "unknown",
             "directive": None,
             "rule_id": "reject.quoted_reported_bracket",
         }
@@ -165,11 +172,24 @@ def test_heuristic_canonicalizes_set_premise_to_whole_message_only() -> None:
         }
 
 
+def test_heuristic_dont_use_forms_are_unknown_not_rewritten() -> None:
+    cases = [
+        "don't use peanuts",
+        "do not use peanuts",
+    ]
+    for message in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "unknown",
+            "directive": None,
+            "rule_id": "reject.directive_adjacent_unsafe",
+        }
+
+
 def test_heuristic_does_not_canonicalize_set_premise_to_with_empty_payload() -> None:
     assert precompile_heuristic("set premise to   ") == {
         "outcome": "unknown",
         "directive": None,
-        "rule_id": None,
+        "rule_id": "reject.directive_adjacent_unsafe",
     }
 
 
@@ -177,7 +197,7 @@ def test_heuristic_does_not_canonicalize_set_premise_to_when_not_whole_message()
     assert precompile_heuristic("please set premise to concise replies") == {
         "outcome": "unknown",
         "directive": None,
-        "rule_id": None,
+        "rule_id": "reject.directive_adjacent_unsafe",
     }
 
 
@@ -198,7 +218,7 @@ def test_heuristic_does_not_canonicalize_change_premise_with_empty_payload() -> 
     assert precompile_heuristic("change premise   ") == {
         "outcome": "unknown",
         "directive": None,
-        "rule_id": None,
+        "rule_id": "reject.directive_adjacent_unsafe",
     }
 
 
@@ -206,7 +226,7 @@ def test_heuristic_does_not_canonicalize_change_premise_when_not_whole_message()
     assert precompile_heuristic("please change premise concise replies") == {
         "outcome": "unknown",
         "directive": None,
-        "rule_id": None,
+        "rule_id": "reject.directive_adjacent_unsafe",
     }
 
 
@@ -233,16 +253,26 @@ def test_heuristic_accepts_strict_canonical_directives() -> None:
 
 
 def test_heuristic_returns_unknown_for_unresolved_cases() -> None:
-    unresolved = [
-        "Could we maybe use uv later",
-        "not sure this is right",
-    ]
+    unresolved = ["Could we maybe use uv later"]
 
     for message in unresolved:
         assert precompile_heuristic(message) == {
             "outcome": "unknown",
             "directive": None,
-            "rule_id": None,
+            "rule_id": "reject.directive_adjacent_unsafe",
+        }
+
+
+def test_heuristic_returns_no_directive_for_ordinary_non_directive_content() -> None:
+    cases = [
+        "not sure this is right",
+        "thanks for the help",
+    ]
+    for message in cases:
+        assert precompile_heuristic(message) == {
+            "outcome": "no_directive",
+            "directive": None,
+            "rule_id": "reject.confident_non_directive",
         }
 
 

--- a/tests/test_precompiler_heuristic.py
+++ b/tests/test_precompiler_heuristic.py
@@ -159,16 +159,16 @@ def test_heuristic_accepts_bracket_wrapper_without_reporting_marker() -> None:
     }
 
 
-def test_heuristic_canonicalizes_set_premise_to_whole_message_only() -> None:
+def test_heuristic_set_premise_to_forms_are_unknown_not_rewritten() -> None:
     cases = [
-        ("set premise to concise replies", "set premise concise replies"),
-        ("set premise to formal tone", "set premise formal tone"),
+        "set premise to concise replies",
+        "set premise to formal tone",
     ]
-    for message, expected in cases:
+    for message in cases:
         assert precompile_heuristic(message) == {
-            "outcome": "directive",
-            "directive": expected,
-            "rule_id": "canonical.structural_set_premise_to",
+            "outcome": "unknown",
+            "directive": None,
+            "rule_id": "reject.directive_adjacent_unsafe",
         }
 
 
@@ -201,16 +201,16 @@ def test_heuristic_does_not_canonicalize_set_premise_to_when_not_whole_message()
     }
 
 
-def test_heuristic_canonicalizes_change_premise_missing_to_whole_message_only() -> None:
+def test_heuristic_change_premise_missing_to_forms_are_unknown_not_rewritten() -> None:
     cases = [
-        ("change premise concise replies", "change premise to concise replies"),
-        ("change premise formal tone", "change premise to formal tone"),
+        "change premise concise replies",
+        "change premise formal tone",
     ]
-    for message, expected in cases:
+    for message in cases:
         assert precompile_heuristic(message) == {
-            "outcome": "directive",
-            "directive": expected,
-            "rule_id": "canonical.structural_change_premise_missing_to",
+            "outcome": "unknown",
+            "directive": None,
+            "rule_id": "reject.directive_adjacent_unsafe",
         }
 
 

--- a/tests/test_precompiler_heuristic_properties.py
+++ b/tests/test_precompiler_heuristic_properties.py
@@ -6,6 +6,7 @@ from hypothesis import strategies as st
 from experimental.preprocessor.constants import (
     PRECOMPILE_OUTCOME_DIRECTIVE,
     PRECOMPILE_OUTCOME_NO_DIRECTIVE,
+    PRECOMPILE_OUTCOME_UNKNOWN,
 )
 from experimental.preprocessor.heuristic_precompiler import precompile_heuristic
 from experimental.preprocessor.output_validation import (
@@ -50,7 +51,7 @@ def test_heuristic_accepts_canonical_directive_with_trailing_period_or_bang(
 @given(st.sampled_from(CANONICAL_DIRECTIVES))
 def test_heuristic_question_suffix_never_produces_directive(directive: str) -> None:
     result = precompile_heuristic(f"{directive}?")
-    assert result["outcome"] == PRECOMPILE_OUTCOME_NO_DIRECTIVE
+    assert result["outcome"] == PRECOMPILE_OUTCOME_UNKNOWN
     assert result["directive"] is None
 
 
@@ -82,11 +83,9 @@ def test_heuristic_rejects_wrapped_directive_with_surrounding_meta_text(
 @given(st.text(max_size=60), st.text(max_size=60))
 def test_heuristic_question_mark_is_always_rejected(prefix: str, suffix: str) -> None:
     message = f"{prefix}?{suffix}"
-    assert precompile_heuristic(message) == {
-        "outcome": PRECOMPILE_OUTCOME_NO_DIRECTIVE,
-        "directive": None,
-        "rule_id": "reject.question_mark",
-    }
+    result = precompile_heuristic(message)
+    assert result["outcome"] in {PRECOMPILE_OUTCOME_NO_DIRECTIVE, PRECOMPILE_OUTCOME_UNKNOWN}
+    assert result["directive"] is None
 
 
 @given(st.text(max_size=120))

--- a/tests/test_precompiler_heuristic_properties.py
+++ b/tests/test_precompiler_heuristic_properties.py
@@ -29,11 +29,15 @@ CANONICAL_DIRECTIVES = [
 NON_EMPTY_TEXT = st.text(min_size=1, max_size=40).filter(lambda s: s.strip() != "")
 WRAPPERS = st.sampled_from(
     [
+        ("(", ")"),
+        ("[", "]"),
+    ]
+)
+QUOTED_WRAPPERS = st.sampled_from(
+    [
         ('"', '"'),
         ("'", "'"),
         ("`", "`"),
-        ("(", ")"),
-        ("[", "]"),
     ]
 )
 
@@ -64,6 +68,16 @@ def test_heuristic_accepts_single_layer_exact_wrapper(
     assert result["outcome"] == PRECOMPILE_OUTCOME_DIRECTIVE
     parsed = parse_precompiler_output(result["directive"])
     assert parsed == result["directive"]
+
+
+@given(st.sampled_from(CANONICAL_DIRECTIVES), QUOTED_WRAPPERS)
+def test_heuristic_quoted_exact_wrappers_never_directive(
+    directive: str, wrapper: tuple[str, str]
+) -> None:
+    left, right = wrapper
+    result = precompile_heuristic(f"{left}{directive}{right}")
+    assert result["outcome"] == PRECOMPILE_OUTCOME_UNKNOWN
+    assert result["directive"] is None
 
 
 @given(

--- a/tests/test_precompiler_output_validation.py
+++ b/tests/test_precompiler_output_validation.py
@@ -114,6 +114,23 @@ def test_parse_returns_validated_directive_only() -> None:
     assert parse_precompiler_output("set premise to concise replies") is None
 
 
+def test_parse_with_source_input_rejects_premise_near_miss_canonicalization() -> None:
+    assert (
+        parse_precompiler_output(
+            "set premise concise replies",
+            source_input="set premise to concise replies",
+        )
+        is None
+    )
+    assert (
+        parse_precompiler_output(
+            "change premise to concise replies",
+            source_input="change premise concise replies",
+        )
+        is None
+    )
+
+
 def test_fallback_rewrite_safety_rejects_premise_near_miss_canonicalization() -> None:
     assert not is_safe_fallback_directive_rewrite(
         "set premise to concise replies",

--- a/tests/test_precompiler_output_validation.py
+++ b/tests/test_precompiler_output_validation.py
@@ -1,36 +1,8 @@
-from experimental.preprocessor.constants import PRECOMPILER_NO_DIRECTIVE_SENTINEL
 from experimental.preprocessor.output_validation import (
     _is_allowed_directive,
-    _normalize_precompiler_output,
     parse_precompiler_output,
+    validate_precompiler_output,
 )
-
-
-def test_normalize_accepts_exact_abstain_sentinel() -> None:
-    assert _normalize_precompiler_output("<NO_DIRECTIVE>") == PRECOMPILER_NO_DIRECTIVE_SENTINEL
-
-
-def test_normalize_repairs_known_malformed_abstain_tags() -> None:
-    assert _normalize_precompiler_output("<NO_DIRECTIPLE>") == PRECOMPILER_NO_DIRECTIVE_SENTINEL
-    assert _normalize_precompiler_output("<NO_DIRECTITIVE>") == PRECOMPILER_NO_DIRECTIVE_SENTINEL
-    assert (
-        _normalize_precompiler_output("<NO_DIRECT_DIRECTIVE>") == PRECOMPILER_NO_DIRECTIVE_SENTINEL
-    )
-
-
-def test_normalize_repairs_malformed_abstain_with_suffix_text() -> None:
-    raw = "<NO_DIRECTDirective> Directive cannot be generated..."
-    assert _normalize_precompiler_output(raw) == PRECOMPILER_NO_DIRECTIVE_SENTINEL
-
-
-def test_normalize_preserves_last_non_empty_line_abstain_behavior() -> None:
-    raw = "<NO_DIRECT Directive>\n<NO_DIRECTIVE>"
-    assert _normalize_precompiler_output(raw) == PRECOMPILER_NO_DIRECTIVE_SENTINEL
-
-
-def test_normalize_returns_none_for_non_string() -> None:
-    assert _normalize_precompiler_output(None) is None
-    assert _normalize_precompiler_output(123) is None
 
 
 def test_is_allowed_directive_accepts_canonical_shapes() -> None:
@@ -40,11 +12,102 @@ def test_is_allowed_directive_accepts_canonical_shapes() -> None:
     assert _is_allowed_directive("use podman instead of docker")
 
 
-def test_parse_accepts_valid_directive_and_rejects_malformed_directive() -> None:
+def test_validate_text_accepts_canonical_directive() -> None:
+    result = validate_precompiler_output("prohibit peanuts")
+    assert result == {
+        "classification": "directive",
+        "output": "prohibit peanuts",
+    }
+
+
+def test_validate_text_accepts_exact_no_directive_sentinel() -> None:
+    result = validate_precompiler_output("<NO_DIRECTIVE>")
+    assert result == {
+        "classification": "no_directive",
+        "output": None,
+    }
+
+
+def test_validate_text_rejects_malformed_or_mixed_output_as_unknown() -> None:
+    assert validate_precompiler_output("<NO_DIRECTIPLE>") == {
+        "classification": "unknown",
+        "output": None,
+    }
+    assert validate_precompiler_output("set premise to concise replies") == {
+        "classification": "unknown",
+        "output": None,
+    }
+    assert validate_precompiler_output("prohibit peanuts and use almonds") == {
+        "classification": "unknown",
+        "output": None,
+    }
+
+
+def test_validate_structured_output_accepts_strict_contract_shape() -> None:
+    assert validate_precompiler_output(
+        {
+            "classification": "directive",
+            "output": "clear state",
+        }
+    ) == {
+        "classification": "directive",
+        "output": "clear state",
+    }
+
+    assert validate_precompiler_output(
+        {
+            "classification": "no_directive",
+            "output": None,
+        }
+    ) == {
+        "classification": "no_directive",
+        "output": None,
+    }
+
+    assert validate_precompiler_output(
+        {
+            "classification": "unknown",
+            "output": None,
+        }
+    ) == {
+        "classification": "unknown",
+        "output": None,
+    }
+
+
+def test_validate_structured_output_rejects_malformed_shape_or_payload_as_unknown() -> None:
+    cases = [
+        None,
+        123,
+        {},
+        {"classification": "directive"},
+        {"output": "clear state"},
+        {"classification": "directive", "output": None},
+        {"classification": "directive", "output": ""},
+        {"classification": "directive", "output": "set premise to concise replies"},
+        {"classification": "no_directive", "output": "clear state"},
+        {"classification": "unknown", "output": "clear state"},
+        {"classification": "unsupported_action", "output": None},
+        {"classification": "directive", "output": "clear state\nreset policies"},
+        {"classification": "directive", "output": "clear state", "extra": True},
+        {"action": "prohibit", "item": "peanuts"},
+    ]
+    for raw in cases:
+        assert validate_precompiler_output(raw) == {
+            "classification": "unknown",
+            "output": None,
+        }
+
+
+def test_validate_text_parses_and_validates_json_contract() -> None:
+    raw = '{"classification":"directive","output":"use docker"}'
+    assert validate_precompiler_output(raw) == {
+        "classification": "directive",
+        "output": "use docker",
+    }
+
+
+def test_parse_returns_validated_directive_only() -> None:
     assert parse_precompiler_output("prohibit peanuts") == "prohibit peanuts"
+    assert parse_precompiler_output("<NO_DIRECTIVE>") is None
     assert parse_precompiler_output("set premise to concise replies") is None
-    assert parse_precompiler_output("wipe policies") is None
-
-
-def test_parse_maps_malformed_abstain_to_canonical_sentinel() -> None:
-    assert parse_precompiler_output("<NO_DIRECTIPLE>") == PRECOMPILER_NO_DIRECTIVE_SENTINEL

--- a/tests/test_precompiler_output_validation.py
+++ b/tests/test_precompiler_output_validation.py
@@ -1,5 +1,6 @@
 from experimental.preprocessor.output_validation import (
     _is_allowed_directive,
+    is_safe_fallback_directive_rewrite,
     parse_precompiler_output,
     validate_precompiler_output,
 )
@@ -111,3 +112,25 @@ def test_parse_returns_validated_directive_only() -> None:
     assert parse_precompiler_output("prohibit peanuts") == "prohibit peanuts"
     assert parse_precompiler_output("<NO_DIRECTIVE>") is None
     assert parse_precompiler_output("set premise to concise replies") is None
+
+
+def test_fallback_rewrite_safety_rejects_premise_near_miss_canonicalization() -> None:
+    assert not is_safe_fallback_directive_rewrite(
+        "set premise to concise replies",
+        "set premise concise replies",
+    )
+    assert not is_safe_fallback_directive_rewrite(
+        "change premise concise replies",
+        "change premise to concise replies",
+    )
+
+
+def test_fallback_rewrite_safety_allows_other_directives() -> None:
+    assert is_safe_fallback_directive_rewrite(
+        "prohibit peanuts",
+        "prohibit peanuts",
+    )
+    assert is_safe_fallback_directive_rewrite(
+        "what is a simple curry recipe?",
+        "use coconut milk",
+    )

--- a/tests/test_precompiler_output_validation.py
+++ b/tests/test_precompiler_output_validation.py
@@ -1,6 +1,5 @@
 from experimental.preprocessor.output_validation import (
     _is_allowed_directive,
-    is_safe_fallback_directive_rewrite,
     parse_precompiler_output,
     validate_precompiler_output,
 )
@@ -131,23 +130,35 @@ def test_parse_with_source_input_rejects_premise_near_miss_canonicalization() ->
     )
 
 
-def test_fallback_rewrite_safety_rejects_premise_near_miss_canonicalization() -> None:
-    assert not is_safe_fallback_directive_rewrite(
-        "set premise to concise replies",
+def test_validation_with_source_input_rejects_premise_near_miss_canonicalization() -> None:
+    assert validate_precompiler_output(
         "set premise concise replies",
-    )
-    assert not is_safe_fallback_directive_rewrite(
-        "change premise concise replies",
+        source_input="set premise to concise replies",
+    ) == {
+        "classification": "unknown",
+        "output": None,
+    }
+    assert validate_precompiler_output(
         "change premise to concise replies",
-    )
+        source_input="change premise concise replies",
+    ) == {
+        "classification": "unknown",
+        "output": None,
+    }
 
 
-def test_fallback_rewrite_safety_allows_other_directives() -> None:
-    assert is_safe_fallback_directive_rewrite(
+def test_validation_with_source_input_allows_other_directives() -> None:
+    assert validate_precompiler_output(
         "prohibit peanuts",
-        "prohibit peanuts",
-    )
-    assert is_safe_fallback_directive_rewrite(
-        "what is a simple curry recipe?",
+        source_input="prohibit peanuts",
+    ) == {
+        "classification": "directive",
+        "output": "prohibit peanuts",
+    }
+    assert validate_precompiler_output(
         "use coconut milk",
-    )
+        source_input="what is a simple curry recipe?",
+    ) == {
+        "classification": "directive",
+        "output": "use coconut milk",
+    }

--- a/tests/test_precompiler_validator_properties.py
+++ b/tests/test_precompiler_validator_properties.py
@@ -1,13 +1,10 @@
-import string
-
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
-from experimental.preprocessor.constants import PRECOMPILER_NO_DIRECTIVE_SENTINEL
 from experimental.preprocessor.output_validation import (
     _is_allowed_directive,
-    _normalize_precompiler_output,
     parse_precompiler_output,
+    validate_precompiler_output,
 )
 
 CANONICAL_DIRECTIVES = [
@@ -35,26 +32,6 @@ NOISY_TEXT = st.one_of(
     st.builds(lambda a, b: f"{a}: {b}", st.text(max_size=30), st.text(max_size=30)),
 )
 
-MALFORMED_ABSTAIN = st.one_of(
-    st.sampled_from(
-        [
-            "<NO_DIRECTIPLE>",
-            "<NO_DIRECTITIVE>",
-            "<NO_DIRECT_DIRECTIVE>",
-            "<NO_DIRECTDirective> Directive cannot be generated...",
-        ]
-    ),
-    st.builds(
-        lambda middle: f"<NO_DIRECT{middle}>",
-        st.text(alphabet=string.ascii_uppercase + "_", min_size=1, max_size=20),
-    ),
-    st.builds(
-        lambda middle, suffix: f"<NO_DIRECT{middle}> {suffix}",
-        st.text(alphabet=string.ascii_uppercase + "_", min_size=1, max_size=20),
-        st.text(min_size=1, max_size=40),
-    ),
-)
-
 
 @given(
     st.one_of(
@@ -74,16 +51,8 @@ def test_parse_non_string_never_produces_directive(raw_output: object) -> None:
 @given(NOISY_TEXT)
 def test_parse_invalid_text_never_becomes_directive(text: str) -> None:
     stripped = text.strip()
-    assume(stripped.upper() != PRECOMPILER_NO_DIRECTIVE_SENTINEL)
     assume(not _is_allowed_directive(stripped))
-    parsed = parse_precompiler_output(text)
-    assert parsed in {None, PRECOMPILER_NO_DIRECTIVE_SENTINEL}
-
-
-@given(MALFORMED_ABSTAIN)
-def test_parse_malformed_abstain_only_maps_to_sentinel_or_rejects(text: str) -> None:
-    parsed = parse_precompiler_output(text)
-    assert parsed in {None, PRECOMPILER_NO_DIRECTIVE_SENTINEL}
+    assert parse_precompiler_output(text) is None
 
 
 @given(st.sampled_from(CANONICAL_DIRECTIVES), SPACE_TEXT, SPACE_TEXT)
@@ -94,24 +63,14 @@ def test_parse_valid_canonical_directive_always_passes(
     assert parse_precompiler_output(raw) == directive
 
 
-@given(NOISY_TEXT)
-def test_normalization_is_idempotent(text: str) -> None:
-    normalized_once = _normalize_precompiler_output(text)
-    if normalized_once is None:
-        return
-    assert _normalize_precompiler_output(normalized_once) == normalized_once
-
-
 @given(st.sampled_from(CANONICAL_DIRECTIVES), NON_EMPTY_TEXT, NON_EMPTY_TEXT)
 def test_parse_rejects_directive_with_surrounding_text(
     directive: str, prefix: str, suffix: str
 ) -> None:
     raw = f"{prefix} {directive} {suffix}"
     stripped = raw.strip()
-    assume(stripped.upper() != PRECOMPILER_NO_DIRECTIVE_SENTINEL)
     assume(not _is_allowed_directive(stripped))
-    parsed = parse_precompiler_output(raw)
-    assert parsed in {None, PRECOMPILER_NO_DIRECTIVE_SENTINEL}
+    assert parse_precompiler_output(raw) is None
 
 
 @given(
@@ -131,21 +90,21 @@ def test_parse_rejects_directive_in_constrained_wrappers(directive: str, wrapper
     assert parse_precompiler_output(wrapped) is None
 
 
-def test_parse_malformed_abstain_negative_boundaries_remain_narrow() -> None:
+def test_validate_malformed_abstain_negative_boundaries_are_unknown() -> None:
     cases = {
-        "<NO_DIRECT>": None,
-        "<NO_DIRECTION>": None,
-        "<NO_DIRECTIVE please>": None,
-        "notes: <NO_DIRECTIVE>": None,
-        "prefix <NO_DIRECTIPLE>": None,
-        "<NOT_DIRECTIVE>": None,
-        "<NO_DIRECTIPLE>": PRECOMPILER_NO_DIRECTIVE_SENTINEL,
+        "<NO_DIRECT>": "unknown",
+        "<NO_DIRECTION>": "unknown",
+        "<NO_DIRECTIVE please>": "unknown",
+        "notes: <NO_DIRECTIVE>": "unknown",
+        "prefix <NO_DIRECTIPLE>": "unknown",
+        "<NOT_DIRECTIVE>": "unknown",
+        "<NO_DIRECTIPLE>": "unknown",
+        "<NO_DIRECTIVE>": "no_directive",
     }
-    for raw, expected in cases.items():
-        parsed = parse_precompiler_output(raw)
-        assert parsed == expected
-        if parsed is not None:
-            assert parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL or _is_allowed_directive(parsed)
+    for raw, expected_cls in cases.items():
+        validated = validate_precompiler_output(raw)
+        assert validated["classification"] == expected_cls
+        assert validated["output"] is None
 
 
 def test_parse_rejects_near_miss_directives_when_wrapped_or_prefixed() -> None:
@@ -157,10 +116,7 @@ def test_parse_rejects_near_miss_directives_when_wrapped_or_prefixed() -> None:
         'he said "use docker"',
     ]
     for raw in cases:
-        parsed = parse_precompiler_output(raw)
-        assert parsed in {None, PRECOMPILER_NO_DIRECTIVE_SENTINEL}
-        if parsed is not None:
-            assert parsed == PRECOMPILER_NO_DIRECTIVE_SENTINEL
+        assert parse_precompiler_output(raw) is None
 
 
 @given(st.one_of(st.none(), st.integers(), st.text(max_size=120)))
@@ -171,3 +127,16 @@ def test_parse_output_idempotent(raw_output: object) -> None:
         assert second is None
     else:
         assert second == first
+
+
+@given(
+    st.one_of(
+        st.none(), st.integers(), st.text(max_size=120), st.dictionaries(st.text(), st.none())
+    )
+)
+def test_validate_output_always_has_null_for_non_directive(raw_output: object) -> None:
+    validated = validate_precompiler_output(raw_output)
+    if validated["classification"] == "directive":
+        assert isinstance(validated["output"], str)
+    else:
+        assert validated["output"] is None


### PR DESCRIPTION
What changed:
- Hardened experimental precompiler classification around explicit directive / no_directive / unknown boundaries.
- Added reject-first handling for directive-adjacent unsafe forms (quoted exact directives, malformed replacement-like forms, admin alias near-misses, polite/modal and question-form near-misses).
- Added and expanded portable precompiler conformance fixtures under tests/fixtures/precompiler/ including representative near-miss abstention cases.
- Added and updated precompiler-focused tests and conformance runner coverage to enforce deterministic fixture replay and validated-directive-only use.

Why this was needed:
- 0.6.9 precompiler hardening needs a conservative, portable contract surface.
- This keeps integration behavior predictable: only validated canonical directives are rewritten; near-miss and unsafe forms abstain.
- Fixture-driven conformance now captures the intended reject-first behavior for future cross-language implementations.