### PR TITLE
codex/0.6.11 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,11 @@ repos:
           - hypothesis
           - litellm
           - pydantic
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: uv run pytest
+        language: system
+        pass_filenames: false

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -3,8 +3,8 @@ title: Context Compiler Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.4
-requirements: context-compiler>=0.6.10
+version: 0.5
+requirements: context-compiler>=0.6.11
 
 Minimal Open WebUI Pipe integration for Context Compiler.
 

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -3,8 +3,8 @@ title: Context Compiler Preprocessor Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.4
-requirements: context-compiler[experimental]>=0.6.10
+version: 0.5
+requirements: context-compiler[experimental]>=0.6.11
 
 Open WebUI integration with Context Compiler preprocessor.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.10"
+version = "0.6.11"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,5 +93,5 @@ markers = [
 ]
 
 [tool.coverage.run]
-source = ["context_compiler"]
+source = ["context_compiler", "host_support"]
 omit = ["demos/*", "evals/*", "tests/*"]

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.10"
+version = "0.6.11"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- Included `host_support` in coverage configuration.
- Added `pytest` to pre-commit to enforce full test runs on commit.
- Updated Open WebUI integration requirements to `context-compiler>=0.6.11`.
- Bumped package version to `0.6.11`.

## Why

This PR prepares the repository for release by:

- Ensuring all shipped modules are covered by tests
- Enforcing the required test workflow at commit time
- Aligning integration metadata with the new release version

## Scope

- No engine behavior changes
- No directive grammar changes
- No Decision API changes
- No integration behavior changes

This is a release hygiene / metadata update only.