### PR TITLE
fix: suppress confirmation model calls in integrations

### DIFF
--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -12,13 +12,14 @@ Intended host usage:
 """
 
 import logging
+import re
 from collections.abc import Callable, Mapping, Sequence
 from importlib import import_module
 from typing import TypedDict, cast
 
+import host_support.confirmation as _confirmation
 from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
-from host_support.confirmation import is_confirmation_text
 from host_support.provider_mode import print_startup_config, resolve_provider_config
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,8 @@ logger = logging.getLogger(__name__)
 # or restart continuity for pending flows will be lost.
 _CHECKPOINTS_BY_SESSION_KEY: dict[str, str] = {}
 _RESTORED_ENGINE_BY_SESSION_KEY: dict[str, int] = {}
+_NEGATIVE_CONFIRMATION_TOKENS = {"no", "nope", "no thanks"}
+_TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
 
 
 class _LiteLLMCallKwargs(TypedDict, total=False):
@@ -138,8 +141,62 @@ def _persist_session_checkpoint_if_needed(
     _CHECKPOINTS_BY_SESSION_KEY[session_key] = engine.export_checkpoint_json()
 
 
+def _normalize_confirmation_for_summary(value: str) -> str:
+    normalized = value.strip().lower()
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = _TRAILING_CONFIRM_PUNCT_RE.sub("", normalized).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
+def _render_item_label(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _summarize_confirmation_update(user_input: str, pending: object) -> str:
+    summarize_fn = getattr(_confirmation, "summarize_confirmation_update", None)
+    if callable(summarize_fn):
+        return cast(str, summarize_fn(user_input, pending))
+
+    normalized = _normalize_confirmation_for_summary(user_input)
+    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
+        return "State unchanged."
+    if not isinstance(pending, dict):
+        return "State updated."
+
+    replacement = pending.get("replacement")
+    if not isinstance(replacement, dict):
+        return "State updated."
+
+    kind = replacement.get("kind")
+    new_item = replacement.get("new_item")
+    old_item = replacement.get("old_item")
+    if kind == "use_only" and isinstance(new_item, str):
+        new_label = _render_item_label(new_item)
+        if new_label:
+            return f"State updated: Use {new_label}."
+        return "State updated."
+
+    if kind == "replace_use" and isinstance(new_item, str) and isinstance(old_item, str):
+        new_label = _render_item_label(new_item)
+        old_label = _render_item_label(old_item)
+        if not new_label or not old_label:
+            return "State updated."
+        prompt = pending.get("prompt_to_user")
+        prohibited_old_prompt = (
+            f'"{old_item}" is currently prohibited. '
+            f'Did you mean to remove it and use "{new_item}" instead?'
+        )
+        if prompt == prohibited_old_prompt:
+            return f"State updated: Removed prohibition on {old_label}; use {new_label}."
+        return f"State updated: Replaced {old_label} with {new_label}."
+
+    return "State updated."
+
+
 def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = None) -> str:
     _restore_session_checkpoint_if_needed(engine, session_key)
+    checkpoint_before = engine.export_checkpoint()
+    pending_before = checkpoint_before.get("pending")
     logger.debug("litellm_basic: engine_input=%s", f"user_input len={len(user_input)}")
     decision = engine.step(user_input)
     kind = cast(str, decision["kind"])
@@ -149,8 +206,12 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
         _persist_session_checkpoint_if_needed(engine, kind, session_key)
         return decision["prompt_to_user"] or ""
     _persist_session_checkpoint_if_needed(engine, kind, session_key)
-    if kind == "update" and is_confirmation_text(user_input):
-        return "State updated."
+    if (
+        kind == "update"
+        and _confirmation.is_confirmation_text(user_input)
+        and pending_before is not None
+    ):
+        return _summarize_confirmation_update(user_input, pending_before)
 
     compiled_state = decision["state"] if decision["state"] is not None else engine.state
     messages = _build_messages(user_input, compiled_state)

--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -18,6 +18,7 @@ from typing import TypedDict, cast
 
 from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
+from host_support.confirmation import is_confirmation_text
 from host_support.provider_mode import print_startup_config, resolve_provider_config
 
 logger = logging.getLogger(__name__)
@@ -148,6 +149,8 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
         _persist_session_checkpoint_if_needed(engine, kind, session_key)
         return decision["prompt_to_user"] or ""
     _persist_session_checkpoint_if_needed(engine, kind, session_key)
+    if kind == "update" and is_confirmation_text(user_input):
+        return "State updated."
 
     compiled_state = decision["state"] if decision["state"] is not None else engine.state
     messages = _build_messages(user_input, compiled_state)

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -29,6 +29,7 @@ from experimental.preprocessor import (
     precompile_heuristic,
     render_prompt,
 )
+from host_support.confirmation import is_confirmation_text
 from host_support.provider_mode import print_startup_config, resolve_provider_config
 
 logger = logging.getLogger(__name__)
@@ -256,6 +257,8 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
         _persist_session_checkpoint_if_needed(engine, kind, session_key)
         return decision["prompt_to_user"] or ""
     _persist_session_checkpoint_if_needed(engine, kind, session_key)
+    if kind == "update" and is_confirmation_text(user_input):
+        return "State updated."
 
     compiled_state = decision["state"] if decision["state"] is not None else engine.state
     messages = _build_messages(user_input, compiled_state)

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -15,12 +15,14 @@ Intended host usage:
 
 import logging
 import os
+import re
 from collections.abc import Callable, Mapping, Sequence
 from importlib import import_module
 from importlib.resources import as_file, files
 from importlib.resources.abc import Traversable
 from typing import TypedDict, cast
 
+import host_support.confirmation as _confirmation
 from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
@@ -29,7 +31,6 @@ from experimental.preprocessor import (
     precompile_heuristic,
     render_prompt,
 )
-from host_support.confirmation import is_confirmation_text
 from host_support.provider_mode import print_startup_config, resolve_provider_config
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,8 @@ _PROMPTS_DIR = files("experimental.preprocessor").joinpath("prompts")
 # or restart continuity for pending flows will be lost.
 _CHECKPOINTS_BY_SESSION_KEY: dict[str, str] = {}
 _RESTORED_ENGINE_BY_SESSION_KEY: dict[str, int] = {}
+_NEGATIVE_CONFIRMATION_TOKENS = {"no", "nope", "no thanks"}
+_TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
 
 
 class _LiteLLMCallKwargs(TypedDict, total=False):
@@ -232,14 +235,64 @@ def _persist_session_checkpoint_if_needed(
     _CHECKPOINTS_BY_SESSION_KEY[session_key] = engine.export_checkpoint_json()
 
 
-def _has_pending_clarification(engine: Engine) -> bool:
-    return engine.export_checkpoint()["pending"] is not None
+def _normalize_confirmation_for_summary(value: str) -> str:
+    normalized = value.strip().lower()
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = _TRAILING_CONFIRM_PUNCT_RE.sub("", normalized).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
+def _render_item_label(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _summarize_confirmation_update(user_input: str, pending: object) -> str:
+    summarize_fn = getattr(_confirmation, "summarize_confirmation_update", None)
+    if callable(summarize_fn):
+        return cast(str, summarize_fn(user_input, pending))
+
+    normalized = _normalize_confirmation_for_summary(user_input)
+    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
+        return "State unchanged."
+    if not isinstance(pending, dict):
+        return "State updated."
+
+    replacement = pending.get("replacement")
+    if not isinstance(replacement, dict):
+        return "State updated."
+
+    kind = replacement.get("kind")
+    new_item = replacement.get("new_item")
+    old_item = replacement.get("old_item")
+    if kind == "use_only" and isinstance(new_item, str):
+        new_label = _render_item_label(new_item)
+        if new_label:
+            return f"State updated: Use {new_label}."
+        return "State updated."
+
+    if kind == "replace_use" and isinstance(new_item, str) and isinstance(old_item, str):
+        new_label = _render_item_label(new_item)
+        old_label = _render_item_label(old_item)
+        if not new_label or not old_label:
+            return "State updated."
+        prompt = pending.get("prompt_to_user")
+        prohibited_old_prompt = (
+            f'"{old_item}" is currently prohibited. '
+            f'Did you mean to remove it and use "{new_item}" instead?'
+        )
+        if prompt == prohibited_old_prompt:
+            return f"State updated: Removed prohibition on {old_label}; use {new_label}."
+        return f"State updated: Replaced {old_label} with {new_label}."
+
+    return "State updated."
 
 
 def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = None) -> str:
     _restore_session_checkpoint_if_needed(engine, session_key)
+    checkpoint_before = engine.export_checkpoint()
+    pending_before = checkpoint_before.get("pending")
     precompiled: str | None = None
-    if _has_pending_clarification(engine):
+    if pending_before is not None:
         compile_input = user_input
     else:
         precompiled = _precompile_user_input(user_input, engine.state)
@@ -257,8 +310,12 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
         _persist_session_checkpoint_if_needed(engine, kind, session_key)
         return decision["prompt_to_user"] or ""
     _persist_session_checkpoint_if_needed(engine, kind, session_key)
-    if kind == "update" and is_confirmation_text(user_input):
-        return "State updated."
+    if (
+        kind == "update"
+        and _confirmation.is_confirmation_text(user_input)
+        and pending_before is not None
+    ):
+        return _summarize_confirmation_update(user_input, pending_before)
 
     compiled_state = decision["state"] if decision["state"] is not None else engine.state
     messages = _build_messages(user_input, compiled_state)

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -19,7 +19,8 @@ Scope is intentionally limited:
 
 import inspect
 import logging
-from typing import Any
+import re
+from typing import Any, cast
 
 from fastapi import Request  # type: ignore[import-not-found]
 from open_webui.models.users import Users  # type: ignore[import-not-found]
@@ -41,9 +42,9 @@ except ModuleNotFoundError:
         return default
 
 
+import host_support.confirmation as _confirmation
 from context_compiler import State, create_engine, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
-from host_support.confirmation import is_confirmation_text
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,8 @@ _ENGINES_BY_CHAT_KEY: dict[str, Engine] = {}
 # Real deployments should persist checkpoints externally (DB/Redis/etc.),
 # or restart continuity for pending flows will be lost.
 _CHECKPOINTS_BY_CHAT_KEY: dict[str, str] = {}
+_NEGATIVE_CONFIRMATION_TOKENS = {"no", "nope", "no thanks"}
+_TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
 
 
 def _resolve_chat_key(
@@ -155,6 +158,58 @@ def _replace_compiler_system_message(
         compiler_message,
         *filtered_messages[insert_at:],
     ]
+
+
+def _normalize_confirmation_for_summary(value: str) -> str:
+    normalized = value.strip().lower()
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = _TRAILING_CONFIRM_PUNCT_RE.sub("", normalized).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
+def _render_item_label(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _summarize_confirmation_update(user_input: str, pending: object) -> str:
+    summarize_fn = getattr(_confirmation, "summarize_confirmation_update", None)
+    if callable(summarize_fn):
+        return cast(str, summarize_fn(user_input, pending))
+
+    normalized = _normalize_confirmation_for_summary(user_input)
+    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
+        return "State unchanged."
+    if not isinstance(pending, dict):
+        return "State updated."
+
+    replacement = pending.get("replacement")
+    if not isinstance(replacement, dict):
+        return "State updated."
+
+    kind = replacement.get("kind")
+    new_item = replacement.get("new_item")
+    old_item = replacement.get("old_item")
+    if kind == "use_only" and isinstance(new_item, str):
+        new_label = _render_item_label(new_item)
+        if new_label:
+            return f"State updated: Use {new_label}."
+        return "State updated."
+
+    if kind == "replace_use" and isinstance(new_item, str) and isinstance(old_item, str):
+        new_label = _render_item_label(new_item)
+        old_label = _render_item_label(old_item)
+        if not new_label or not old_label:
+            return "State updated."
+        prompt = pending.get("prompt_to_user")
+        prohibited_old_prompt = (
+            f'"{old_item}" is currently prohibited. '
+            f'Did you mean to remove it and use "{new_item}" instead?'
+        )
+        if prompt == prohibited_old_prompt:
+            return f"State updated: Removed prohibition on {old_label}; use {new_label}."
+        return f"State updated: Replaced {old_label} with {new_label}."
+
+    return "State updated."
 
 
 class Pipe:
@@ -318,6 +373,8 @@ class Pipe:
                 engine.import_checkpoint_json(checkpoint)
             _ENGINES_BY_CHAT_KEY[chat_key] = engine
 
+        checkpoint_before = engine.export_checkpoint()
+        pending_before = checkpoint_before.get("pending")
         logger.debug("pipe: engine_input=%r", latest_user_text)
         decision = engine.step(latest_user_text)
         kind = decision["kind"]
@@ -330,8 +387,8 @@ class Pipe:
             return await self._forward_passthrough(body, __user__, __request__)
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            if is_confirmation_text(latest_user_text):
-                return "State updated."
+            if _confirmation.is_confirmation_text(latest_user_text) and pending_before is not None:
+                return _summarize_confirmation_update(latest_user_text, pending_before)
             return await self._forward_update(body, __user__, __request__, engine.state)
 
         return await self._forward_passthrough(body, __user__, __request__)

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -43,6 +43,7 @@ except ModuleNotFoundError:
 
 from context_compiler import State, create_engine, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
+from host_support.confirmation import is_confirmation_text
 
 logger = logging.getLogger(__name__)
 
@@ -329,6 +330,8 @@ class Pipe:
             return await self._forward_passthrough(body, __user__, __request__)
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
+            if is_confirmation_text(latest_user_text):
+                return "State updated."
             return await self._forward_update(body, __user__, __request__, engine.state)
 
         return await self._forward_passthrough(body, __user__, __request__)

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -52,6 +52,7 @@ from experimental.preprocessor import (
     precompile_heuristic,
     render_prompt,
 )
+from host_support.confirmation import is_confirmation_text
 
 logger = logging.getLogger(__name__)
 
@@ -537,6 +538,8 @@ class Pipe:
             )
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
+            if is_confirmation_text(latest_user_text):
+                return "State updated."
             return await self._forward_update(
                 body,
                 __user__,

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -19,9 +19,10 @@ Core decision handling remains the same as the base integration.
 
 import inspect
 import logging
+import re
 from importlib.resources import as_file, files
 from importlib.resources.abc import Traversable
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from fastapi import Request  # type: ignore[import-not-found]
 from open_webui.models.users import Users  # type: ignore[import-not-found]
@@ -44,6 +45,7 @@ except ModuleNotFoundError:
         return default
 
 
+import host_support.confirmation as _confirmation
 from context_compiler import State, create_engine, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
@@ -52,7 +54,6 @@ from experimental.preprocessor import (
     precompile_heuristic,
     render_prompt,
 )
-from host_support.confirmation import is_confirmation_text
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,8 @@ _ENGINES_BY_CHAT_KEY: dict[str, Engine] = {}
 # or restart continuity for pending flows will be lost.
 _CHECKPOINTS_BY_CHAT_KEY: dict[str, str] = {}
 _PROMPTS_DIR = files("experimental.preprocessor").joinpath("prompts")
+_NEGATIVE_CONFIRMATION_TOKENS = {"no", "nope", "no thanks"}
+_TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
 
 
 def _prompt_file_path(profile: str) -> Traversable:
@@ -145,8 +148,56 @@ def _replace_compiler_system_message(
     ]
 
 
-def _has_pending_clarification(engine: Engine) -> bool:
-    return engine.export_checkpoint()["pending"] is not None
+def _normalize_confirmation_for_summary(value: str) -> str:
+    normalized = value.strip().lower()
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = _TRAILING_CONFIRM_PUNCT_RE.sub("", normalized).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
+def _render_item_label(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _summarize_confirmation_update(user_input: str, pending: object) -> str:
+    summarize_fn = getattr(_confirmation, "summarize_confirmation_update", None)
+    if callable(summarize_fn):
+        return cast(str, summarize_fn(user_input, pending))
+
+    normalized = _normalize_confirmation_for_summary(user_input)
+    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
+        return "State unchanged."
+    if not isinstance(pending, dict):
+        return "State updated."
+
+    replacement = pending.get("replacement")
+    if not isinstance(replacement, dict):
+        return "State updated."
+
+    kind = replacement.get("kind")
+    new_item = replacement.get("new_item")
+    old_item = replacement.get("old_item")
+    if kind == "use_only" and isinstance(new_item, str):
+        new_label = _render_item_label(new_item)
+        if new_label:
+            return f"State updated: Use {new_label}."
+        return "State updated."
+
+    if kind == "replace_use" and isinstance(new_item, str) and isinstance(old_item, str):
+        new_label = _render_item_label(new_item)
+        old_label = _render_item_label(old_item)
+        if not new_label or not old_label:
+            return "State updated."
+        prompt = pending.get("prompt_to_user")
+        prohibited_old_prompt = (
+            f'"{old_item}" is currently prohibited. '
+            f'Did you mean to remove it and use "{new_item}" instead?'
+        )
+        if prompt == prohibited_old_prompt:
+            return f"State updated: Removed prohibition on {old_label}; use {new_label}."
+        return f"State updated: Replaced {old_label} with {new_label}."
+
+    return "State updated."
 
 
 def _extract_completion_content(response: object) -> str | None:
@@ -502,9 +553,12 @@ class Pipe:
                 engine.import_checkpoint_json(checkpoint)
             _ENGINES_BY_CHAT_KEY[chat_key] = engine
 
+        checkpoint_before = engine.export_checkpoint()
+        pending_before = checkpoint_before.get("pending")
+
         precompiled: str | None = None
         precompile_error: str | None = None
-        if not _has_pending_clarification(engine):
+        if pending_before is None:
             precompiled, precompile_error = await self._precompile_user_input(
                 latest_user_text,
                 engine.state,
@@ -538,8 +592,8 @@ class Pipe:
             )
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            if is_confirmation_text(latest_user_text):
-                return "State updated."
+            if _confirmation.is_confirmation_text(latest_user_text) and pending_before is not None:
+                return _summarize_confirmation_update(latest_user_text, pending_before)
             return await self._forward_update(
                 body,
                 __user__,

--- a/host_support/confirmation.py
+++ b/host_support/confirmation.py
@@ -1,0 +1,33 @@
+"""Host-support confirmation helpers aligned with directive grammar behavior.
+
+This module provides host-side logic for confirmation token handling. It mirrors
+the confirmation normalization and token behavior defined in
+`DirectiveGrammarSpec.md` and must stay aligned with that specification to avoid
+drift between engine and host behavior.
+"""
+
+import re
+
+_TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
+
+_AFFIRMATIVE_CONFIRMATION_TOKENS = frozenset(
+    {"yes", "yes please", "yep", "yeah", "sure", "ok", "okay"}
+)
+_NEGATIVE_CONFIRMATION_TOKENS = frozenset({"no", "nope", "no thanks"})
+
+CONFIRMATION_TOKENS: frozenset[str] = (
+    _AFFIRMATIVE_CONFIRMATION_TOKENS | _NEGATIVE_CONFIRMATION_TOKENS
+)
+
+
+def normalize_confirmation_text(value: str) -> str:
+    """Normalize confirmation text using directive grammar confirmation rules."""
+    normalized = value.strip().lower()
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = _TRAILING_CONFIRM_PUNCT_RE.sub("", normalized).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
+def is_confirmation_text(value: str) -> bool:
+    """Return whether input is a recognized confirmation token."""
+    return normalize_confirmation_text(value) in CONFIRMATION_TOKENS

--- a/host_support/confirmation.py
+++ b/host_support/confirmation.py
@@ -20,6 +20,10 @@ CONFIRMATION_TOKENS: frozenset[str] = (
 )
 
 
+def _render_item_label(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
 def _normalize_confirmation_text(value: str) -> str:
     """Normalize confirmation text using directive grammar confirmation rules."""
     normalized = value.strip().lower()
@@ -31,3 +35,52 @@ def _normalize_confirmation_text(value: str) -> str:
 def is_confirmation_text(value: str) -> bool:
     """Return whether input is a recognized confirmation token."""
     return _normalize_confirmation_text(value) in CONFIRMATION_TOKENS
+
+
+def summarize_confirmation_update(user_input: str, pending: object) -> str:
+    """Return deterministic host summary text for confirmation-only updates.
+
+    This helper is intentionally conservative:
+    - negative confirmations always return ``State unchanged.``
+    - affirmative confirmations return an exact deterministic summary only when
+      pending metadata unambiguously identifies the confirmed transition
+    - otherwise it falls back to ``State updated.``
+    """
+    normalized = _normalize_confirmation_text(user_input)
+    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
+        return "State unchanged."
+    if normalized not in _AFFIRMATIVE_CONFIRMATION_TOKENS:
+        return "State updated."
+    if not isinstance(pending, dict):
+        return "State updated."
+
+    replacement = pending.get("replacement")
+    if not isinstance(replacement, dict):
+        return "State updated."
+
+    kind = replacement.get("kind")
+    new_item = replacement.get("new_item")
+    old_item = replacement.get("old_item")
+
+    if kind == "use_only" and isinstance(new_item, str):
+        new_label = _render_item_label(new_item)
+        if new_label:
+            return f"State updated: Use {new_label}."
+        return "State updated."
+
+    if kind == "replace_use" and isinstance(new_item, str) and isinstance(old_item, str):
+        new_label = _render_item_label(new_item)
+        old_label = _render_item_label(old_item)
+        if not new_label or not old_label:
+            return "State updated."
+
+        prompt = pending.get("prompt_to_user")
+        prohibited_old_prompt = (
+            f'"{old_item}" is currently prohibited. '
+            f'Did you mean to remove it and use "{new_item}" instead?'
+        )
+        if prompt == prohibited_old_prompt:
+            return f"State updated: Removed prohibition on {old_label}; use {new_label}."
+        return f"State updated: Replaced {old_label} with {new_label}."
+
+    return "State updated."

--- a/host_support/confirmation.py
+++ b/host_support/confirmation.py
@@ -20,7 +20,7 @@ CONFIRMATION_TOKENS: frozenset[str] = (
 )
 
 
-def normalize_confirmation_text(value: str) -> str:
+def _normalize_confirmation_text(value: str) -> str:
     """Normalize confirmation text using directive grammar confirmation rules."""
     normalized = value.strip().lower()
     normalized = re.sub(r"\s+", " ", normalized)
@@ -30,4 +30,4 @@ def normalize_confirmation_text(value: str) -> str:
 
 def is_confirmation_text(value: str) -> bool:
     """Return whether input is a recognized confirmation token."""
-    return normalize_confirmation_text(value) in CONFIRMATION_TOKENS
+    return _normalize_confirmation_text(value) in CONFIRMATION_TOKENS

--- a/tests/test_host_confirmation.py
+++ b/tests/test_host_confirmation.py
@@ -1,0 +1,113 @@
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+import host_support.confirmation as _confirmation
+
+_EXPECTED_CONFIRMATION_TOKENS = frozenset(
+    {
+        "yes",
+        "yes please",
+        "yep",
+        "yeah",
+        "sure",
+        "ok",
+        "okay",
+        "no",
+        "nope",
+        "no thanks",
+    }
+)
+
+_TRAILING_PUNCT = st.text(alphabet=".,!?", min_size=0, max_size=4)
+_EDGE_WHITESPACE = st.text(alphabet=" \t\n\r", min_size=0, max_size=4)
+_INTERNAL_WHITESPACE = st.text(alphabet=" \t\n\r", min_size=1, max_size=4)
+
+
+def _apply_mixed_case(value: str, flags: list[bool]) -> str:
+    if not flags:
+        return value
+    chars: list[str] = []
+    for index, char in enumerate(value):
+        flag = flags[index % len(flags)]
+        chars.append(char.upper() if flag else char.lower())
+    return "".join(chars)
+
+
+def test_confirmation_tokens_match_spec_exactly() -> None:
+    assert _confirmation.CONFIRMATION_TOKENS == _EXPECTED_CONFIRMATION_TOKENS
+
+
+def test_normalize_confirmation_text_examples() -> None:
+    assert _confirmation.normalize_confirmation_text(" YES!  ") == "yes"
+    assert _confirmation.normalize_confirmation_text("yes   please.") == "yes please"
+    assert _confirmation.normalize_confirmation_text("no thanks.") == "no thanks"
+    assert _confirmation.normalize_confirmation_text("Okay??") == "okay"
+
+
+def test_is_confirmation_text_accepts_spec_tokens() -> None:
+    for token in sorted(_EXPECTED_CONFIRMATION_TOKENS):
+        assert _confirmation.is_confirmation_text(token)
+
+
+def test_is_confirmation_text_rejects_required_near_misses() -> None:
+    rejected = [
+        "y",
+        "n",
+        "yes but explain",
+        "okay now answer",
+        "sure, explain",
+        "",
+        "   \t\n  ",
+    ]
+    for value in rejected:
+        assert not _confirmation.is_confirmation_text(value)
+
+
+@given(
+    token=st.sampled_from(sorted(_EXPECTED_CONFIRMATION_TOKENS)),
+    leading_ws=_EDGE_WHITESPACE,
+    trailing_ws=_EDGE_WHITESPACE,
+    internal_ws=_INTERNAL_WHITESPACE,
+    trailing_punct=_TRAILING_PUNCT,
+    case_flags=st.lists(st.booleans(), min_size=1, max_size=8),
+)
+def test_accepted_tokens_survive_normalization_variants(
+    token: str,
+    leading_ws: str,
+    trailing_ws: str,
+    internal_ws: str,
+    trailing_punct: str,
+    case_flags: list[bool],
+) -> None:
+    spaced = token.replace(" ", internal_ws)
+    cased = _apply_mixed_case(spaced, case_flags)
+    candidate = f"{leading_ws}{cased}{trailing_punct}{trailing_ws}"
+    assert _confirmation.is_confirmation_text(candidate)
+
+
+@given(
+    token=st.sampled_from(sorted(_EXPECTED_CONFIRMATION_TOKENS)),
+    extra_text=st.text(
+        alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ",
+        min_size=1,
+        max_size=20,
+    ),
+)
+def test_semantic_extensions_after_valid_token_are_rejected(token: str, extra_text: str) -> None:
+    normalized_extra = _confirmation.normalize_confirmation_text(extra_text)
+    assume(normalized_extra != "")
+    candidate = f"{token} {extra_text}"
+    assert not _confirmation.is_confirmation_text(candidate)
+
+
+@given(
+    st.text(
+        alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,!?\t\n\r",
+        min_size=0,
+        max_size=40,
+    )
+)
+def test_non_token_strings_are_rejected(value: str) -> None:
+    normalized = _confirmation.normalize_confirmation_text(value)
+    assume(normalized not in _confirmation.CONFIRMATION_TOKENS)
+    assert not _confirmation.is_confirmation_text(value)

--- a/tests/test_host_confirmation.py
+++ b/tests/test_host_confirmation.py
@@ -40,11 +40,11 @@ def test_confirmation_tokens_match_spec_exactly() -> None:
     assert _confirmation.CONFIRMATION_TOKENS == _EXPECTED_CONFIRMATION_TOKENS
 
 
-def test_normalize_confirmation_text_examples() -> None:
-    assert _confirmation.normalize_confirmation_text(" YES!  ") == "yes"
-    assert _confirmation.normalize_confirmation_text("yes   please.") == "yes please"
-    assert _confirmation.normalize_confirmation_text("no thanks.") == "no thanks"
-    assert _confirmation.normalize_confirmation_text("Okay??") == "okay"
+def test_is_confirmation_text_normalization_examples() -> None:
+    assert _confirmation.is_confirmation_text(" YES!  ")
+    assert _confirmation.is_confirmation_text("yes   please.")
+    assert _confirmation.is_confirmation_text("no thanks.")
+    assert _confirmation.is_confirmation_text("Okay??")
 
 
 def test_is_confirmation_text_accepts_spec_tokens() -> None:
@@ -97,22 +97,20 @@ def test_accepted_tokens_survive_normalization_variants(
     ),
 )
 def test_semantic_extensions_after_valid_token_are_rejected(token: str, extra_text: str) -> None:
-    normalized_extra = _confirmation.normalize_confirmation_text(extra_text)
-    assume(normalized_extra != "")
+    assume(extra_text.strip() != "")
     candidate = f"{token} {extra_text}"
     assert not _confirmation.is_confirmation_text(candidate)
 
 
 @given(
     st.text(
-        alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,!?\t\n\r",
-        min_size=0,
+        alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+        min_size=1,
         max_size=40,
     )
 )
 def test_non_token_strings_are_rejected(value: str) -> None:
-    normalized = _confirmation.normalize_confirmation_text(value)
-    assume(normalized not in _confirmation.CONFIRMATION_TOKENS)
+    assume(value.lower() not in _confirmation.CONFIRMATION_TOKENS)
     assert not _confirmation.is_confirmation_text(value)
 
 

--- a/tests/test_host_confirmation.py
+++ b/tests/test_host_confirmation.py
@@ -1,7 +1,10 @@
+from typing import Any
+
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
 import host_support.confirmation as _confirmation
+from context_compiler import create_engine
 
 _EXPECTED_CONFIRMATION_TOKENS = frozenset(
     {
@@ -111,3 +114,80 @@ def test_non_token_strings_are_rejected(value: str) -> None:
     normalized = _confirmation.normalize_confirmation_text(value)
     assume(normalized not in _confirmation.CONFIRMATION_TOKENS)
     assert not _confirmation.is_confirmation_text(value)
+
+
+def _create_engine_with_pending_confirmation() -> tuple[Any, dict[str, object], str]:
+    engine = create_engine()
+    pre_pending_state = engine.state
+    first = engine.step("use docker instead of kubectl")
+    assert first["kind"] == "clarify"
+    pending_prompt = first["prompt_to_user"]
+    assert isinstance(pending_prompt, str)
+    checkpoint = engine.export_checkpoint()
+    assert checkpoint["pending"] is not None
+    return engine, pre_pending_state, pending_prompt
+
+
+def test_engine_host_confirmation_parity_for_required_candidates() -> None:
+    candidates = [
+        "yes",
+        "yes please",
+        "yep",
+        "yeah",
+        "sure",
+        "ok",
+        "okay",
+        "no",
+        "nope",
+        "no thanks",
+        "YES!",
+        " yes please ",
+        "no thanks.",
+        "y",
+        "n",
+        "yes but explain",
+        "okay now answer",
+        "sure, explain",
+        "",
+        " \t\n ",
+    ]
+
+    for candidate in candidates:
+        host_accepts = _confirmation.is_confirmation_text(candidate)
+        engine, pre_pending_state, pending_prompt = _create_engine_with_pending_confirmation()
+
+        decision = engine.step(candidate)
+        checkpoint = engine.export_checkpoint()
+
+        if host_accepts:
+            assert decision["kind"] == "update"
+            assert checkpoint["pending"] is None
+        else:
+            assert decision["kind"] == "clarify"
+            assert decision["prompt_to_user"] == pending_prompt
+            assert engine.state == pre_pending_state
+            assert checkpoint["pending"] is not None
+
+
+@given(
+    st.text(
+        alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,!?\t\n\r",
+        min_size=0,
+        max_size=40,
+    )
+)
+def test_engine_host_confirmation_parity_property(value: str) -> None:
+    host_accepts = _confirmation.is_confirmation_text(value)
+    engine, pre_pending_state, pending_prompt = _create_engine_with_pending_confirmation()
+
+    decision = engine.step(value)
+    checkpoint = engine.export_checkpoint()
+    engine_resolved = decision["kind"] == "update"
+
+    assert engine_resolved == host_accepts
+    if host_accepts:
+        assert checkpoint["pending"] is None
+    else:
+        assert decision["prompt_to_user"] == pending_prompt
+        assert engine.state == pre_pending_state
+        assert checkpoint["pending"] is not None

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -239,3 +239,62 @@ def test_litellm_with_preprocessor_checkpoint_resume_yes_no_end_to_end(
     finally:
         module._call_litellm = call_litellm
         module._precompile_user_input = precompile_user_input
+
+
+@pytest.mark.parametrize(
+    ("confirmation", "expected_policies"),
+    [
+        ("yes", {"docker": "use"}),
+        ("YES!", {"docker": "use"}),
+        (" yes please ", {"docker": "use"}),
+        ("no thanks.", {}),
+    ],
+)
+def test_litellm_basic_confirmation_update_returns_ack_without_downstream_model_call(
+    confirmation: str, expected_policies: dict[str, str]
+) -> None:
+    module = _load_module(
+        "litellm_basic_confirmation_ack",
+        Path("examples/integrations/litellm/basic.py"),
+    )
+    checkpoints = cast(dict[str, str], module._CHECKPOINTS_BY_SESSION_KEY)
+    restored = cast(dict[str, int], module._RESTORED_ENGINE_BY_SESSION_KEY)
+    checkpoints.clear()
+    restored.clear()
+
+    call_litellm = cast(Any, module._call_litellm)
+    litellm_calls = 0
+
+    def _track_litellm(_messages: list[dict[str, str]]) -> str:
+        nonlocal litellm_calls
+        litellm_calls += 1
+        raise AssertionError("downstream model should not be called")
+
+    module._call_litellm = _track_litellm
+    session_key = "basic-confirmation-ack"
+
+    try:
+        first_engine = create_engine()
+        clarify = module.handle_turn(
+            "use docker instead of kubectl",
+            first_engine,
+            session_key=session_key,
+        )
+        assert clarify == 'Did you mean to use "docker" instead?'
+        assert session_key in checkpoints
+        first_checkpoint = json.loads(checkpoints[session_key])
+        assert first_checkpoint["pending"] is not None
+
+        second_engine = create_engine()
+        resumed = module.handle_turn(confirmation, second_engine, session_key=session_key)
+        assert resumed == "State updated."
+        assert litellm_calls == 0
+        assert second_engine.state == {
+            "premise": None,
+            "policies": expected_policies,
+            "version": 2,
+        }
+        resumed_checkpoint = json.loads(checkpoints[session_key])
+        assert resumed_checkpoint["pending"] is None
+    finally:
+        module._call_litellm = call_litellm

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -108,8 +108,16 @@ def test_litellm_with_preprocessor_checkpoint_restore_and_persist_points() -> No
     _assert_checkpoint_behavior(module)
 
 
-@pytest.mark.parametrize("confirmation", ["yes", "no"])
-def test_litellm_with_preprocessor_bypasses_precompile_while_pending(confirmation: str) -> None:
+@pytest.mark.parametrize(
+    ("confirmation", "expected_response"),
+    [
+        ("yes", "State updated: Use kubectl."),
+        ("no", "State unchanged."),
+    ],
+)
+def test_litellm_with_preprocessor_bypasses_precompile_while_pending(
+    confirmation: str, expected_response: str
+) -> None:
     module = _load_module(
         "litellm_with_preprocessor_pending_bypass",
         Path("examples/integrations/litellm/with_preprocessor.py"),
@@ -166,20 +174,20 @@ def test_litellm_with_preprocessor_bypasses_precompile_while_pending(confirmatio
         module._call_litellm = call_litellm
         module._precompile_user_input = precompile_user_input
 
-    assert result == "State updated."
+    assert result == expected_response
     assert engine.step_inputs == [confirmation]
     assert litellm_calls == 0
 
 
 @pytest.mark.parametrize(
-    ("confirmation", "expected_policies"),
+    ("confirmation", "expected_policies", "expected_response"),
     [
-        ("yes", {"kubectl": "use"}),
-        ("no", {}),
+        ("yes", {"kubectl": "use"}, "State updated: Use kubectl."),
+        ("no", {}, "State unchanged."),
     ],
 )
 def test_litellm_with_preprocessor_checkpoint_resume_yes_no_end_to_end(
-    confirmation: str, expected_policies: dict[str, str]
+    confirmation: str, expected_policies: dict[str, str], expected_response: str
 ) -> None:
     module = _load_module(
         "litellm_with_preprocessor_checkpoint_resume_e2e",
@@ -227,7 +235,7 @@ def test_litellm_with_preprocessor_checkpoint_resume_yes_no_end_to_end(
         module._precompile_user_input = _fail_precompile
         second_engine = create_engine()
         resumed = module.handle_turn(confirmation, second_engine, session_key=session_key)
-        assert resumed == "State updated."
+        assert resumed == expected_response
         assert second_engine.state == {
             "premise": None,
             "policies": expected_policies,
@@ -242,16 +250,16 @@ def test_litellm_with_preprocessor_checkpoint_resume_yes_no_end_to_end(
 
 
 @pytest.mark.parametrize(
-    ("confirmation", "expected_policies"),
+    ("confirmation", "expected_policies", "expected_response"),
     [
-        ("yes", {"docker": "use"}),
-        ("YES!", {"docker": "use"}),
-        (" yes please ", {"docker": "use"}),
-        ("no thanks.", {}),
+        ("yes", {"docker": "use"}, "State updated: Use docker."),
+        ("YES!", {"docker": "use"}, "State updated: Use docker."),
+        (" yes please ", {"docker": "use"}, "State updated: Use docker."),
+        ("no thanks.", {}, "State unchanged."),
     ],
 )
 def test_litellm_basic_confirmation_update_returns_ack_without_downstream_model_call(
-    confirmation: str, expected_policies: dict[str, str]
+    confirmation: str, expected_policies: dict[str, str], expected_response: str
 ) -> None:
     module = _load_module(
         "litellm_basic_confirmation_ack",
@@ -287,7 +295,7 @@ def test_litellm_basic_confirmation_update_returns_ack_without_downstream_model_
 
         second_engine = create_engine()
         resumed = module.handle_turn(confirmation, second_engine, session_key=session_key)
-        assert resumed == "State updated."
+        assert resumed == expected_response
         assert litellm_calls == 0
         assert second_engine.state == {
             "premise": None,
@@ -298,3 +306,127 @@ def test_litellm_basic_confirmation_update_returns_ack_without_downstream_model_
         assert resumed_checkpoint["pending"] is None
     finally:
         module._call_litellm = call_litellm
+
+
+def test_litellm_basic_confirmation_summary_true_replacement() -> None:
+    module = _load_module(
+        "litellm_basic_confirmation_replace_summary",
+        Path("examples/integrations/litellm/basic.py"),
+    )
+    checkpoints = cast(dict[str, str], module._CHECKPOINTS_BY_SESSION_KEY)
+    restored = cast(dict[str, int], module._RESTORED_ENGINE_BY_SESSION_KEY)
+    checkpoints.clear()
+    restored.clear()
+
+    call_litellm = cast(Any, module._call_litellm)
+    module._call_litellm = lambda _messages: "ok"
+    session_key = "basic-replace-summary"
+
+    try:
+        engine = create_engine()
+        assert module.handle_turn("use podman", engine, session_key=session_key) == "ok"
+        assert module.handle_turn("prohibit docker", engine, session_key=session_key) == "ok"
+        clarify = module.handle_turn(
+            "use docker instead of podman", engine, session_key=session_key
+        )
+        assert (
+            clarify == '"docker" is currently prohibited. '
+            'Did you mean to remove "podman" and use "docker" instead?'
+        )
+
+        resumed = module.handle_turn("yes", create_engine(), session_key=session_key)
+        assert resumed == "State updated: Replaced podman with docker."
+    finally:
+        module._call_litellm = call_litellm
+
+
+def test_litellm_basic_confirmation_summary_prohibited_old_replacement() -> None:
+    module = _load_module(
+        "litellm_basic_confirmation_prohibited_old_summary",
+        Path("examples/integrations/litellm/basic.py"),
+    )
+    checkpoints = cast(dict[str, str], module._CHECKPOINTS_BY_SESSION_KEY)
+    restored = cast(dict[str, int], module._RESTORED_ENGINE_BY_SESSION_KEY)
+    checkpoints.clear()
+    restored.clear()
+
+    call_litellm = cast(Any, module._call_litellm)
+    module._call_litellm = lambda _messages: "ok"
+    session_key = "basic-prohibited-old-summary"
+
+    try:
+        engine = create_engine()
+        assert module.handle_turn("prohibit docker", engine, session_key=session_key) == "ok"
+        clarify = module.handle_turn(
+            "use podman instead of docker", engine, session_key=session_key
+        )
+        assert (
+            clarify == '"docker" is currently prohibited. '
+            'Did you mean to remove it and use "podman" instead?'
+        )
+
+        resumed = module.handle_turn("yes", create_engine(), session_key=session_key)
+        assert resumed == "State updated: Removed prohibition on docker; use podman."
+    finally:
+        module._call_litellm = call_litellm
+
+
+def test_litellm_basic_confirmation_summary_falls_back_for_unknown_pending_shape() -> None:
+    module = _load_module(
+        "litellm_basic_confirmation_summary_fallback",
+        Path("examples/integrations/litellm/basic.py"),
+    )
+
+    class _FallbackPendingEngine:
+        def __init__(self) -> None:
+            self.state: dict[str, object] = {"premise": None, "policies": {}, "version": 2}
+            self._pending = {
+                "kind": "replacement",
+                "replacement": {
+                    "kind": "unknown_kind",
+                    "new_item": "docker",
+                    "old_item": "podman",
+                },
+                "prompt_to_user": "confirm?",
+            }
+
+        def export_checkpoint(self) -> dict[str, object]:
+            return {
+                "checkpoint_version": 1,
+                "authoritative_state": self.state,
+                "pending": self._pending,
+            }
+
+        def export_checkpoint_json(self) -> str:
+            return "ckpt-fallback"
+
+        def step(self, _text: str) -> dict[str, object]:
+            self._pending = None
+            return {"kind": "update", "state": self.state}
+
+    checkpoints = cast(dict[str, str], module._CHECKPOINTS_BY_SESSION_KEY)
+    restored = cast(dict[str, int], module._RESTORED_ENGINE_BY_SESSION_KEY)
+    checkpoints.clear()
+    restored.clear()
+
+    call_litellm = cast(Any, module._call_litellm)
+    litellm_calls = 0
+
+    def _track_litellm(_messages: list[dict[str, str]]) -> str:
+        nonlocal litellm_calls
+        litellm_calls += 1
+        return "ok"
+
+    module._call_litellm = _track_litellm
+    try:
+        result = module.handle_turn(
+            "yes",
+            _FallbackPendingEngine(),
+            session_key="basic-summary-fallback",
+        )
+    finally:
+        module._call_litellm = call_litellm
+
+    assert result == "State updated."
+    assert litellm_calls == 0
+    assert checkpoints["basic-summary-fallback"] == "ckpt-fallback"

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -150,7 +150,14 @@ def test_litellm_with_preprocessor_bypasses_precompile_while_pending(confirmatio
     def _fail_precompile(_text: str, _state: dict[str, object]) -> None:
         raise AssertionError("should not precompile")
 
-    module._call_litellm = lambda _messages: "ok"
+    litellm_calls = 0
+
+    def _track_litellm(_messages: list[dict[str, str]]) -> str:
+        nonlocal litellm_calls
+        litellm_calls += 1
+        return "ok"
+
+    module._call_litellm = _track_litellm
     module._precompile_user_input = _fail_precompile
     try:
         engine = _PendingEngine()
@@ -159,8 +166,9 @@ def test_litellm_with_preprocessor_bypasses_precompile_while_pending(confirmatio
         module._call_litellm = call_litellm
         module._precompile_user_input = precompile_user_input
 
-    assert result == "ok"
+    assert result == "State updated."
     assert engine.step_inputs == [confirmation]
+    assert litellm_calls == 0
 
 
 @pytest.mark.parametrize(
@@ -194,7 +202,14 @@ def test_litellm_with_preprocessor_checkpoint_resume_yes_no_end_to_end(
     def _fail_precompile(_text: str, _state: dict[str, object]) -> None:
         raise AssertionError("precompile should be bypassed while pending is restored")
 
-    module._call_litellm = lambda _messages: "ok"
+    litellm_calls = 0
+
+    def _track_litellm(_messages: list[dict[str, str]]) -> str:
+        nonlocal litellm_calls
+        litellm_calls += 1
+        return "ok"
+
+    module._call_litellm = _track_litellm
     module._precompile_user_input = _precompile_before_pending
     session_key = "resume-e2e"
 
@@ -212,7 +227,7 @@ def test_litellm_with_preprocessor_checkpoint_resume_yes_no_end_to_end(
         module._precompile_user_input = _fail_precompile
         second_engine = create_engine()
         resumed = module.handle_turn(confirmation, second_engine, session_key=session_key)
-        assert resumed == "ok"
+        assert resumed == "State updated."
         assert second_engine.state == {
             "premise": None,
             "policies": expected_policies,
@@ -220,6 +235,7 @@ def test_litellm_with_preprocessor_checkpoint_resume_yes_no_end_to_end(
         }
         resumed_checkpoint = json.loads(checkpoints[session_key])
         assert resumed_checkpoint["pending"] is None
+        assert litellm_calls == 0
     finally:
         module._call_litellm = call_litellm
         module._precompile_user_input = precompile_user_input

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -261,6 +261,62 @@ def test_pipe_supports_async_user_lookup(monkeypatch) -> None:
     assert isinstance(result, dict)
 
 
+def test_pipe_normal_update_forwards_and_persists_checkpoint(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_update_forward", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    forwarded_payloads: list[dict[str, object]] = []
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        forwarded_payloads.append(payload)
+        return {"ok": True}
+
+    module.generate_chat_completion = _chat_completion
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    chat_key = "chat-normal-update"
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "prohibit peanuts"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_key,
+        )
+    )
+
+    assert result == {"ok": True}
+    assert len(forwarded_payloads) == 1
+
+    payload = forwarded_payloads[0]
+    assert payload["model"] == "base-model"
+    messages = payload.get("messages")
+    assert isinstance(messages, list)
+    state_messages = [
+        msg
+        for msg in messages
+        if isinstance(msg, dict)
+        and msg.get("role") == "system"
+        and isinstance(msg.get("content"), str)
+        and msg["content"].startswith("[[cc_state]]")
+    ]
+    assert len(state_messages) == 1
+    state_block = state_messages[0]["content"]
+    assert isinstance(state_block, str)
+    assert "Prohibit: peanuts" in state_block
+
+    checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
+    assert checkpoint["pending"] is None
+    assert checkpoint["authoritative_state"]["policies"] == {"peanuts": "prohibit"}
+
+
 @pytest.mark.parametrize(
     ("confirmation", "expected_policies", "expected_response"),
     [

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -94,6 +94,13 @@ def test_pipe_restore_and_persist_checkpoint_points(monkeypatch) -> None:
             self.export_calls += 1
             return self._checkpoint_out
 
+        def export_checkpoint(self) -> dict[str, object]:
+            return {
+                "checkpoint_version": 1,
+                "authoritative_state": self.state,
+                "pending": None,
+            }
+
         def step(self, _text: str) -> dict[str, object]:
             if self.kind == "clarify":
                 return {"kind": "clarify", "prompt_to_user": "confirm?", "state": None}
@@ -255,16 +262,19 @@ def test_pipe_supports_async_user_lookup(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("confirmation", "expected_policies"),
+    ("confirmation", "expected_policies", "expected_response"),
     [
-        ("yes", {"docker": "use"}),
-        ("YES!", {"docker": "use"}),
-        (" yes please ", {"docker": "use"}),
-        ("no thanks.", {}),
+        ("yes", {"docker": "use"}, "State updated: Use docker."),
+        ("YES!", {"docker": "use"}, "State updated: Use docker."),
+        (" yes please ", {"docker": "use"}, "State updated: Use docker."),
+        ("no thanks.", {}, "State unchanged."),
     ],
 )
 def test_pipe_confirmation_update_returns_ack_without_downstream_model_call(
-    monkeypatch, confirmation: str, expected_policies: dict[str, str]
+    monkeypatch,
+    confirmation: str,
+    expected_policies: dict[str, str],
+    expected_response: str,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_pipe_confirmation_ack", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
@@ -311,7 +321,7 @@ def test_pipe_confirmation_update_returns_ack_without_downstream_model_call(
             __chat_id__=chat_key,
         )
     )
-    assert resumed == "State updated."
+    assert resumed == expected_response
     assert downstream_calls == 0
 
     resumed_engine = module._ENGINES_BY_CHAT_KEY[chat_key]

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -1,9 +1,12 @@
 import asyncio
 import builtins
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
+
+import pytest
 
 MODULE_PATH = Path("examples/integrations/openwebui/open_webui_pipe.py")
 
@@ -249,3 +252,73 @@ def test_pipe_supports_async_user_lookup(monkeypatch) -> None:
     )
 
     assert isinstance(result, dict)
+
+
+@pytest.mark.parametrize(
+    ("confirmation", "expected_policies"),
+    [
+        ("yes", {"docker": "use"}),
+        ("YES!", {"docker": "use"}),
+        (" yes please ", {"docker": "use"}),
+        ("no thanks.", {}),
+    ],
+)
+def test_pipe_confirmation_update_returns_ack_without_downstream_model_call(
+    monkeypatch, confirmation: str, expected_policies: dict[str, str]
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_confirmation_ack", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    downstream_calls = 0
+
+    async def _track_downstream(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+
+    module.generate_chat_completion = _track_downstream
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    chat_key = "chat-confirm-ack"
+
+    clarify = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "use docker instead of kubectl"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_key,
+        )
+    )
+    assert clarify == 'Did you mean to use "docker" instead?'
+    first_checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
+    assert first_checkpoint["pending"] is not None
+
+    resumed = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": confirmation}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_key,
+        )
+    )
+    assert resumed == "State updated."
+    assert downstream_calls == 0
+
+    resumed_engine = module._ENGINES_BY_CHAT_KEY[chat_key]
+    assert resumed_engine.state == {
+        "premise": None,
+        "policies": expected_policies,
+        "version": 2,
+    }
+    resumed_checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
+    assert resumed_checkpoint["pending"] is None

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -449,6 +449,13 @@ def test_preprocessor_pipe_bypasses_precompile_while_pending(
 
     monkeypatch.setattr(module, "precompile_heuristic", _fail_precompile)
 
+    async def _fail_downstream_model(
+        _: object, payload: dict[str, Any], __: object
+    ) -> dict[str, object]:
+        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+
+    monkeypatch.setattr(module, "generate_chat_completion", _fail_downstream_model)
+
     pipe = module.Pipe()
     pipe.valves.BASE_MODEL_ID = "base-model"
     pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
@@ -462,8 +469,9 @@ def test_preprocessor_pipe_bypasses_precompile_while_pending(
         )
     )
 
-    assert isinstance(result, dict)
+    assert result == "State updated."
     assert engine.step_inputs == [confirmation]
+    assert module._CHECKPOINTS_BY_CHAT_KEY["chat-pending"] == "ckpt-out"
 
 
 @pytest.mark.parametrize(
@@ -511,6 +519,14 @@ def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
     assert heuristic_inputs == ["use kubectl instead of docker"]
 
     module._ENGINES_BY_CHAT_KEY.clear()
+
+    async def _fail_downstream_model(
+        _: object, payload: dict[str, Any], __: object
+    ) -> dict[str, object]:
+        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+
+    monkeypatch.setattr(module, "generate_chat_completion", _fail_downstream_model)
+
     resumed = asyncio.run(
         pipe.pipe(
             {
@@ -522,7 +538,7 @@ def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
             __chat_id__=chat_key,
         )
     )
-    assert isinstance(resumed, dict)
+    assert resumed == "State updated."
     resumed_engine = cast(Any, module._ENGINES_BY_CHAT_KEY[chat_key])
     assert resumed_engine.state == {
         "premise": None,

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -401,9 +401,15 @@ def test_preprocessor_pipe_restore_and_persist_checkpoint_points(monkeypatch) ->
     assert module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] == "ckpt-keep"
 
 
-@pytest.mark.parametrize("confirmation", ["yes", "no"])
+@pytest.mark.parametrize(
+    ("confirmation", "expected_response"),
+    [
+        ("yes", "State updated: Use kubectl."),
+        ("no", "State unchanged."),
+    ],
+)
 def test_preprocessor_pipe_bypasses_precompile_while_pending(
-    monkeypatch, confirmation: str
+    monkeypatch, confirmation: str, expected_response: str
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_pending_bypass", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
@@ -469,20 +475,23 @@ def test_preprocessor_pipe_bypasses_precompile_while_pending(
         )
     )
 
-    assert result == "State updated."
+    assert result == expected_response
     assert engine.step_inputs == [confirmation]
     assert module._CHECKPOINTS_BY_CHAT_KEY["chat-pending"] == "ckpt-out"
 
 
 @pytest.mark.parametrize(
-    ("confirmation", "expected_policies"),
+    ("confirmation", "expected_policies", "expected_response"),
     [
-        ("yes", {"kubectl": "use"}),
-        ("no", {}),
+        ("yes", {"kubectl": "use"}, "State updated: Use kubectl."),
+        ("no", {}, "State unchanged."),
     ],
 )
 def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
-    monkeypatch, confirmation: str, expected_policies: dict[str, str]
+    monkeypatch,
+    confirmation: str,
+    expected_policies: dict[str, str],
+    expected_response: str,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_resume_e2e", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
@@ -538,7 +547,7 @@ def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
             __chat_id__=chat_key,
         )
     )
-    assert resumed == "State updated."
+    assert resumed == expected_response
     resumed_engine = cast(Any, module._ENGINES_BY_CHAT_KEY[chat_key])
     assert resumed_engine.state == {
         "premise": None,

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -401,6 +401,73 @@ def test_preprocessor_pipe_restore_and_persist_checkpoint_points(monkeypatch) ->
     assert module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] == "ckpt-keep"
 
 
+def test_preprocessor_pipe_normal_update_forwards_and_persists_checkpoint(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_update_forward", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    monkeypatch.setattr(
+        module,
+        "precompile_heuristic",
+        lambda _text: {
+            "outcome": module.PRECOMPILE_OUTCOME_DIRECTIVE,
+            "directive": "prohibit peanuts",
+        },
+    )
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
+
+    forwarded_payloads: list[dict[str, object]] = []
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        forwarded_payloads.append(payload)
+        return {"ok": True}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    chat_key = "chat-preproc-update"
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "please disallow peanuts"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_key,
+        )
+    )
+
+    assert result == {"ok": True}
+    assert len(forwarded_payloads) == 1
+
+    payload = forwarded_payloads[0]
+    assert payload["model"] == "base-model"
+    messages = payload.get("messages")
+    assert isinstance(messages, list)
+    state_messages = [
+        msg
+        for msg in messages
+        if isinstance(msg, dict)
+        and msg.get("role") == "system"
+        and isinstance(msg.get("content"), str)
+        and msg["content"].startswith("[[cc_state]]")
+    ]
+    assert len(state_messages) == 1
+    state_block = state_messages[0]["content"]
+    assert isinstance(state_block, str)
+    assert "Prohibit: peanuts" in state_block
+
+    checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
+    assert checkpoint["pending"] is None
+    assert checkpoint["authoritative_state"]["policies"] == {"peanuts": "prohibit"}
+
+
 @pytest.mark.parametrize(
     ("confirmation", "expected_response"),
     [


### PR DESCRIPTION
## What changed

- Added host confirmation support for detecting confirmation-only turns.
- Suppressed downstream model calls when pending clarifications resolve via confirmation tokens.
- Added deterministic confirmation summaries, including:
  - `State updated: Use ...`
  - `State updated: Replaced ... with ...`
  - `State updated: Removed prohibition on ...; use ...`
  - `State unchanged.`
- Applied behavior consistently across Open WebUI and LiteLLM integrations.
- Added helper, parity, Hypothesis, and integration regression coverage.

## Why

Confirmation-only turns like `yes` previously resolved pending compiler state, then forwarded `yes` to the downstream model. That produced confusing model output and wasted tokens.

This keeps confirmation resolution deterministic and visibly host-owned.
