### PR TITLE
fix: append OpenWebUI trace to streamed responses

### DIFF
--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -3,7 +3,7 @@ title: Context Compiler Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.8
+version: 0.8.1
 requirements: context-compiler>=0.6.14
 
 Minimal Open WebUI Pipe integration for Context Compiler.
@@ -20,7 +20,8 @@ Scope is intentionally limited:
 import inspect
 import logging
 import re
-from typing import Any
+from collections.abc import AsyncIterator
+from typing import Any, cast
 
 from fastapi import Request  # type: ignore[import-not-found]
 from open_webui.models.users import Users  # type: ignore[import-not-found]
@@ -362,6 +363,9 @@ class Pipe:
         return bool(getattr(self.valves, "SHOW_CONTEXT_COMPILER_TRACE", False))
 
     def _append_trace_to_response(self, response: Any, trace_text: str) -> Any:
+        aiter = getattr(response, "__aiter__", None)
+        if callable(aiter):
+            return self._append_trace_to_stream(cast(AsyncIterator[object], response), trace_text)
         if isinstance(response, str):
             return f"{response}\n\n{trace_text}"
         if isinstance(response, dict):
@@ -376,6 +380,26 @@ class Pipe:
                             message["content"] = f"{content}\n\n{trace_text}"
                             return response
         return response
