### PR TITLE
feat: make litellm update deterministic in examples

### DIFF
--- a/examples/integrations/litellm/README.md
+++ b/examples/integrations/litellm/README.md
@@ -118,6 +118,8 @@ These files are importable integration references for host applications.
   continuity requires external persistence (DB/Redis/etc.).
 - Display the returned assistant text.
 
+Note: In these LiteLLM example integrations, update decisions are rendered deterministically and do not call the downstream LLM. This makes state transitions explicit. Production hosts may choose different rendering behavior.
+
 ## Troubleshooting
 
 - `litellm is required`: install `context-compiler[integrations]` (or `context-compiler[experimental]` for preprocessor).

--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -3,7 +3,8 @@
 Flow:
 1. Call engine.step(user_input)
 2. clarify -> return prompt_to_user (no model call)
-3. passthrough/update -> call LiteLLM with compiled state + user input
+3. update -> return deterministic acknowledgment text (no model call)
+4. passthrough -> call LiteLLM with compiled state + user input
 
 Intended host usage:
 - collect user input
@@ -193,6 +194,36 @@ def _summarize_confirmation_update(user_input: str, pending: object) -> str:
     return "State updated."
 
 
+def _summarize_update_from_input(user_input: str) -> str:
+    normalized = re.sub(r"\s+", " ", user_input.strip())
+    lower = normalized.lower()
+
+    if lower == "clear state":
+        return "State cleared."
+    if lower == "reset policies":
+        return "Policies reset."
+
+    use_match = re.match(r"^use\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if use_match is not None:
+        item = _render_item_label(use_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Use {item}."
+
+    prohibit_match = re.match(r"^prohibit\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if prohibit_match is not None:
+        item = _render_item_label(prohibit_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Prohibit {item}."
+
+    remove_policy_match = re.match(r"^remove\s+policy\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if remove_policy_match is not None:
+        item = _render_item_label(remove_policy_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Removed policy {item}."
+
+    return "State updated."
+
+
 def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = None) -> str:
     _restore_session_checkpoint_if_needed(engine, session_key)
     checkpoint_before = engine.export_checkpoint()
@@ -212,6 +243,8 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
         and pending_before is not None
     ):
         return _summarize_confirmation_update(user_input, pending_before)
+    if kind == "update":
+        return _summarize_update_from_input(user_input)
 
     compiled_state = decision["state"] if decision["state"] is not None else engine.state
     messages = _build_messages(user_input, compiled_state)

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -5,7 +5,9 @@ Flow:
 2. Run heuristic precompiler
 3. If no directive, run LLM fallback precompiler using prompt files
 4. Pass directive (or original input) to engine.step(...)
-5. Handle clarify/passthrough/update like the basic integration
+5. clarify -> return prompt_to_user (no model call)
+6. update -> return deterministic acknowledgment text (no model call)
+7. passthrough -> call LiteLLM with compiled state + user input
 
 Intended host usage:
 - collect user input

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -287,6 +287,36 @@ def _summarize_confirmation_update(user_input: str, pending: object) -> str:
     return "State updated."
 
 
+def _summarize_update_from_input(user_input: str) -> str:
+    normalized = re.sub(r"\s+", " ", user_input.strip())
+    lower = normalized.lower()
+
+    if lower == "clear state":
+        return "State cleared."
+    if lower == "reset policies":
+        return "Policies reset."
+
+    use_match = re.match(r"^use\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if use_match is not None:
+        item = _render_item_label(use_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Use {item}."
+
+    prohibit_match = re.match(r"^prohibit\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if prohibit_match is not None:
+        item = _render_item_label(prohibit_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Prohibit {item}."
+
+    remove_policy_match = re.match(r"^remove\s+policy\s+(.+)$", normalized, flags=re.IGNORECASE)
+    if remove_policy_match is not None:
+        item = _render_item_label(remove_policy_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Removed policy {item}."
+
+    return "State updated."
+
+
 def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = None) -> str:
     _restore_session_checkpoint_if_needed(engine, session_key)
     checkpoint_before = engine.export_checkpoint()
@@ -316,6 +346,8 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
         and pending_before is not None
     ):
         return _summarize_confirmation_update(user_input, pending_before)
+    if kind == "update":
+        return _summarize_update_from_input(compile_input)
 
     compiled_state = decision["state"] if decision["state"] is not None else engine.state
     messages = _build_messages(user_input, compiled_state)

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -11,7 +11,11 @@ from context_compiler import create_engine
 class _FakeEngine:
     def __init__(self, kind: str, checkpoint_out: str, *, has_pending: bool = False) -> None:
         self.kind = kind
-        self.state: dict[str, object] = {"premise": None, "policies": {}, "version": 2}
+        self.state: dict[str, object] = {
+            "premise": None,
+            "policies": {"peanuts": "prohibit"},
+            "version": 2,
+        }
         self._checkpoint_out = checkpoint_out
         self._has_pending = has_pending
         self.imported: list[str] = []
@@ -90,13 +94,21 @@ def _assert_checkpoint_behavior(module: object) -> None:
         assert update_engine.export_calls == 1
         assert checkpoints["s1"] == "ckpt-update"
 
+        remove_policy_engine = _FakeEngine("update", "ckpt-remove-policy")
+        result = module.handle_turn("remove policy peanuts", remove_policy_engine, session_key="s1")
+        assert result == "State updated: Removed policy peanuts."
+        assert litellm_calls == 1
+        assert remove_policy_engine.imported == ["ckpt-update"]
+        assert remove_policy_engine.export_calls == 1
+        assert checkpoints["s1"] == "ckpt-remove-policy"
+
         clarify_engine = _FakeEngine("clarify", "ckpt-clarify")
         result = module.handle_turn(
             "use kubectl instead of docker", clarify_engine, session_key="s1"
         )
         assert result == "confirm?"
         assert litellm_calls == 1
-        assert clarify_engine.imported == ["ckpt-update"]
+        assert clarify_engine.imported == ["ckpt-remove-policy"]
         assert clarify_engine.export_calls == 1
         assert checkpoints["s1"] == "ckpt-clarify"
     finally:

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -61,7 +61,14 @@ def _assert_checkpoint_behavior(module: object) -> None:
     restored.clear()
 
     call_litellm = cast(Any, module._call_litellm)
-    module._call_litellm = lambda _messages: "ok"
+    litellm_calls = 0
+
+    def _track_litellm(_messages: list[dict[str, str]]) -> str:
+        nonlocal litellm_calls
+        litellm_calls += 1
+        return "ok"
+
+    module._call_litellm = _track_litellm
     if hasattr(module, "_precompile_user_input"):
         module._precompile_user_input = lambda _text, _state: None
 
@@ -70,13 +77,15 @@ def _assert_checkpoint_behavior(module: object) -> None:
         passthrough_engine = _FakeEngine("passthrough", "ckpt-passthrough")
         result = module.handle_turn("hello", passthrough_engine, session_key="s1")
         assert result == "ok"
+        assert litellm_calls == 1
         assert passthrough_engine.imported == ["ckpt-in"]
         assert passthrough_engine.export_calls == 0
         assert checkpoints["s1"] == "ckpt-in"
 
         update_engine = _FakeEngine("update", "ckpt-update")
         result = module.handle_turn("use docker", update_engine, session_key="s1")
-        assert result == "ok"
+        assert result == "State updated: Use docker."
+        assert litellm_calls == 1
         assert update_engine.imported == ["ckpt-in"]
         assert update_engine.export_calls == 1
         assert checkpoints["s1"] == "ckpt-update"
@@ -86,6 +95,7 @@ def _assert_checkpoint_behavior(module: object) -> None:
             "use kubectl instead of docker", clarify_engine, session_key="s1"
         )
         assert result == "confirm?"
+        assert litellm_calls == 1
         assert clarify_engine.imported == ["ckpt-update"]
         assert clarify_engine.export_calls == 1
         assert checkpoints["s1"] == "ckpt-clarify"
@@ -324,8 +334,14 @@ def test_litellm_basic_confirmation_summary_true_replacement() -> None:
 
     try:
         engine = create_engine()
-        assert module.handle_turn("use podman", engine, session_key=session_key) == "ok"
-        assert module.handle_turn("prohibit docker", engine, session_key=session_key) == "ok"
+        assert (
+            module.handle_turn("use podman", engine, session_key=session_key)
+            == "State updated: Use podman."
+        )
+        assert (
+            module.handle_turn("prohibit docker", engine, session_key=session_key)
+            == "State updated: Prohibit docker."
+        )
         clarify = module.handle_turn(
             "use docker instead of podman", engine, session_key=session_key
         )
@@ -356,7 +372,10 @@ def test_litellm_basic_confirmation_summary_prohibited_old_replacement() -> None
 
     try:
         engine = create_engine()
-        assert module.handle_turn("prohibit docker", engine, session_key=session_key) == "ok"
+        assert (
+            module.handle_turn("prohibit docker", engine, session_key=session_key)
+            == "State updated: Prohibit docker."
+        )
         clarify = module.handle_turn(
             "use podman instead of docker", engine, session_key=session_key
         )


### PR DESCRIPTION
- Make LiteLLM example integrations render `Decision.update` deterministically (no downstream LLM call)
- Add input-based update summaries (use, prohibit, remove policy, clear/reset)
- Extend tests to assert no-forward behavior and update summaries
- Update README and docstrings to reflect deterministic update behavior

This clarifies that `update` is a state transition event; rendering is host-defined.