### PR TITLE
chore: expose host support api and bump version to 0.6.12

### DIFF
--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -18,10 +18,21 @@ from collections.abc import Callable, Mapping, Sequence
 from importlib import import_module
 from typing import TypedDict, cast
 
-import host_support.confirmation as _confirmation
 from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
-from host_support.provider_mode import print_startup_config, resolve_provider_config
+
+try:
+    from host_support import is_confirmation_text, summarize_confirmation_update
+except ImportError:
+    import host_support.confirmation as _confirmation
+
+    is_confirmation_text = _confirmation.is_confirmation_text
+    summarize_confirmation_update = _confirmation.summarize_confirmation_update
+
+try:
+    from host_support import print_startup_config, resolve_provider_config
+except ImportError:
+    from host_support.provider_mode import print_startup_config, resolve_provider_config
 
 logger = logging.getLogger(__name__)
 # Example-only in-memory checkpoint store.
@@ -154,9 +165,9 @@ def _render_item_label(value: str) -> str:
 
 
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:
-    summarize_fn = getattr(_confirmation, "summarize_confirmation_update", None)
+    summarize_fn = summarize_confirmation_update
     if callable(summarize_fn):
-        return cast(str, summarize_fn(user_input, pending))
+        return summarize_fn(user_input, pending)
 
     normalized = _normalize_confirmation_for_summary(user_input)
     if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
@@ -237,11 +248,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
         _persist_session_checkpoint_if_needed(engine, kind, session_key)
         return decision["prompt_to_user"] or ""
     _persist_session_checkpoint_if_needed(engine, kind, session_key)
-    if (
-        kind == "update"
-        and _confirmation.is_confirmation_text(user_input)
-        and pending_before is not None
-    ):
+    if kind == "update" and is_confirmation_text(user_input) and pending_before is not None:
         return _summarize_confirmation_update(user_input, pending_before)
     if kind == "update":
         return _summarize_update_from_input(user_input)

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -24,7 +24,6 @@ from importlib.resources import as_file, files
 from importlib.resources.abc import Traversable
 from typing import TypedDict, cast
 
-import host_support.confirmation as _confirmation
 from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
@@ -33,7 +32,19 @@ from experimental.preprocessor import (
     precompile_heuristic,
     render_prompt,
 )
-from host_support.provider_mode import print_startup_config, resolve_provider_config
+
+try:
+    from host_support import is_confirmation_text, summarize_confirmation_update
+except ImportError:
+    import host_support.confirmation as _confirmation
+
+    is_confirmation_text = _confirmation.is_confirmation_text
+    summarize_confirmation_update = _confirmation.summarize_confirmation_update
+
+try:
+    from host_support import print_startup_config, resolve_provider_config
+except ImportError:
+    from host_support.provider_mode import print_startup_config, resolve_provider_config
 
 logger = logging.getLogger(__name__)
 
@@ -249,9 +260,9 @@ def _render_item_label(value: str) -> str:
 
 
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:
-    summarize_fn = getattr(_confirmation, "summarize_confirmation_update", None)
+    summarize_fn = summarize_confirmation_update
     if callable(summarize_fn):
-        return cast(str, summarize_fn(user_input, pending))
+        return summarize_fn(user_input, pending)
 
     normalized = _normalize_confirmation_for_summary(user_input)
     if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
@@ -342,11 +353,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
         _persist_session_checkpoint_if_needed(engine, kind, session_key)
         return decision["prompt_to_user"] or ""
     _persist_session_checkpoint_if_needed(engine, kind, session_key)
-    if (
-        kind == "update"
-        and _confirmation.is_confirmation_text(user_input)
-        and pending_before is not None
-    ):
+    if kind == "update" and is_confirmation_text(user_input) and pending_before is not None:
         return _summarize_confirmation_update(user_input, pending_before)
     if kind == "update":
         return _summarize_update_from_input(compile_input)

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -4,7 +4,7 @@ author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
 version: 0.6
-requirements: context-compiler>=0.6.11
+requirements: context-compiler>=0.6.12
 
 Minimal Open WebUI Pipe integration for Context Compiler.
 
@@ -20,7 +20,7 @@ Scope is intentionally limited:
 import inspect
 import logging
 import re
-from typing import Any, cast
+from typing import Any
 
 from fastapi import Request  # type: ignore[import-not-found]
 from open_webui.models.users import Users  # type: ignore[import-not-found]
