### PR TITLE
feat: make openwebui update deterministic and clarify docs

### DIFF
--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -80,7 +80,9 @@ Use the Open WebUI model picker/list to copy exact model ids for `BASE_MODEL_ID`
 
 ## Manual Validation
 
-Validate clarify short-circuit, passthrough forwarding, update injection with one `[[cc_state]]`, no accumulation across repeated updates, chat isolation with real chat ids, restart state loss, and non-text bypass behavior.
+Validate clarify short-circuit, passthrough forwarding, deterministic update acknowledgments with no downstream forward, chat isolation with real chat ids, restart state loss, and non-text bypass behavior.
+
+Note: In the OpenWebUI example pipes, update decisions are rendered deterministically and do not call the downstream LLM. This makes state transitions explicit. Production hosts may choose different rendering behavior.
 
 ## Behavioral comparisons
 

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -3,7 +3,7 @@ title: Context Compiler Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.5
+version: 0.6
 requirements: context-compiler>=0.6.11
 
 Minimal Open WebUI Pipe integration for Context Compiler.

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -171,6 +171,36 @@ def _render_item_label(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip()
 
 
+def _summarize_update_from_input(user_input: str) -> str:
+    normalized = re.sub(r"\s+", " ", user_input.strip())
+    lower = normalized.lower()
+
+    if lower == "clear state":
+        return "State cleared."
+    if lower == "reset policies":
+        return "Policies reset."
+
+    use_match = re.match(r"^use\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if use_match is not None:
+        item = _render_item_label(use_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Use {item}."
+
+    prohibit_match = re.match(r"^prohibit\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if prohibit_match is not None:
+        item = _render_item_label(prohibit_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Prohibit {item}."
+
+    remove_policy_match = re.match(r"^remove\s+policy\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if remove_policy_match is not None:
+        item = _render_item_label(remove_policy_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Removed policy {item}."
+
+    return "State updated."
+
+
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:
     summarize_fn = getattr(_confirmation, "summarize_confirmation_update", None)
     if callable(summarize_fn):
@@ -217,7 +247,7 @@ class Pipe:
 
     - ``clarify`` returns plain text and skips model forwarding.
     - ``passthrough`` forwards with minimal mutation.
-    - ``update`` injects one compiler-owned system message and forwards.
+    - ``update`` returns deterministic acknowledgment text.
     """
 
     class Valves(BaseModel):
@@ -395,6 +425,6 @@ class Pipe:
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
             if _confirmation.is_confirmation_text(latest_user_text) and pending_before is not None:
                 return _summarize_confirmation_update(latest_user_text, pending_before)
-            return await self._forward_update(body, __user__, __request__, engine.state)
+            return _summarize_update_from_input(latest_user_text)
 
         return await self._forward_passthrough(body, __user__, __request__)

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -159,6 +159,36 @@ def _render_item_label(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip()
 
 
+def _summarize_update_from_input(user_input: str) -> str:
+    normalized = re.sub(r"\s+", " ", user_input.strip())
+    lower = normalized.lower()
+
+    if lower == "clear state":
+        return "State cleared."
+    if lower == "reset policies":
+        return "Policies reset."
+
+    use_match = re.match(r"^use\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if use_match is not None:
+        item = _render_item_label(use_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Use {item}."
+
+    prohibit_match = re.match(r"^prohibit\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if prohibit_match is not None:
+        item = _render_item_label(prohibit_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Prohibit {item}."
+
+    remove_policy_match = re.match(r"^remove\s+policy\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if remove_policy_match is not None:
+        item = _render_item_label(remove_policy_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Removed policy {item}."
+
+    return "State updated."
+
+
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:
     summarize_fn = getattr(_confirmation, "summarize_confirmation_update", None)
     if callable(summarize_fn):
@@ -602,13 +632,7 @@ class Pipe:
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
             if _confirmation.is_confirmation_text(latest_user_text) and pending_before is not None:
                 return _summarize_confirmation_update(latest_user_text, pending_before)
-            return await self._forward_update(
-                body,
-                __user__,
-                __request__,
-                engine.state,
-                base_model_id=base_model_id,
-            )
+            return _summarize_update_from_input(compile_input)
 
         return await self._forward_passthrough(
             body,

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -3,7 +3,7 @@ title: Context Compiler Preprocessor Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.5
+version: 0.6
 requirements: context-compiler[experimental]>=0.6.11
 
 Open WebUI integration with Context Compiler preprocessor.

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -258,6 +258,7 @@ class Pipe:
 
     This variant adds a precompiler stage before ``engine.step(...)``:
     heuristic first, then Open WebUI-native LLM fallback.
+    Update decisions return deterministic acknowledgment text.
     """
 
     class Valves(BaseModel):

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -265,7 +265,7 @@ def test_pipe_supports_async_user_lookup(monkeypatch) -> None:
     assert isinstance(result, dict)
 
 
-def test_pipe_normal_update_forwards_and_persists_checkpoint(monkeypatch) -> None:
+def test_pipe_normal_update_returns_deterministic_ack_and_persists_checkpoint(monkeypatch) -> None:
     module = _load_module_with_openwebui_stubs("owui_pipe_update_forward", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
@@ -296,29 +296,31 @@ def test_pipe_normal_update_forwards_and_persists_checkpoint(monkeypatch) -> Non
         )
     )
 
-    assert result == {"ok": True}
-    assert len(forwarded_payloads) == 1
-
-    payload = forwarded_payloads[0]
-    assert payload["model"] == "base-model"
-    messages = payload.get("messages")
-    assert isinstance(messages, list)
-    state_messages = [
-        msg
-        for msg in messages
-        if isinstance(msg, dict)
-        and msg.get("role") == "system"
-        and isinstance(msg.get("content"), str)
-        and msg["content"].startswith("[[cc_state]]")
-    ]
-    assert len(state_messages) == 1
-    state_block = state_messages[0]["content"]
-    assert isinstance(state_block, str)
-    assert "Prohibit: peanuts" in state_block
+    assert result == "State updated: Prohibit peanuts."
+    assert len(forwarded_payloads) == 0
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
     assert checkpoint["authoritative_state"]["policies"] == {"peanuts": "prohibit"}
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "remove policy peanuts"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_key,
+        )
+    )
+
+    assert result == "State updated: Removed policy peanuts."
+    assert len(forwarded_payloads) == 0
+
+    checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
+    assert checkpoint["pending"] is None
+    assert checkpoint["authoritative_state"]["policies"] == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -403,7 +403,9 @@ def test_preprocessor_pipe_restore_and_persist_checkpoint_points(monkeypatch) ->
     assert module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] == "ckpt-keep"
 
 
-def test_preprocessor_pipe_normal_update_forwards_and_persists_checkpoint(monkeypatch) -> None:
+def test_preprocessor_pipe_normal_update_returns_deterministic_ack_and_persists_checkpoint(
+    monkeypatch,
+) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_update_forward", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
@@ -411,10 +413,17 @@ def test_preprocessor_pipe_normal_update_forwards_and_persists_checkpoint(monkey
     monkeypatch.setattr(
         module,
         "precompile_heuristic",
-        lambda _text: {
-            "outcome": module.PRECOMPILE_OUTCOME_DIRECTIVE,
-            "directive": "prohibit peanuts",
-        },
+        lambda text: (
+            {
+                "outcome": module.PRECOMPILE_OUTCOME_DIRECTIVE,
+                "directive": "remove policy peanuts",
+            }
+            if "remove policy peanuts" in text.lower()
+            else {
+                "outcome": module.PRECOMPILE_OUTCOME_DIRECTIVE,
+                "directive": "prohibit peanuts",
+            }
+        ),
     )
     monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
 
@@ -445,29 +454,31 @@ def test_preprocessor_pipe_normal_update_forwards_and_persists_checkpoint(monkey
         )
     )
 
-    assert result == {"ok": True}
-    assert len(forwarded_payloads) == 1
-
-    payload = forwarded_payloads[0]
-    assert payload["model"] == "base-model"
-    messages = payload.get("messages")
-    assert isinstance(messages, list)
-    state_messages = [
-        msg
-        for msg in messages
-        if isinstance(msg, dict)
-        and msg.get("role") == "system"
-        and isinstance(msg.get("content"), str)
-        and msg["content"].startswith("[[cc_state]]")
-    ]
-    assert len(state_messages) == 1
-    state_block = state_messages[0]["content"]
-    assert isinstance(state_block, str)
-    assert "Prohibit: peanuts" in state_block
+    assert result == "State updated: Prohibit peanuts."
+    assert len(forwarded_payloads) == 0
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
     assert checkpoint["authoritative_state"]["policies"] == {"peanuts": "prohibit"}
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "remove policy peanuts"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_key,
+        )
+    )
+
+    assert result == "State updated: Removed policy peanuts."
+    assert len(forwarded_payloads) == 0
+
+    checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
+    assert checkpoint["pending"] is None
+    assert checkpoint["authoritative_state"]["policies"] == {}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Make OpenWebUI example pipes render `Decision.update` deterministically (no downstream LLM call)
- Add input-based summaries for update (use, prohibit, remove policy, clear/reset)
- Extend tests to cover remove policy behavior (no forward, state updated)
- Bump OpenWebUI example version to 0.6
- Clarify integration README and preprocessor pipe docstring

This change affects example integrations only; engine semantics are unchanged.