### PR TITLE
fix: harden 0.6.13 example integration behavior

### DIFF
--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -161,7 +161,7 @@ def _normalize_confirmation_for_summary(value: str) -> str:
 
 
 def _render_item_label(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip()
+    return re.sub(r"\s+", " ", value).strip().lower()
 
 
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:

--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -211,6 +211,8 @@ def _summarize_update_from_input(user_input: str) -> str:
 
     if lower == "clear state":
         return "State cleared."
+    if lower == "clear premise":
+        return "Premise cleared."
     if lower == "reset policies":
         return "Policies reset."
 

--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -214,6 +214,14 @@ def _summarize_update_from_input(user_input: str) -> str:
     if lower == "reset policies":
         return "Policies reset."
 
+    replacement_match = re.match(
+        r"^use\s+(.+?)\s+instead\s+of\s+(.+)$", normalized, flags=re.IGNORECASE
+    )
+    if replacement_match is not None:
+        item = _render_item_label(replacement_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Use {item}."
+
     use_match = re.match(r"^use\s+(.+)$", normalized, flags=re.IGNORECASE)
     if use_match is not None:
         item = _render_item_label(use_match.group(1).rstrip(" .!?"))

--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -164,6 +164,19 @@ def _render_item_label(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip().lower()
 
 
+def _near_miss_directive_clarify(value: str) -> str | None:
+    normalized = re.sub(r"\s+", " ", value.strip())
+    lower = normalized.lower()
+
+    if lower in {"reset premise", "reset premises", "clear premises"}:
+        return "Unknown directive.\nUse 'clear premise' or 'reset policies'."
+    if lower.startswith("set premise to "):
+        return "Invalid premise syntax.\nUse 'set premise <value>'."
+    if lower.startswith("change premise ") and not lower.startswith("change premise to "):
+        return "Invalid premise syntax.\nUse 'change premise to <value>'."
+    return None
+
+
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:
     summarize_fn = summarize_confirmation_update
     if callable(summarize_fn):
@@ -253,10 +266,13 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
     decision = engine.step(user_input)
     kind = cast(str, decision["kind"])
     logger.debug("litellm_basic: decision=%s", kind)
+    near_miss_prompt = _near_miss_directive_clarify(user_input)
 
     if kind == "clarify":
         _persist_session_checkpoint_if_needed(engine, kind, session_key)
-        return decision["prompt_to_user"] or ""
+        return near_miss_prompt or decision["prompt_to_user"] or ""
+    if near_miss_prompt is not None and kind == "passthrough":
+        return near_miss_prompt
     _persist_session_checkpoint_if_needed(engine, kind, session_key)
     if kind == "update" and is_confirmation_text(user_input) and pending_before is not None:
         return _summarize_confirmation_update(user_input, pending_before)

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -322,6 +322,8 @@ def _summarize_update_from_input(user_input: str) -> str:
 
     if lower == "clear state":
         return "State cleared."
+    if lower == "clear premise":
+        return "Premise cleared."
     if lower == "reset policies":
         return "Policies reset."
 

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -59,6 +59,19 @@ _NEGATIVE_CONFIRMATION_TOKENS = {"no", "nope", "no thanks"}
 _TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
 
 
+def _is_directive_shaped_input(message: str) -> bool:
+    normalized = re.sub(r"\s+", " ", message.strip()).lower()
+    return (
+        normalized.startswith("use")
+        or normalized.startswith("prohibit")
+        or normalized.startswith("remove policy")
+        or normalized.startswith("set premise")
+        or normalized.startswith("change premise")
+        or normalized.startswith("clear")
+        or normalized.startswith("reset")
+    )
+
+
 class _LiteLLMCallKwargs(TypedDict, total=False):
     model: str
     messages: list[dict[str, str]]
@@ -215,6 +228,9 @@ def _precompile_user_input(message: str, state: State) -> str | None:
                 return parsed
     except Exception:
         logger.debug("preprocessor: heuristic_exception", exc_info=True)
+
+    if _is_directive_shaped_input(message):
+        return None
 
     try:
         fallback_directive = _llm_fallback_precompile(message, state)

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -275,6 +275,19 @@ def _render_item_label(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip().lower()
 
 
+def _near_miss_directive_clarify(value: str) -> str | None:
+    normalized = re.sub(r"\s+", " ", value.strip())
+    lower = normalized.lower()
+
+    if lower in {"reset premise", "reset premises", "clear premises"}:
+        return "Unknown directive.\nUse 'clear premise' or 'reset policies'."
+    if lower.startswith("set premise to "):
+        return "Invalid premise syntax.\nUse 'set premise <value>'."
+    if lower.startswith("change premise ") and not lower.startswith("change premise to "):
+        return "Invalid premise syntax.\nUse 'change premise to <value>'."
+    return None
+
+
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:
     summarize_fn = summarize_confirmation_update
     if callable(summarize_fn):
@@ -374,10 +387,13 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
     decision = engine.step(compile_input)
     kind = cast(str, decision["kind"])
     logger.debug("preprocessor: decision=%s", kind)
+    near_miss_prompt = _near_miss_directive_clarify(user_input)
 
     if kind == "clarify":
         _persist_session_checkpoint_if_needed(engine, kind, session_key)
-        return decision["prompt_to_user"] or ""
+        return near_miss_prompt or decision["prompt_to_user"] or ""
+    if near_miss_prompt is not None and kind == "passthrough":
+        return near_miss_prompt
     _persist_session_checkpoint_if_needed(engine, kind, session_key)
     if kind == "update" and is_confirmation_text(user_input) and pending_before is not None:
         return _summarize_confirmation_update(user_input, pending_before)

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -309,6 +309,14 @@ def _summarize_update_from_input(user_input: str) -> str:
     if lower == "reset policies":
         return "Policies reset."
 
+    replacement_match = re.match(
+        r"^use\s+(.+?)\s+instead\s+of\s+(.+)$", normalized, flags=re.IGNORECASE
+    )
+    if replacement_match is not None:
+        item = _render_item_label(replacement_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Use {item}."
+
     use_match = re.match(r"^use\s+(.+)$", normalized, flags=re.IGNORECASE)
     if use_match is not None:
         item = _render_item_label(use_match.group(1).rstrip(" .!?"))

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -256,7 +256,7 @@ def _normalize_confirmation_for_summary(value: str) -> str:
 
 
 def _render_item_label(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip()
+    return re.sub(r"\s+", " ", value).strip().lower()
 
 
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -3,7 +3,7 @@ title: Context Compiler Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.6
+version: 0.7
 requirements: context-compiler>=0.6.12
 
 Minimal Open WebUI Pipe integration for Context Compiler.

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -178,6 +178,19 @@ def _render_item_label(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip().lower()
 
 
+def _near_miss_directive_clarify(value: str) -> str | None:
+    normalized = re.sub(r"\s+", " ", value.strip())
+    lower = normalized.lower()
+
+    if lower in {"reset premise", "reset premises", "clear premises"}:
+        return "Unknown directive.\nUse 'clear premise' or 'reset policies'."
+    if lower.startswith("set premise to "):
+        return "Invalid premise syntax.\nUse 'set premise <value>'."
+    if lower.startswith("change premise ") and not lower.startswith("change premise to "):
+        return "Invalid premise syntax.\nUse 'change premise to <value>'."
+    return None
+
+
 def _summarize_update_from_input(user_input: str) -> str:
     normalized = re.sub(r"\s+", " ", user_input.strip())
     lower = normalized.lower()
@@ -432,10 +445,13 @@ class Pipe:
         decision = engine.step(latest_user_text)
         kind = decision["kind"]
         logger.debug("pipe: decision=%s", kind)
+        near_miss_prompt = _near_miss_directive_clarify(latest_user_text)
 
         if kind == "clarify":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            return decision["prompt_to_user"] or ""
+            return near_miss_prompt or decision["prompt_to_user"] or ""
+        if near_miss_prompt is not None and kind == "passthrough":
+            return near_miss_prompt
         if kind == "passthrough":
             return await self._forward_passthrough(body, __user__, __request__)
         if kind == "update":

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -184,6 +184,8 @@ def _summarize_update_from_input(user_input: str) -> str:
 
     if lower == "clear state":
         return "State cleared."
+    if lower == "clear premise":
+        return "Premise cleared."
     if lower == "reset policies":
         return "Policies reset."
 

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -187,6 +187,14 @@ def _summarize_update_from_input(user_input: str) -> str:
     if lower == "reset policies":
         return "Policies reset."
 
+    replacement_match = re.match(
+        r"^use\s+(.+?)\s+instead\s+of\s+(.+)$", normalized, flags=re.IGNORECASE
+    )
+    if replacement_match is not None:
+        item = _render_item_label(replacement_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Use {item}."
+
     use_match = re.match(r"^use\s+(.+)$", normalized, flags=re.IGNORECASE)
     if use_match is not None:
         item = _render_item_label(use_match.group(1).rstrip(" .!?"))

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -175,7 +175,7 @@ def _normalize_confirmation_for_summary(value: str) -> str:
 
 
 def _render_item_label(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip()
+    return re.sub(r"\s+", " ", value).strip().lower()
 
 
 def _summarize_update_from_input(user_input: str) -> str:

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -175,6 +175,14 @@ def _summarize_update_from_input(user_input: str) -> str:
     if lower == "reset policies":
         return "Policies reset."
 
+    replacement_match = re.match(
+        r"^use\s+(.+?)\s+instead\s+of\s+(.+)$", normalized, flags=re.IGNORECASE
+    )
+    if replacement_match is not None:
+        item = _render_item_label(replacement_match.group(1).rstrip(" .!?"))
+        if item:
+            return f"State updated: Use {item}."
+
     use_match = re.match(r"^use\s+(.+)$", normalized, flags=re.IGNORECASE)
     if use_match is not None:
         item = _render_item_label(use_match.group(1).rstrip(" .!?"))

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -76,6 +76,19 @@ _NEGATIVE_CONFIRMATION_TOKENS = {"no", "nope", "no thanks"}
 _TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
 
 
+def _is_directive_shaped_input(message: str) -> bool:
+    normalized = re.sub(r"\s+", " ", message.strip()).lower()
+    return (
+        normalized.startswith("use")
+        or normalized.startswith("prohibit")
+        or normalized.startswith("remove policy")
+        or normalized.startswith("set premise")
+        or normalized.startswith("change premise")
+        or normalized.startswith("clear")
+        or normalized.startswith("reset")
+    )
+
+
 def _prompt_file_path(profile: str) -> Traversable:
     # Runtime prompt selection for fallback precompilation:
     # - default: most instruction-following models
@@ -466,6 +479,9 @@ class Pipe:
             parsed = parse_precompiler_output(heuristic_result["directive"])
             if parsed is not None:
                 return parsed, None
+
+        if _is_directive_shaped_input(message):
+            return None, None
 
         return await self._llm_fallback_precompile(
             message,

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -163,7 +163,7 @@ def _normalize_confirmation_for_summary(value: str) -> str:
 
 
 def _render_item_label(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip()
+    return re.sub(r"\s+", " ", value).strip().lower()
 
 
 def _summarize_update_from_input(user_input: str) -> str:

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -3,7 +3,7 @@ title: Context Compiler Preprocessor Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.6
+version: 0.7
 requirements: context-compiler[experimental]>=0.6.12
 
 Open WebUI integration with Context Compiler preprocessor.

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -179,6 +179,19 @@ def _render_item_label(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip().lower()
 
 
+def _near_miss_directive_clarify(value: str) -> str | None:
+    normalized = re.sub(r"\s+", " ", value.strip())
+    lower = normalized.lower()
+
+    if lower in {"reset premise", "reset premises", "clear premises"}:
+        return "Unknown directive.\nUse 'clear premise' or 'reset policies'."
+    if lower.startswith("set premise to "):
+        return "Invalid premise syntax.\nUse 'set premise <value>'."
+    if lower.startswith("change premise ") and not lower.startswith("change premise to "):
+        return "Invalid premise syntax.\nUse 'change premise to <value>'."
+    return None
+
+
 def _summarize_update_from_input(user_input: str) -> str:
     normalized = re.sub(r"\s+", " ", user_input.strip())
     lower = normalized.lower()
@@ -651,10 +664,13 @@ class Pipe:
         decision = engine.step(compile_input)
         kind = decision["kind"]
         logger.debug("preprocessor: decision=%s", kind)
+        near_miss_prompt = _near_miss_directive_clarify(latest_user_text)
 
         if kind == "clarify":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            return decision["prompt_to_user"] or ""
+            return near_miss_prompt or decision["prompt_to_user"] or ""
+        if near_miss_prompt is not None and kind == "passthrough":
+            return near_miss_prompt
         if kind == "passthrough":
             return await self._forward_passthrough(
                 body,

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -185,6 +185,8 @@ def _summarize_update_from_input(user_input: str) -> str:
 
     if lower == "clear state":
         return "State cleared."
+    if lower == "clear premise":
+        return "Premise cleared."
     if lower == "reset policies":
         return "Policies reset."
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.12"
+version = "0.6.13"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -461,3 +461,49 @@ def test_litellm_basic_confirmation_summary_falls_back_for_unknown_pending_shape
     assert result == "State updated."
     assert litellm_calls == 0
     assert checkpoints["basic-summary-fallback"] == "ckpt-fallback"
+
+
+@pytest.mark.parametrize(
+    ("module_name", "path"),
+    [
+        ("litellm_basic_update_responses_no_llm", Path("examples/integrations/litellm/basic.py")),
+        (
+            "litellm_with_preprocessor_update_responses_no_llm",
+            Path("examples/integrations/litellm/with_preprocessor.py"),
+        ),
+    ],
+)
+def test_litellm_update_responses_are_deterministic_and_skip_downstream_model(
+    module_name: str, path: Path
+) -> None:
+    module = _load_module(module_name, path)
+    checkpoints = cast(dict[str, str], module._CHECKPOINTS_BY_SESSION_KEY)
+    restored = cast(dict[str, int], module._RESTORED_ENGINE_BY_SESSION_KEY)
+    checkpoints.clear()
+    restored.clear()
+
+    call_litellm = cast(Any, module._call_litellm)
+    litellm_calls = 0
+
+    def _track_litellm(_messages: list[dict[str, str]]) -> str:
+        nonlocal litellm_calls
+        litellm_calls += 1
+        raise AssertionError("downstream model should not be called for update summaries")
+
+    module._call_litellm = _track_litellm
+
+    try:
+        engine = create_engine()
+        assert module.handle_turn("set premise concise replies", engine) == "State updated."
+        assert module.handle_turn("use docker", engine) == "State updated: Use docker."
+        assert module.handle_turn("prohibit peanuts", engine) == "State updated: Prohibit peanuts."
+        assert (
+            module.handle_turn("remove policy peanuts", engine)
+            == "State updated: Removed policy peanuts."
+        )
+        assert module.handle_turn("reset policies", engine) == "Policies reset."
+        assert module.handle_turn("clear state", engine) == "State cleared."
+    finally:
+        module._call_litellm = call_litellm
+
+    assert litellm_calls == 0

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -577,3 +577,74 @@ def test_litellm_update_responses_are_deterministic_and_skip_downstream_model(
         module._call_litellm = call_litellm
 
     assert litellm_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("module_name", "path"),
+    [
+        ("litellm_basic_near_miss_clarify", Path("examples/integrations/litellm/basic.py")),
+        (
+            "litellm_with_preprocessor_near_miss_clarify",
+            Path("examples/integrations/litellm/with_preprocessor.py"),
+        ),
+    ],
+)
+def test_litellm_near_miss_directives_return_deterministic_clarify_without_downstream(
+    module_name: str, path: Path
+) -> None:
+    module = _load_module(module_name, path)
+    checkpoints = cast(dict[str, str], module._CHECKPOINTS_BY_SESSION_KEY)
+    restored = cast(dict[str, int], module._RESTORED_ENGINE_BY_SESSION_KEY)
+    checkpoints.clear()
+    restored.clear()
+
+    call_litellm = cast(Any, module._call_litellm)
+    litellm_calls = 0
+
+    def _track_litellm(_messages: list[dict[str, str]]) -> str:
+        nonlocal litellm_calls
+        litellm_calls += 1
+        raise AssertionError("downstream model should not be called for near-miss clarify")
+
+    fallback_calls = 0
+    fallback_original = None
+    if hasattr(module, "_llm_fallback_precompile"):
+        fallback_original = module._llm_fallback_precompile
+
+        def _track_fallback(_message: str, _state: dict[str, object]) -> None:
+            nonlocal fallback_calls
+            fallback_calls += 1
+            raise AssertionError("fallback should not be called for near-miss directive input")
+
+        module._llm_fallback_precompile = _track_fallback
+
+    module._call_litellm = _track_litellm
+    try:
+        engine = create_engine()
+        assert (
+            module.handle_turn("reset premise", engine)
+            == "Unknown directive.\nUse 'clear premise' or 'reset policies'."
+        )
+        assert (
+            module.handle_turn("reset premises", engine)
+            == "Unknown directive.\nUse 'clear premise' or 'reset policies'."
+        )
+        assert (
+            module.handle_turn("clear premises", engine)
+            == "Unknown directive.\nUse 'clear premise' or 'reset policies'."
+        )
+        assert (
+            module.handle_turn("set premise to concise answers", engine)
+            == "Invalid premise syntax.\nUse 'set premise <value>'."
+        )
+        assert (
+            module.handle_turn("change premise formal tone", engine)
+            == "Invalid premise syntax.\nUse 'change premise to <value>'."
+        )
+    finally:
+        module._call_litellm = call_litellm
+        if fallback_original is not None:
+            module._llm_fallback_precompile = fallback_original
+
+    assert litellm_calls == 0
+    assert fallback_calls == 0

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -495,11 +495,26 @@ def test_litellm_literal_replacement_update_summary_uses_new_item_only(
 
     module._call_litellm = _track_litellm
     try:
-        engine = create_engine()
-        assert module.handle_turn("use docker", engine) == "State updated: Use docker."
+        engine_use = create_engine()
+        assert module.handle_turn("use   DOCKER", engine_use) == "State updated: Use docker."
+
+        engine_prohibit = create_engine()
         assert (
-            module.handle_turn("use podman instead of docker", engine)
-            == "State updated: Use podman."
+            module.handle_turn("prohibit DOCKER", engine_prohibit)
+            == "State updated: Prohibit docker."
+        )
+
+        engine_remove = create_engine()
+        assert (
+            module.handle_turn("remove policy DOCKER", engine_remove)
+            == "State updated: Removed policy docker."
+        )
+
+        engine_replace = create_engine()
+        assert module.handle_turn("use docker", engine_replace) == "State updated: Use docker."
+        assert (
+            module.handle_turn("use KUBECTL instead of DOCKER", engine_replace)
+            == "State updated: Use kubectl."
         )
 
         engine_noop = create_engine()

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -466,6 +466,57 @@ def test_litellm_basic_confirmation_summary_falls_back_for_unknown_pending_shape
 @pytest.mark.parametrize(
     ("module_name", "path"),
     [
+        ("litellm_basic_literal_replace_summary", Path("examples/integrations/litellm/basic.py")),
+        (
+            "litellm_with_preprocessor_literal_replace_summary",
+            Path("examples/integrations/litellm/with_preprocessor.py"),
+        ),
+    ],
+)
+def test_litellm_literal_replacement_update_summary_uses_new_item_only(
+    module_name: str, path: Path
+) -> None:
+    module = _load_module(module_name, path)
+    checkpoints = cast(dict[str, str], module._CHECKPOINTS_BY_SESSION_KEY)
+    restored = cast(dict[str, int], module._RESTORED_ENGINE_BY_SESSION_KEY)
+    checkpoints.clear()
+    restored.clear()
+
+    call_litellm = cast(Any, module._call_litellm)
+    litellm_calls = 0
+
+    def _track_litellm(_messages: list[dict[str, str]]) -> str:
+        nonlocal litellm_calls
+        litellm_calls += 1
+        raise AssertionError("downstream model should not be called for update summaries")
+
+    if hasattr(module, "_llm_fallback_precompile"):
+        module._llm_fallback_precompile = lambda _message, _state: None
+
+    module._call_litellm = _track_litellm
+    try:
+        engine = create_engine()
+        assert module.handle_turn("use docker", engine) == "State updated: Use docker."
+        assert (
+            module.handle_turn("use podman instead of docker", engine)
+            == "State updated: Use podman."
+        )
+
+        engine_noop = create_engine()
+        assert module.handle_turn("use docker", engine_noop) == "State updated: Use docker."
+        assert (
+            module.handle_turn("use docker instead of docker", engine_noop)
+            == "State updated: Use docker."
+        )
+    finally:
+        module._call_litellm = call_litellm
+
+    assert litellm_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("module_name", "path"),
+    [
         ("litellm_basic_update_responses_no_llm", Path("examples/integrations/litellm/basic.py")),
         (
             "litellm_with_preprocessor_update_responses_no_llm",

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -517,6 +517,10 @@ def test_litellm_literal_replacement_update_summary_uses_new_item_only(
             == "State updated: Use kubectl."
         )
 
+        engine_premise = create_engine()
+        assert module.handle_turn("set premise concise answers", engine_premise) == "State updated."
+        assert module.handle_turn("clear premise", engine_premise) == "Premise cleared."
+
         engine_noop = create_engine()
         assert module.handle_turn("use docker", engine_noop) == "State updated: Use docker."
         assert (

--- a/tests/test_litellm_preprocessor_model_config.py
+++ b/tests/test_litellm_preprocessor_model_config.py
@@ -4,6 +4,8 @@ import types
 from pathlib import Path
 from typing import Any
 
+from context_compiler import create_engine
+
 LITELLM_WITH_PREPROC_PATH = Path("examples/integrations/litellm/with_preprocessor.py")
 LITELLM_PROXY_WITH_PREPROC_PATH = Path(
     "examples/integrations/litellm_proxy/context_compiler_precall_hook_with_preprocessor.py"
@@ -169,3 +171,62 @@ def test_litellm_proxy_fallback_rejects_premise_near_miss_rewrite(monkeypatch):
 
     result = module._llm_fallback_precompile("change premise concise replies", None)
     assert result is None
+
+
+def test_litellm_precompile_skips_fallback_for_directive_shaped_malformed_inputs(monkeypatch):
+    module = _load_module("litellm_with_preproc_skip_fallback_malformed", LITELLM_WITH_PREPROC_PATH)
+
+    monkeypatch.setattr(
+        module,
+        "precompile_heuristic",
+        lambda _text: {"outcome": "no_directive", "directive": None},
+    )
+
+    fallback_calls = 0
+
+    def _fallback(_message: str, _state: dict[str, object]) -> None:
+        nonlocal fallback_calls
+        fallback_calls += 1
+        raise AssertionError("fallback should not be called for directive-shaped malformed input")
+
+    downstream_calls = 0
+
+    def _downstream(_messages: list[dict[str, str]]) -> str:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        raise AssertionError("downstream should not be called for clarify output")
+
+    monkeypatch.setattr(module, "_llm_fallback_precompile", _fallback)
+    monkeypatch.setattr(module, "_call_litellm", _downstream)
+
+    cases = [
+        (
+            "use",
+            "Policy item cannot be empty.\nUse 'use <item>' with a non-empty value.",
+        ),
+        (
+            "prohibit",
+            "Policy item cannot be empty.\nUse 'prohibit <item>' with a non-empty value.",
+        ),
+        (
+            "remove policy",
+            "Policy item cannot be empty.\nUse 'remove policy <item>' with a non-empty value.",
+        ),
+        (
+            "use docker instead of",
+            "Replacement requires both new and old items.\n"
+            "Use 'use <new item> instead of <old item>' with non-empty values.",
+        ),
+        (
+            "use instead of docker",
+            "Replacement requires both new and old items.\n"
+            "Use 'use <new item> instead of <old item>' with non-empty values.",
+        ),
+    ]
+
+    for text, expected in cases:
+        engine = create_engine()
+        assert module.handle_turn(text, engine) == expected
+
+    assert fallback_calls == 0
+    assert downstream_calls == 0

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -439,6 +439,52 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
     assert downstream_calls == 0
 
 
+def test_pipe_near_miss_directives_return_deterministic_clarify_without_downstream(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_near_miss_clarify", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    downstream_calls = 0
+
+    async def _track_downstream(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+
+    module.generate_chat_completion = _track_downstream
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+
+    cases = [
+        ("reset premise", "Unknown directive.\nUse 'clear premise' or 'reset policies'."),
+        ("reset premises", "Unknown directive.\nUse 'clear premise' or 'reset policies'."),
+        ("clear premises", "Unknown directive.\nUse 'clear premise' or 'reset policies'."),
+        ("set premise to concise answers", "Invalid premise syntax.\nUse 'set premise <value>'."),
+        (
+            "change premise formal tone",
+            "Invalid premise syntax.\nUse 'change premise to <value>'.",
+        ),
+    ]
+
+    for idx, (user_input, expected) in enumerate(cases):
+        result = asyncio.run(
+            pipe.pipe(
+                {"model": "pipe-model", "messages": [{"role": "user", "content": user_input}]},
+                __user__={"id": "u1"},
+                __request__=object(),
+                __chat_id__=f"chat-near-miss-{idx}",
+            )
+        )
+        assert result == expected
+
+    assert downstream_calls == 0
+
+
 @pytest.mark.parametrize(
     ("confirmation", "expected_policies", "expected_response"),
     [

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -405,6 +405,29 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
         pipe.pipe(
             {
                 "model": "pipe-model",
+                "messages": [{"role": "user", "content": "set premise concise answers"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-premise",
+        )
+    )
+    assert result == "State updated."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "clear premise"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-premise",
+        )
+    )
+    assert result == "Premise cleared."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
                 "messages": [{"role": "user", "content": "use docker instead of docker"}],
             },
             __user__={"id": "u1"},

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -323,6 +323,63 @@ def test_pipe_normal_update_returns_deterministic_ack_and_persists_checkpoint(mo
     assert checkpoint["authoritative_state"]["policies"] == {}
 
 
+def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_literal_replace_summary", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    downstream_calls = 0
+
+    async def _track_downstream(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+
+    module.generate_chat_completion = _track_downstream
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-replace",
+        )
+    )
+    assert result == "State updated: Use docker."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "use podman instead of docker"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-replace",
+        )
+    )
+    assert result == "State updated: Use podman."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "use docker instead of docker"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-replace-noop",
+        )
+    )
+    assert result == "State updated: Use docker."
+    assert downstream_calls == 0
+
+
 @pytest.mark.parametrize(
     ("confirmation", "expected_policies", "expected_response"),
     [

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -344,6 +344,42 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
 
     result = asyncio.run(
         pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use   DOCKER"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-use",
+        )
+    )
+    assert result == "State updated: Use docker."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "prohibit DOCKER"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-prohibit",
+        )
+    )
+    assert result == "State updated: Prohibit docker."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "remove policy DOCKER"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-remove",
+        )
+    )
+    assert result == "State updated: Removed policy docker."
+
+    result = asyncio.run(
+        pipe.pipe(
             {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
             __user__={"id": "u1"},
             __request__=object(),
@@ -356,14 +392,14 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
         pipe.pipe(
             {
                 "model": "pipe-model",
-                "messages": [{"role": "user", "content": "use podman instead of docker"}],
+                "messages": [{"role": "user", "content": "use KUBECTL instead of DOCKER"}],
             },
             __user__={"id": "u1"},
             __request__=object(),
             __chat_id__="chat-replace",
         )
     )
-    assert result == "State updated: Use podman."
+    assert result == "State updated: Use kubectl."
 
     result = asyncio.run(
         pipe.pipe(

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -481,6 +481,66 @@ def test_preprocessor_pipe_normal_update_returns_deterministic_ack_and_persists_
     assert checkpoint["authoritative_state"]["policies"] == {}
 
 
+def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_literal_replace_summary", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    downstream_calls = 0
+
+    async def _track_downstream(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+
+    monkeypatch.setattr(module, "generate_chat_completion", _track_downstream)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-replace",
+        )
+    )
+    assert result == "State updated: Use docker."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "use podman instead of docker"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-replace",
+        )
+    )
+    assert result == "State updated: Use podman."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "use docker instead of docker"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-replace-noop",
+        )
+    )
+    assert result == "State updated: Use docker."
+    assert downstream_calls == 0
+
+
 @pytest.mark.parametrize(
     ("confirmation", "expected_response"),
     [

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -732,3 +732,90 @@ def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
     }
     resumed_checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert resumed_checkpoint["pending"] is None
+
+
+@pytest.mark.parametrize(
+    ("user_input", "expected"),
+    [
+        (
+            "use",
+            "Policy item cannot be empty.\nUse 'use <item>' with a non-empty value.",
+        ),
+        (
+            "prohibit",
+            "Policy item cannot be empty.\nUse 'prohibit <item>' with a non-empty value.",
+        ),
+        (
+            "remove policy",
+            "Policy item cannot be empty.\nUse 'remove policy <item>' with a non-empty value.",
+        ),
+        (
+            "use docker instead of",
+            "Replacement requires both new and old items.\n"
+            "Use 'use <new item> instead of <old item>' with non-empty values.",
+        ),
+        (
+            "use instead of docker",
+            "Replacement requires both new and old items.\n"
+            "Use 'use <new item> instead of <old item>' with non-empty values.",
+        ),
+    ],
+)
+def test_preprocessor_pipe_skips_fallback_for_directive_shaped_malformed_inputs(
+    monkeypatch,
+    user_input: str,
+    expected: str,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_skip_fallback_malformed", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    monkeypatch.setattr(
+        module,
+        "precompile_heuristic",
+        lambda _text: {"outcome": "no_directive", "directive": None},
+    )
+
+    fallback_calls = 0
+
+    async def _fallback(
+        self,
+        message: str,
+        state: dict[str, object],
+        *,
+        request: object,
+        user_payload: dict[str, object],
+        prompt_profile: str,
+        model_id: str,
+    ) -> tuple[str | None, str | None]:
+        nonlocal fallback_calls
+        del self, message, state, request, user_payload, prompt_profile, model_id
+        fallback_calls += 1
+        raise AssertionError("fallback should not be called for directive-shaped malformed input")
+
+    downstream_calls = 0
+
+    async def _downstream(_: object, payload: dict[str, Any], __: object) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+
+    monkeypatch.setattr(module.Pipe, "_llm_fallback_precompile", _fallback)
+    monkeypatch.setattr(module, "generate_chat_completion", _downstream)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": user_input}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-malformed",
+        )
+    )
+
+    assert result == expected
+    assert fallback_calls == 0
+    assert downstream_calls == 0

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -842,3 +842,73 @@ def test_preprocessor_pipe_skips_fallback_for_directive_shaped_malformed_inputs(
     assert result == expected
     assert fallback_calls == 0
     assert downstream_calls == 0
+
+
+def test_preprocessor_pipe_near_miss_directives_return_deterministic_clarify_without_model_calls(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_near_miss_clarify", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    monkeypatch.setattr(
+        module,
+        "precompile_heuristic",
+        lambda _text: {"outcome": "no_directive", "directive": None},
+    )
+
+    fallback_calls = 0
+
+    async def _fallback(
+        self,
+        message: str,
+        state: dict[str, object],
+        *,
+        request: object,
+        user_payload: dict[str, object],
+        prompt_profile: str,
+        model_id: str,
+    ) -> tuple[str | None, str | None]:
+        nonlocal fallback_calls
+        del self, message, state, request, user_payload, prompt_profile, model_id
+        fallback_calls += 1
+        raise AssertionError("fallback should not be called for near-miss directive input")
+
+    downstream_calls = 0
+
+    async def _downstream(_: object, payload: dict[str, Any], __: object) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+
+    monkeypatch.setattr(module.Pipe, "_llm_fallback_precompile", _fallback)
+    monkeypatch.setattr(module, "generate_chat_completion", _downstream)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+
+    cases = [
+        ("reset premise", "Unknown directive.\nUse 'clear premise' or 'reset policies'."),
+        ("reset premises", "Unknown directive.\nUse 'clear premise' or 'reset policies'."),
+        ("clear premises", "Unknown directive.\nUse 'clear premise' or 'reset policies'."),
+        ("set premise to concise answers", "Invalid premise syntax.\nUse 'set premise <value>'."),
+        (
+            "change premise formal tone",
+            "Invalid premise syntax.\nUse 'change premise to <value>'.",
+        ),
+    ]
+
+    for idx, (user_input, expected) in enumerate(cases):
+        result = asyncio.run(
+            pipe.pipe(
+                {"model": "pipe-model", "messages": [{"role": "user", "content": user_input}]},
+                __user__={"id": "u1"},
+                __request__=object(),
+                __chat_id__=f"chat-near-miss-{idx}",
+            )
+        )
+        assert result == expected
+
+    assert fallback_calls == 0
+    assert downstream_calls == 0

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -505,6 +505,42 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
 
     result = asyncio.run(
         pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use   DOCKER"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-use",
+        )
+    )
+    assert result == "State updated: Use docker."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "prohibit DOCKER"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-prohibit",
+        )
+    )
+    assert result == "State updated: Prohibit docker."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "remove policy DOCKER"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-remove",
+        )
+    )
+    assert result == "State updated: Removed policy docker."
+
+    result = asyncio.run(
+        pipe.pipe(
             {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
             __user__={"id": "u1"},
             __request__=object(),
@@ -517,14 +553,14 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
         pipe.pipe(
             {
                 "model": "pipe-model",
-                "messages": [{"role": "user", "content": "use podman instead of docker"}],
+                "messages": [{"role": "user", "content": "use KUBECTL instead of DOCKER"}],
             },
             __user__={"id": "u1"},
             __request__=object(),
             __chat_id__="chat-replace",
         )
     )
-    assert result == "State updated: Use podman."
+    assert result == "State updated: Use kubectl."
 
     result = asyncio.run(
         pipe.pipe(

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -566,6 +566,29 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
         pipe.pipe(
             {
                 "model": "pipe-model",
+                "messages": [{"role": "user", "content": "set premise concise answers"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-premise",
+        )
+    )
+    assert result == "State updated."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "clear premise"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-premise",
+        )
+    )
+    assert result == "Premise cleared."
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
                 "messages": [{"role": "user", "content": "use docker instead of docker"}],
             },
             __user__={"id": "u1"},

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.12"
+version = "0.6.13"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed
- Updated example integrations to keep update acknowledgments deterministic and accurate:
  - replacement updates now summarize as `State updated: Use <new>.`
  - policy item labels in deterministic acknowledgments are normalized consistently
  - `clear premise` now returns `Premise cleared.`
- Updated preprocessor variants to skip fallback LLM calls for directive-shaped malformed inputs and return deterministic clarify via engine flow.
- Added integration-focused regression coverage across LiteLLM and OpenWebUI example paths for:
  - replacement acknowledgment rendering
  - casing normalization consistency
  - fallback suppression on malformed directive-shaped inputs
  - clear premise acknowledgment
  - near-miss directive clarify behavior
- Finalized release metadata updates:
  - package version bumped to `0.6.13`
  - OpenWebUI pipe frontmatter versions bumped to `0.7`
  - `uv.lock` regenerated

## Why this was needed
These changes remove misleading user-facing behavior in example integrations (false success-like passthrough replies, inconsistent acknowledgment text, and unnecessary preprocessor fallback calls), while preserving deterministic directive handling and expected passthrough behavior.