@@ -42,9 +42,16 @@ except ModuleNotFoundError:
         return default
 
 
-import host_support.confirmation as _confirmation
 from context_compiler import State, create_engine, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
+
+try:
+    from host_support import is_confirmation_text, summarize_confirmation_update
+except ImportError:
+    import host_support.confirmation as _confirmation
+
+    is_confirmation_text = _confirmation.is_confirmation_text
+    summarize_confirmation_update = _confirmation.summarize_confirmation_update
 
 logger = logging.getLogger(__name__)
 
@@ -202,9 +209,9 @@ def _summarize_update_from_input(user_input: str) -> str:
 
 
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:
-    summarize_fn = getattr(_confirmation, "summarize_confirmation_update", None)
+    summarize_fn = summarize_confirmation_update
     if callable(summarize_fn):
-        return cast(str, summarize_fn(user_input, pending))
+        return summarize_fn(user_input, pending)
 
     normalized = _normalize_confirmation_for_summary(user_input)
     if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
@@ -423,7 +430,7 @@ class Pipe:
             return await self._forward_passthrough(body, __user__, __request__)
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            if _confirmation.is_confirmation_text(latest_user_text) and pending_before is not None:
+            if is_confirmation_text(latest_user_text) and pending_before is not None:
                 return _summarize_confirmation_update(latest_user_text, pending_before)
             return _summarize_update_from_input(latest_user_text)
 

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -4,7 +4,7 @@ author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
 version: 0.6
-requirements: context-compiler[experimental]>=0.6.11
+requirements: context-compiler[experimental]>=0.6.12
 
 Open WebUI integration with Context Compiler preprocessor.
 
@@ -22,7 +22,7 @@ import logging
 import re
 from importlib.resources import as_file, files
 from importlib.resources.abc import Traversable
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from fastapi import Request  # type: ignore[import-not-found]
 from open_webui.models.users import Users  # type: ignore[import-not-found]
@@ -45,7 +45,6 @@ except ModuleNotFoundError:
         return default
 
 
-import host_support.confirmation as _confirmation
 from context_compiler import State, create_engine, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
@@ -54,6 +53,14 @@ from experimental.preprocessor import (
     precompile_heuristic,
     render_prompt,
 )
+
+try:
+    from host_support import is_confirmation_text, summarize_confirmation_update
+except ImportError:
+    import host_support.confirmation as _confirmation
+
+    is_confirmation_text = _confirmation.is_confirmation_text
+    summarize_confirmation_update = _confirmation.summarize_confirmation_update
 
 logger = logging.getLogger(__name__)
 
@@ -190,9 +197,9 @@ def _summarize_update_from_input(user_input: str) -> str:
 
 
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:
-    summarize_fn = getattr(_confirmation, "summarize_confirmation_update", None)
+    summarize_fn = summarize_confirmation_update
     if callable(summarize_fn):
-        return cast(str, summarize_fn(user_input, pending))
+        return summarize_fn(user_input, pending)
 
     normalized = _normalize_confirmation_for_summary(user_input)
     if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
@@ -631,7 +638,7 @@ class Pipe:
             )
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            if _confirmation.is_confirmation_text(latest_user_text) and pending_before is not None:
+            if is_confirmation_text(latest_user_text) and pending_before is not None:
                 return _summarize_confirmation_update(latest_user_text, pending_before)
             return _summarize_update_from_input(compile_input)
 

--- a/host_support/__init__.py
+++ b/host_support/__init__.py
@@ -1,1 +1,12 @@
 """Host-side shared helpers."""
+
+from .confirmation import is_confirmation_text, summarize_confirmation_update
+from .provider_mode import ProviderConfig, print_startup_config, resolve_provider_config
+
+__all__ = [
+    "ProviderConfig",
+    "is_confirmation_text",
+    "print_startup_config",
+    "resolve_provider_config",
+    "summarize_confirmation_update",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.11"
+version = "0.6.12"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.11"
+version = "0.6.12"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
- Expose host_support public functions via __init__ and __all__
- Update example integrations to prefer top-level host_support imports (with fallback for compatibility)
- Bump OpenWebUI example frontmatter requirements to context-compiler>=0.6.12
- Bump package version to 0.6.12

No behavior changes; this clarifies the public host_support API surface and aligns examples with it.