### PR TITLE
Update Open WebUI model-not-found guidance

### DIFF
--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -29,6 +29,14 @@ Note: The `PROVIDER` environment contract used in LiteLLM examples/demos does no
 
 Checkpoint continuation in these examples requires `context-compiler>=0.6.10`.
 
+### Model configuration
+
+- Open: `http://localhost:3000/admin/functions`
+- Verify `BASE_MODEL_ID` matches an existing Open WebUI model id exactly.
+- Example:
+  - `BASE_MODEL_ID = llama3.1:8b`
+- Model ids are configured in: `Admin Panel → Settings → Models`
+
 If using `open_webui_pipe_with_preprocessor.py`:
 - Install preprocessor support in the Open WebUI environment:
   - `pip install "context-compiler[experimental]"`

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -223,7 +223,11 @@ class Pipe:
     class Valves(BaseModel):
         BASE_MODEL_ID: str = Field(
             default="",
-            description="Open WebUI model id used as the base model for forwarding.",
+            description=(
+                "Required Open WebUI model id used for forwarding. Must exactly match a "
+                "configured model id in Open WebUI (not arbitrary text), for example: "
+                "llama3.1:8b."
+            ),
         )
 
     def __init__(self) -> None:
@@ -246,8 +250,9 @@ class Pipe:
     def _normalize_forward_error(self, response: Any) -> str | None:
         if self._contains_model_not_found(response):
             return (
-                "Context Compiler pipe misconfigured: BASE_MODEL_ID was not found "
-                "in Open WebUI models."
+                "Context Compiler pipe misconfigured: BASE_MODEL_ID is invalid or not "
+                "configured in Open WebUI. Configure a valid model id in "
+                "Admin Panel → Settings → Models."
             )
         return None
 
@@ -255,8 +260,9 @@ class Pipe:
         detail = getattr(exc, "detail", None)
         if self._contains_model_not_found(detail) or self._contains_model_not_found(str(exc)):
             return (
-                "Context Compiler pipe misconfigured: BASE_MODEL_ID was not found "
-                "in Open WebUI models."
+                "Context Compiler pipe misconfigured: BASE_MODEL_ID is invalid or not "
+                "configured in Open WebUI. Configure a valid model id in "
+                "Admin Panel → Settings → Models."
             )
         return None
 

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -233,7 +233,11 @@ class Pipe:
     class Valves(BaseModel):
         BASE_MODEL_ID: str = Field(
             default="",
-            description="Open WebUI model id used as the base model for forwarding.",
+            description=(
+                "Required Open WebUI model id used for forwarding. Must exactly match a "
+                "configured model id in Open WebUI (not arbitrary text), for example: "
+                "llama3.1:8b."
+            ),
         )
         PREPROCESSOR_MODEL_ID: str = Field(
             default="",
@@ -270,8 +274,9 @@ class Pipe:
     def _normalize_forward_error(self, response: Any) -> str | None:
         if self._contains_model_not_found(response):
             return (
-                "Context Compiler pipe misconfigured: BASE_MODEL_ID was not found "
-                "in Open WebUI models."
+                "Context Compiler pipe misconfigured: BASE_MODEL_ID is invalid or not "
+                "configured in Open WebUI. Configure a valid model id in "
+                "Admin Panel → Settings → Models."
             )
         return None
 
@@ -279,16 +284,18 @@ class Pipe:
         detail = getattr(exc, "detail", None)
         if self._contains_model_not_found(detail) or self._contains_model_not_found(str(exc)):
             return (
-                "Context Compiler pipe misconfigured: BASE_MODEL_ID was not found "
-                "in Open WebUI models."
+                "Context Compiler pipe misconfigured: BASE_MODEL_ID is invalid or not "
+                "configured in Open WebUI. Configure a valid model id in "
+                "Admin Panel → Settings → Models."
             )
         return None
 
     def _normalize_preprocessor_error(self, response: Any) -> str | None:
         if self._contains_model_not_found(response):
             return (
-                "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID was not found "
-                "in Open WebUI models."
+                "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID is invalid or "
+                "not configured in Open WebUI. Configure a valid model id in "
+                "Admin Panel → Settings → Models."
             )
         return None
 
@@ -296,8 +303,9 @@ class Pipe:
         detail = getattr(exc, "detail", None)
         if self._contains_model_not_found(detail) or self._contains_model_not_found(str(exc)):
             return (
-                "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID was not found "
-                "in Open WebUI models."
+                "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID is invalid or "
+                "not configured in Open WebUI. Configure a valid model id in "
+                "Admin Panel → Settings → Models."
             )
         return None
 

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -205,7 +205,9 @@ def test_pipe_normalizes_model_not_found_response(monkeypatch) -> None:
     )
 
     assert result == (
-        "Context Compiler pipe misconfigured: BASE_MODEL_ID was not found in Open WebUI models."
+        "Context Compiler pipe misconfigured: BASE_MODEL_ID is invalid or not "
+        "configured in Open WebUI. Configure a valid model id in "
+        "Admin Panel → Settings → Models."
     )
 
 
@@ -236,7 +238,9 @@ def test_pipe_normalizes_model_not_found_exception(monkeypatch) -> None:
     )
 
     assert result == (
-        "Context Compiler pipe misconfigured: BASE_MODEL_ID was not found in Open WebUI models."
+        "Context Compiler pipe misconfigured: BASE_MODEL_ID is invalid or not "
+        "configured in Open WebUI. Configure a valid model id in "
+        "Admin Panel → Settings → Models."
     )
 
 

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -274,8 +274,9 @@ def test_pipe_normalizes_preprocessor_model_not_found_response(monkeypatch) -> N
     )
 
     assert result == (
-        "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID was not found "
-        "in Open WebUI models."
+        "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID is invalid or "
+        "not configured in Open WebUI. Configure a valid model id in "
+        "Admin Panel → Settings → Models."
     )
 
 
@@ -309,8 +310,9 @@ def test_pipe_normalizes_preprocessor_model_not_found_exception(monkeypatch) -> 
     )
 
     assert result == (
-        "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID was not found "
-        "in Open WebUI models."
+        "Context Compiler pipe misconfigured: PREPROCESSOR_MODEL_ID is invalid or "
+        "not configured in Open WebUI. Configure a valid model id in "
+        "Admin Panel → Settings → Models."
     )
 
 


### PR DESCRIPTION
## Summary
- Clarify `BASE_MODEL_ID` setup in both Open WebUI example pipes so it is explicit that the value must exactly match a configured Open WebUI model id.
- Replace vague model-not-found messages with deterministic, actionable guidance that points users to `Admin Panel → Settings → Models`.
- Update Open WebUI test expectations to match the new wording for base and preprocessor model lookup failures.

## Testing
- Updated unit tests to assert the new deterministic error strings.
- Not run (not requested).