### PR TITLE
chore: bump openwebui example version to 0.3

### DIFF
--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -3,7 +3,7 @@ title: Context Compiler Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.2
+version: 0.3
 requirements: context-compiler>=0.6.7
 
 Minimal Open WebUI Pipe integration for Context Compiler.

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -3,7 +3,7 @@ title: Context Compiler Preprocessor Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.2
+version: 0.3
 requirements: context-compiler[experimental]>=0.6.7
 
 Open WebUI integration with Context Compiler preprocessor.


### PR DESCRIPTION
What changed:
- Updated OpenWebUI example function frontmatter version in examples/integrations/openwebui/open_webui_pipe.py from 0.2 to 0.3.
- Updated OpenWebUI preprocessor example function frontmatter version in examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py from 0.2 to 0.3.

Why this change was needed:
- Align OpenWebUI example integration metadata with the new example release revision (0.3) without changing runtime behavior.