+
+    def _append_trace_to_stream(
+        self, stream: AsyncIterator[object], trace_text: str
+    ) -> AsyncIterator[object]:
+        async def _wrapped() -> AsyncIterator[object]:
+            chunk_type: type[str] | type[bytes] | None = None
+            async for chunk in stream:
+                if chunk_type is None:
+                    if isinstance(chunk, bytes):
+                        chunk_type = bytes
+                    elif isinstance(chunk, str):
+                        chunk_type = str
+                yield chunk
+            suffix = f"\n\n{trace_text}"
+            if chunk_type is bytes:
+                yield suffix.encode("utf-8")
+            else:
+                yield suffix
+
+        return _wrapped()
 
     def _with_trace(
         self,

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -3,7 +3,7 @@ title: Context Compiler Preprocessor Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.8
+version: 0.8.1
 requirements: context-compiler[experimental]>=0.6.14
 
 Open WebUI integration with Context Compiler preprocessor.
@@ -20,9 +20,10 @@ Core decision handling remains the same as the base integration.
 import inspect
 import logging
 import re
+from collections.abc import AsyncIterator
 from importlib.resources import as_file, files
 from importlib.resources.abc import Traversable
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from fastapi import Request  # type: ignore[import-not-found]
 from open_webui.models.users import Users  # type: ignore[import-not-found]
@@ -389,6 +390,9 @@ class Pipe:
         return bool(getattr(self.valves, "SHOW_CONTEXT_COMPILER_TRACE", False))
 
     def _append_trace_to_response(self, response: Any, trace_text: str) -> Any:
+        aiter = getattr(response, "__aiter__", None)
+        if callable(aiter):
+            return self._append_trace_to_stream(cast(AsyncIterator[object], response), trace_text)
         if isinstance(response, str):
             return f"{response}\n\n{trace_text}"
         if isinstance(response, dict):
@@ -403,6 +407,26 @@ class Pipe:
                             message["content"] = f"{content}\n\n{trace_text}"
                             return response
         return response
+
+    def _append_trace_to_stream(
+        self, stream: AsyncIterator[object], trace_text: str
+    ) -> AsyncIterator[object]:
+        async def _wrapped() -> AsyncIterator[object]:
+            chunk_type: type[str] | type[bytes] | None = None
+            async for chunk in stream:
+                if chunk_type is None:
+                    if isinstance(chunk, bytes):
+                        chunk_type = bytes
+                    elif isinstance(chunk, str):
+                        chunk_type = str
+                yield chunk
+            suffix = f"\n\n{trace_text}"
+            if chunk_type is bytes:
+                yield suffix.encode("utf-8")
+            else:
+                yield suffix
+
+        return _wrapped()
 
     def _with_trace(
         self,

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -694,3 +694,20 @@ def test_litellm_with_preprocessor_trace_on_includes_preprocessor_output() -> No
     assert "decision kind: update" in result
     assert "preprocessor output: prohibit peanuts" in result
     assert "downstream LLM call: no" in result
+
+
+def test_litellm_with_preprocessor_trace_on_passthrough_includes_trace() -> None:
+    module = _load_module(
+        "litellm_with_preprocessor_trace_on_passthrough",
+        Path("examples/integrations/litellm/with_preprocessor.py"),
+    )
+    module.SHOW_CONTEXT_COMPILER_TRACE = True
+    module._call_litellm = lambda _messages: "ok"
+    module._precompile_user_input = lambda _text, _state: None
+    engine = create_engine()
+
+    result = module.handle_turn("hello", engine)
+    assert "ok" in result
+    assert "Context Compiler trace" in result
+    assert "decision kind: passthrough" in result
+    assert "downstream LLM call: yes" in result

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -614,3 +614,44 @@ def test_pipe_trace_on_appends_trace_to_user_visible_output(monkeypatch) -> None
     assert "Context Compiler trace" in content
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
+
+
+def test_pipe_trace_on_passthrough_stream_appends_trace_after_chunks(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_trace_on_stream", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    async def _streaming_response() -> object:
+        for part in ("down", "stream"):
+            yield part
+
+    async def _chat_completion(_: object, payload: dict[str, object], __: object) -> object:
+        del payload
+        return _streaming_response()
+
+    module.generate_chat_completion = _chat_completion
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-trace-on-stream",
+        )
+    )
+
+    async def _collect() -> str:
+        parts: list[str] = []
+        async for chunk in result:
+            assert isinstance(chunk, str)
+            parts.append(chunk)
+        return "".join(parts)
+
+    content = asyncio.run(_collect())
+    assert content.startswith("downstream")
+    assert "Context Compiler trace" in content
+    assert "decision kind: passthrough" in content
+    assert "downstream LLM call: yes" in content

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -1182,3 +1182,51 @@ def test_preprocessor_pipe_trace_on_passthrough_appends_trace_to_llm_content(mon
     assert "Context Compiler trace" in content
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
+
+
+def test_preprocessor_pipe_trace_on_passthrough_stream_appends_trace_after_chunks(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_trace_on_stream", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    async def _streaming_response() -> Any:
+        for part in ("down", "stream"):
+            yield part
+
+    async def _chat_completion(_: object, payload: dict[str, Any], __: object) -> Any:
+        if payload.get("model") == "prep-model":
+            return {"choices": [{"message": {"content": "no_directive"}}]}
+        return _streaming_response()
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+    monkeypatch.setattr(module, "precompile_heuristic", lambda _text: {"outcome": "no_directive"})
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda _value, **_kwargs: None)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-trace-on-stream",
+        )
+    )
+
+    async def _collect() -> str:
+        parts: list[str] = []
+        async for chunk in result:
+            assert isinstance(chunk, str)
+            parts.append(chunk)
+        return "".join(parts)
+
+    content = asyncio.run(_collect())
+    assert content.startswith("downstream")
+    assert "Context Compiler trace" in content
+    assert "decision kind: passthrough" in content
+    assert "downstream LLM call: yes" in content

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -1148,3 +1148,37 @@ def test_preprocessor_pipe_trace_on_appends_trace_to_user_visible_output(monkeyp
     assert "decision kind: update" in result
     assert "preprocessor output: prohibit peanuts" in result
     assert "downstream LLM call: no" in result
+
+
+def test_preprocessor_pipe_trace_on_passthrough_appends_trace_to_llm_content(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_trace_on_passthrough", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    async def _chat_completion(_: object, payload: dict[str, Any], __: object) -> dict[str, object]:
+        if payload.get("model") == "prep-model":
+            return {"choices": [{"message": {"content": "no_directive"}}]}
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+    monkeypatch.setattr(module, "precompile_heuristic", lambda _text: {"outcome": "no_directive"})
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda _value, **_kwargs: None)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-trace-on-passthrough",
+        )
+    )
+    content = result["choices"][0]["message"]["content"]
+    assert "downstream" in content
+    assert "Context Compiler trace" in content
+    assert "decision kind: passthrough" in content
+    assert "downstream LLM call: yes" in content


### PR DESCRIPTION
## What changed
* fix: append trace to streamed passthrough responses in OpenWebUI pipes
* test: add coverage for streaming passthrough trace paths
* chore: bump OpenWebUI function versions to 0.8.1

-

## Why

- OpenWebUI passthrough wasn't showing traces for direct llm calls

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
