### PR TITLE
fix: harden openwebui trace and update routing

### DIFF
--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -80,9 +80,15 @@ Use the Open WebUI model picker/list to copy exact model ids for `BASE_MODEL_ID`
 
 ## Manual Validation
 
-Validate clarify short-circuit, passthrough forwarding, deterministic update acknowledgments with no downstream forward, chat isolation with real chat ids, restart state loss, and non-text bypass behavior.
+Validate clarify short-circuit, passthrough forwarding without state injection,
+update forwarding with authoritative `[[cc_state]]` injection, chat isolation
+with real chat ids, restart state loss, and non-text bypass behavior.
 
-Note: In the OpenWebUI example pipes, update decisions are rendered deterministically and do not call the downstream LLM. This makes state transitions explicit. Production hosts may choose different rendering behavior.
+Note: In the OpenWebUI example pipes, `update` decisions call the downstream
+LLM with authoritative compiler state injected as a compiler-owned system
+message (`[[cc_state]] ...`). When trace is enabled, responses include the
+injected state block and a concise representation of downstream payload
+messages so state-to-payload behavior is directly visible.
 
 ## Behavioral comparisons
 

--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -49,6 +49,10 @@ If using `open_webui_pipe_with_preprocessor.py`:
 - Optional: set `PREPROCESSOR_MODEL_ID` to route fallback precompilation through
   a separate model. If unset, fallback uses `BASE_MODEL_ID`.
 - Fallback routing is Open WebUI-native (no LiteLLM dependency for this pipe).
+- The heuristic precompiler is intentionally conservative/high-precision and
+  may abstain on mixed-prose natural language (for example, `i think we should
+  use docker`). In those cases, behavior may remain passthrough unless fallback
+  precompilation returns a validated canonical directive.
 - Invalid configured model ids return explicit runtime misconfiguration errors:
   - `BASE_MODEL_ID` not found in Open WebUI models
   - `PREPROCESSOR_MODEL_ID` not found in Open WebUI models

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -18,6 +18,7 @@ Scope is intentionally limited:
 """
 
 import inspect
+import json
 import logging
 import re
 from collections.abc import AsyncIterator
@@ -46,42 +47,6 @@ except ModuleNotFoundError:
 from context_compiler import State, create_engine, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 
-try:
-    from host_support import is_confirmation_text, summarize_confirmation_update
-except ImportError:
-    import host_support.confirmation as _confirmation
-
-    is_confirmation_text = _confirmation.is_confirmation_text
-    summarize_confirmation_update = _confirmation.summarize_confirmation_update
-try:
-    from host_support import build_trace
-except ImportError:
-    try:
-        from host_support.observability import build_trace
-    except ImportError:
-
-        def build_trace(
-            *,
-            original_input: str,
-            compiler_input: str,
-            decision: object,
-            state_before: object,
-            state_after: object,
-            preprocessor_output: str | None = None,
-            llm_called: bool = False,
-        ) -> str:
-            del (
-                original_input,
-                compiler_input,
-                decision,
-                state_before,
-                state_after,
-                preprocessor_output,
-                llm_called,
-            )
-            return ""
-
-
 logger = logging.getLogger(__name__)
 
 _CC_MARKER = "[[cc_state]]"
@@ -91,8 +56,6 @@ _ENGINES_BY_CHAT_KEY: dict[str, Engine] = {}
 # Real deployments should persist checkpoints externally (DB/Redis/etc.),
 # or restart continuity for pending flows will be lost.
 _CHECKPOINTS_BY_CHAT_KEY: dict[str, str] = {}
-_NEGATIVE_CONFIRMATION_TOKENS = {"no", "nope", "no thanks"}
-_TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
 
 
 def _resolve_chat_key(
@@ -196,26 +159,89 @@ def _replace_compiler_system_message(
     ]
 
 
-def _summarize_payload_messages_for_trace(messages: list[dict[str, Any]]) -> str:
-    if not messages:
-        return "[]"
+def _normalize_state(value: object) -> State:
+    if isinstance(value, dict):
+        return cast(State, value)
+    return {"premise": None, "policies": {}, "version": 2}
+
+
+def _active_state_summary(state: object) -> str:
+    normalized = _normalize_state(state)
+    premise = get_premise_value(normalized)
+    use_items = sorted(get_policy_items(normalized, "use"))
+    prohibit_items = sorted(get_policy_items(normalized, "prohibit"))
     parts: list[str] = []
-    for message in messages:
-        role = message.get("role")
-        content = message.get("content")
-        if isinstance(content, str):
-            content_preview = f"{content[:57]}..." if len(content) > 60 else content
+    if premise is not None:
+        parts.append(f'premise="{premise}"')
+    if use_items:
+        parts.append("use " + ", ".join(use_items))
+    if prohibit_items:
+        parts.append("prohibit " + ", ".join(prohibit_items))
+    return "; ".join(parts) if parts else "none"
+
+
+def _compact_state_change(before: object, after: object) -> str:
+    before_state = _normalize_state(before)
+    after_state = _normalize_state(after)
+    before_premise = get_premise_value(before_state)
+    after_premise = get_premise_value(after_state)
+    before_use = set(get_policy_items(before_state, "use"))
+    after_use = set(get_policy_items(after_state, "use"))
+    before_prohibit = set(get_policy_items(before_state, "prohibit"))
+    after_prohibit = set(get_policy_items(after_state, "prohibit"))
+
+    parts: list[str] = []
+    if before_premise != after_premise:
+        if after_premise is None:
+            parts.append("-premise")
+        elif before_premise is None:
+            parts.append(f'+premise "{after_premise}"')
         else:
-            content_preview = repr(content)
-        parts.append(f"{role}:{content_preview!r}")
-    return "[" + ", ".join(parts) + "]"
+            parts.append(f'~premise "{after_premise}"')
+    for item in sorted(after_use - before_use):
+        parts.append(f"+use {item}")
+    for item in sorted(before_use - after_use):
+        parts.append(f"-use {item}")
+    for item in sorted(after_prohibit - before_prohibit):
+        parts.append(f"+prohibit {item}")
+    for item in sorted(before_prohibit - after_prohibit):
+        parts.append(f"-prohibit {item}")
+    return ", ".join(parts) if parts else "none"
 
 
-def _normalize_confirmation_for_summary(value: str) -> str:
-    normalized = value.strip().lower()
-    normalized = re.sub(r"\s+", " ", normalized)
-    normalized = _TRAILING_CONFIRM_PUNCT_RE.sub("", normalized).strip()
-    return re.sub(r"\s+", " ", normalized)
+def _build_compact_trace_text(
+    *,
+    decision: object,
+    state_before: object,
+    state_after: object,
+    llm_called: bool,
+    state_injected: str,
+) -> str:
+    kind_obj = decision.get("kind") if isinstance(decision, dict) else None
+    kind = kind_obj if isinstance(kind_obj, str) else "unknown"
+    lines = ["Context Compiler trace", "", f"decision kind: {kind}"]
+
+    if kind == "update":
+        lines.append(f"state change: {_compact_state_change(state_before, state_after)}")
+        lines.append(f"active state: {_active_state_summary(state_after)}")
+        lines.append(f"downstream LLM call: {'yes' if llm_called else 'no'}")
+        lines.append("")
+        lines.append(f"state injected: {state_injected}")
+        return "\n".join(lines)
+
+    if kind == "clarify":
+        prompt_obj = decision.get("prompt_to_user") if isinstance(decision, dict) else None
+        prompt = prompt_obj if isinstance(prompt_obj, str) else ""
+        lines.append(f"clarification prompt: {prompt}")
+        lines.append(f"active state: {_active_state_summary(state_after)}")
+        lines.append(f"downstream LLM call: {'yes' if llm_called else 'no'}")
+        lines.append("state injected: no")
+        return "\n".join(lines)
+
+    lines.append(f"active state: {_active_state_summary(state_after)}")
+    lines.append(f"downstream LLM call: {'yes' if llm_called else 'no'}")
+    lines.append("state injected: no")
+    return "\n".join(lines)
 
 
 def _render_item_label(value: str) -> str:
@@ -271,47 +297,6 @@ def _summarize_update_from_input(user_input: str) -> str:
         item = _render_item_label(remove_policy_match.group(1).rstrip(" .!?"))
         if item:
             return f"State updated: Removed policy {item}."
-
-    return "State updated."
-
-
-def _summarize_confirmation_update(user_input: str, pending: object) -> str:
-    summarize_fn = summarize_confirmation_update
-    if callable(summarize_fn):
-        return summarize_fn(user_input, pending)
-
-    normalized = _normalize_confirmation_for_summary(user_input)
-    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
-        return "State unchanged."
-    if not isinstance(pending, dict):
-        return "State updated."
-
-    replacement = pending.get("replacement")
-    if not isinstance(replacement, dict):
-        return "State updated."
-
-    kind = replacement.get("kind")
-    new_item = replacement.get("new_item")
-    old_item = replacement.get("old_item")
-    if kind == "use_only" and isinstance(new_item, str):
-        new_label = _render_item_label(new_item)
-        if new_label:
-            return f"State updated: Use {new_label}."
-        return "State updated."
-
-    if kind == "replace_use" and isinstance(new_item, str) and isinstance(old_item, str):
-        new_label = _render_item_label(new_item)
-        old_label = _render_item_label(old_item)
-        if not new_label or not old_label:
-            return "State updated."
-        prompt = pending.get("prompt_to_user")
-        prohibited_old_prompt = (
-            f'"{old_item}" is currently prohibited. '
-            f'Did you mean to remove it and use "{new_item}" instead?'
-        )
-        if prompt == prohibited_old_prompt:
-            return f"State updated: Removed prohibition on {old_label}; use {new_label}."
-        return f"State updated: Replaced {old_label} with {new_label}."
 
     return "State updated."
 
@@ -378,6 +363,12 @@ class Pipe:
         return bool(getattr(self.valves, "SHOW_CONTEXT_COMPILER_TRACE", False))
 
     def _append_trace_to_response(self, response: Any, trace_text: str) -> Any:
+        body_iterator = getattr(response, "body_iterator", None)
+        if body_iterator is not None and callable(getattr(body_iterator, "__aiter__", None)):
+            response.body_iterator = self._append_trace_to_stream(
+                cast(AsyncIterator[object], body_iterator), trace_text
+            )
+            return response
         aiter = getattr(response, "__aiter__", None)
         if callable(aiter):
             return self._append_trace_to_stream(cast(AsyncIterator[object], response), trace_text)
@@ -409,13 +400,35 @@ class Pipe:
     ) -> AsyncIterator[object]:
         async def _wrapped() -> AsyncIterator[object]:
             chunk_type: type[str] | type[bytes] | None = None
+            saw_done = False
+            trace_json = json.dumps({"choices": [{"delta": {"content": f"\n\n{trace_text}"}}]})
+            trace_event = f"data: {trace_json}\n\n"
+
+            def _matches_done(value: str) -> bool:
+                normalized = value.strip()
+                return normalized == "data: [DONE]" or normalized == "[DONE]"
+
             async for chunk in stream:
                 if chunk_type is None:
                     if isinstance(chunk, bytes):
                         chunk_type = bytes
                     elif isinstance(chunk, str):
                         chunk_type = str
+                if isinstance(chunk, bytes):
+                    decoded = chunk.decode("utf-8", errors="ignore")
+                    if _matches_done(decoded):
+                        saw_done = True
+                        yield trace_event.encode("utf-8")
+                        yield chunk
+                        continue
+                elif isinstance(chunk, str) and _matches_done(chunk):
+                    saw_done = True
+                    yield trace_event
+                    yield chunk
+                    continue
                 yield chunk
+            if saw_done:
+                return
             suffix = f"\n\n{trace_text}"
             if chunk_type is bytes:
                 yield suffix.encode("utf-8")
@@ -435,21 +448,18 @@ class Pipe:
         state_after: object,
         llm_called: bool,
         preprocessor_output: str | None = None,
-        trace_details: list[str] | None = None,
+        state_injected: str = "no",
     ) -> Any:
         if not self._trace_enabled():
             return response
-        trace_text = build_trace(
-            original_input=original_input,
-            compiler_input=compiler_input,
+        del original_input, compiler_input, preprocessor_output
+        trace_text = _build_compact_trace_text(
             decision=decision,
             state_before=state_before,
             state_after=state_after,
-            preprocessor_output=preprocessor_output,
             llm_called=llm_called,
+            state_injected=state_injected,
         )
-        if trace_details:
-            trace_text = "\n".join([trace_text, *trace_details])
         return self._append_trace_to_response(response, trace_text)
 
     async def _forward_passthrough(
@@ -586,10 +596,6 @@ class Pipe:
                 state_before=state_before,
                 state_after=state_after,
                 llm_called=False,
-                trace_details=[
-                    f"- current state: {state_after!r}",
-                    "- downstream payload messages: not sent (clarify)",
-                ],
             )
         if near_miss_prompt is not None and kind == "passthrough":
             return self._with_trace(
@@ -600,14 +606,9 @@ class Pipe:
                 state_before=state_before,
                 state_after=state_after,
                 llm_called=False,
-                trace_details=[
-                    f"- current state: {state_after!r}",
-                    "- downstream payload messages: not sent (clarify)",
-                ],
             )
         if kind == "passthrough":
             response = await self._forward_passthrough(body, __user__, __request__)
-            payload_messages = [dict(msg) for msg in messages]
             return self._with_trace(
                 response,
                 original_input=latest_user_text,
@@ -616,20 +617,9 @@ class Pipe:
                 state_before=state_before,
                 state_after=state_after,
                 llm_called=True,
-                trace_details=[
-                    f"- current state: {state_after!r}",
-                    "- payload state injection: no",
-                    "- downstream payload messages: "
-                    f"{_summarize_payload_messages_for_trace(payload_messages)}",
-                ],
             )
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            injected_state_block = _render_compiler_state_block(state_after)
-            payload_messages = _replace_compiler_system_message(
-                [dict(msg) for msg in messages],
-                injected_state_block,
-            )
             response = await self._forward_update(
                 body,
                 __user__,
@@ -644,13 +634,7 @@ class Pipe:
                 state_before=state_before,
                 state_after=state_after,
                 llm_called=True,
-                trace_details=[
-                    f"- current state: {state_after!r}",
-                    f"- injected [[cc_state]] block: {injected_state_block!r}",
-                    "- payload state injection: yes",
-                    "- downstream payload messages: "
-                    f"{_summarize_payload_messages_for_trace(payload_messages)}",
-                ],
+                state_injected=_active_state_summary(state_after),
             )
 
         response = await self._forward_passthrough(body, __user__, __request__)

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -244,6 +244,35 @@ def _build_compact_trace_text(
     return "\n".join(lines)
 
 
+def _strip_trace_block_from_text(content: str) -> str:
+    marker = "Context Compiler trace"
+    index = content.find(marker)
+    if index < 0:
+        return content
+    return content[:index].rstrip()
+
+
+def _strip_trace_blocks_from_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    cleaned: list[dict[str, Any]] = []
+    for message in messages:
+        msg = dict(message)
+        content = msg.get("content")
+        if isinstance(content, str):
+            msg["content"] = _strip_trace_block_from_text(content)
+        cleaned.append(msg)
+    return cleaned
+
+
+def _strip_existing_trace_from_chunk(chunk: object) -> object:
+    if isinstance(chunk, str):
+        return _strip_trace_block_from_text(chunk)
+    if isinstance(chunk, bytes):
+        decoded = chunk.decode("utf-8", errors="ignore")
+        cleaned = _strip_trace_block_from_text(decoded)
+        return cleaned.encode("utf-8")
+    return chunk
+
+
 def _render_item_label(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip().lower()
 
@@ -373,7 +402,8 @@ class Pipe:
         if callable(aiter):
             return self._append_trace_to_stream(cast(AsyncIterator[object], response), trace_text)
         if isinstance(response, str):
-            return f"{response}\n\n{trace_text}"
+            cleaned = _strip_trace_block_from_text(response)
+            return f"{cleaned}\n\n{trace_text}"
         if isinstance(response, dict):
             choices = response.get("choices")
             if isinstance(choices, list) and choices:
@@ -383,7 +413,8 @@ class Pipe:
                     if isinstance(message, dict):
                         content = message.get("content")
                         if isinstance(content, str):
-                            message["content"] = f"{content}\n\n{trace_text}"
+                            cleaned = _strip_trace_block_from_text(content)
+                            message["content"] = f"{cleaned}\n\n{trace_text}"
                             return response
         choices_attr = getattr(response, "choices", None)
         if isinstance(choices_attr, list) and choices_attr:
@@ -391,7 +422,8 @@ class Pipe:
             message_attr = getattr(first_choice, "message", None)
             content_attr = getattr(message_attr, "content", None)
             if message_attr is not None and isinstance(content_attr, str):
-                message_attr.content = f"{content_attr}\n\n{trace_text}"
+                cleaned = _strip_trace_block_from_text(content_attr)
+                message_attr.content = f"{cleaned}\n\n{trace_text}"
                 return response
         return response
 
@@ -426,7 +458,7 @@ class Pipe:
                     yield trace_event
                     yield chunk
                     continue
-                yield chunk
+                yield _strip_existing_trace_from_chunk(chunk)
             if saw_done:
                 return
             suffix = f"\n\n{trace_text}"
@@ -471,6 +503,11 @@ class Pipe:
         """Forward with a shallow body copy and model override only."""
         payload = {**body}
         payload["model"] = self.valves.BASE_MODEL_ID
+        raw_messages = body.get("messages")
+        if isinstance(raw_messages, list):
+            payload["messages"] = _strip_trace_blocks_from_messages(
+                [msg for msg in raw_messages if isinstance(msg, dict)]
+            )
         user = Users.get_user_by_id(user_payload["id"])
         if inspect.isawaitable(user):
             user = await user
@@ -503,7 +540,9 @@ class Pipe:
 
         raw_messages = body.get("messages")
         messages = (
-            [dict(msg) for msg in raw_messages if isinstance(msg, dict)]
+            _strip_trace_blocks_from_messages(
+                [msg for msg in raw_messages if isinstance(msg, dict)]
+            )
             if isinstance(raw_messages, list)
             else []
         )

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -330,6 +330,16 @@ def _summarize_update_from_input(user_input: str) -> str:
     return "State updated."
 
 
+def _is_administrative_update_input(user_input: str) -> bool:
+    normalized = re.sub(r"\s+", " ", user_input.strip()).lower()
+    return (
+        normalized == "clear state"
+        or normalized == "clear premise"
+        or normalized == "reset policies"
+        or normalized.startswith("remove policy ")
+    )
+
+
 class Pipe:
     """Map Context Compiler decisions into Open WebUI pipe behavior.
 
@@ -659,6 +669,16 @@ class Pipe:
             )
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
+            if _is_administrative_update_input(latest_user_text):
+                return self._with_trace(
+                    _summarize_update_from_input(latest_user_text),
+                    original_input=latest_user_text,
+                    compiler_input=latest_user_text,
+                    decision=decision,
+                    state_before=state_before,
+                    state_after=state_after,
+                    llm_called=False,
+                )
             response = await self._forward_update(
                 body,
                 __user__,

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -3,7 +3,7 @@ title: Context Compiler Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.8.1
+version: 0.8.2
 requirements: context-compiler>=0.6.14
 
 Minimal Open WebUI Pipe integration for Context Compiler.

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -196,6 +196,21 @@ def _replace_compiler_system_message(
     ]
 
 
+def _summarize_payload_messages_for_trace(messages: list[dict[str, Any]]) -> str:
+    if not messages:
+        return "[]"
+    parts: list[str] = []
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content")
+        if isinstance(content, str):
+            content_preview = f"{content[:57]}..." if len(content) > 60 else content
+        else:
+            content_preview = repr(content)
+        parts.append(f"{role}:{content_preview!r}")
+    return "[" + ", ".join(parts) + "]"
+
+
 def _normalize_confirmation_for_summary(value: str) -> str:
     normalized = value.strip().lower()
     normalized = re.sub(r"\s+", " ", normalized)
@@ -306,7 +321,7 @@ class Pipe:
 
     - ``clarify`` returns plain text and skips model forwarding.
     - ``passthrough`` forwards with minimal mutation.
-    - ``update`` returns deterministic acknowledgment text.
+    - ``update`` forwards with compiler-owned state injection.
     """
 
     class Valves(BaseModel):
@@ -412,6 +427,7 @@ class Pipe:
         state_after: object,
         llm_called: bool,
         preprocessor_output: str | None = None,
+        trace_details: list[str] | None = None,
     ) -> Any:
         if not self._trace_enabled():
             return response
@@ -424,6 +440,8 @@ class Pipe:
             preprocessor_output=preprocessor_output,
             llm_called=llm_called,
         )
+        if trace_details:
+            trace_text = "\n".join([trace_text, *trace_details])
         return self._append_trace_to_response(response, trace_text)
 
     async def _forward_passthrough(
@@ -540,7 +558,6 @@ class Pipe:
             _ENGINES_BY_CHAT_KEY[chat_key] = engine
 
         checkpoint_before = engine.export_checkpoint()
-        pending_before = checkpoint_before.get("pending")
         logger.debug("pipe: engine_input=%r", latest_user_text)
         decision = engine.step(latest_user_text)
         kind = decision["kind"]
@@ -561,6 +578,10 @@ class Pipe:
                 state_before=state_before,
                 state_after=state_after,
                 llm_called=False,
+                trace_details=[
+                    f"- current state: {state_after!r}",
+                    "- downstream payload messages: not sent (clarify)",
+                ],
             )
         if near_miss_prompt is not None and kind == "passthrough":
             return self._with_trace(
@@ -571,9 +592,14 @@ class Pipe:
                 state_before=state_before,
                 state_after=state_after,
                 llm_called=False,
+                trace_details=[
+                    f"- current state: {state_after!r}",
+                    "- downstream payload messages: not sent (clarify)",
+                ],
             )
         if kind == "passthrough":
             response = await self._forward_passthrough(body, __user__, __request__)
+            payload_messages = [dict(msg) for msg in messages]
             return self._with_trace(
                 response,
                 original_input=latest_user_text,
@@ -582,21 +608,41 @@ class Pipe:
                 state_before=state_before,
                 state_after=state_after,
                 llm_called=True,
+                trace_details=[
+                    f"- current state: {state_after!r}",
+                    "- payload state injection: no",
+                    "- downstream payload messages: "
+                    f"{_summarize_payload_messages_for_trace(payload_messages)}",
+                ],
             )
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            if is_confirmation_text(latest_user_text) and pending_before is not None:
-                result = _summarize_confirmation_update(latest_user_text, pending_before)
-            else:
-                result = _summarize_update_from_input(latest_user_text)
+            injected_state_block = _render_compiler_state_block(state_after)
+            payload_messages = _replace_compiler_system_message(
+                [dict(msg) for msg in messages],
+                injected_state_block,
+            )
+            response = await self._forward_update(
+                body,
+                __user__,
+                __request__,
+                state_after,
+            )
             return self._with_trace(
-                result,
+                response,
                 original_input=latest_user_text,
                 compiler_input=latest_user_text,
                 decision=decision,
                 state_before=state_before,
                 state_after=state_after,
-                llm_called=False,
+                llm_called=True,
+                trace_details=[
+                    f"- current state: {state_after!r}",
+                    f"- injected [[cc_state]] block: {injected_state_block!r}",
+                    "- payload state injection: yes",
+                    "- downstream payload messages: "
+                    f"{_summarize_payload_messages_for_trace(payload_messages)}",
+                ],
             )
 
         response = await self._forward_passthrough(body, __user__, __request__)

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -394,6 +394,14 @@ class Pipe:
                         if isinstance(content, str):
                             message["content"] = f"{content}\n\n{trace_text}"
                             return response
+        choices_attr = getattr(response, "choices", None)
+        if isinstance(choices_attr, list) and choices_attr:
+            first_choice = choices_attr[0]
+            message_attr = getattr(first_choice, "message", None)
+            content_attr = getattr(message_attr, "content", None)
+            if message_attr is not None and isinstance(content_attr, str):
+                message_attr.content = f"{content_attr}\n\n{trace_text}"
+                return response
         return response
 
     def _append_trace_to_stream(

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -197,6 +197,21 @@ def _replace_compiler_system_message(
     ]
 
 
+def _summarize_payload_messages_for_trace(messages: list[dict[str, Any]]) -> str:
+    if not messages:
+        return "[]"
+    parts: list[str] = []
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content")
+        if isinstance(content, str):
+            content_preview = f"{content[:57]}..." if len(content) > 60 else content
+        else:
+            content_preview = repr(content)
+        parts.append(f"{role}:{content_preview!r}")
+    return "[" + ", ".join(parts) + "]"
+
+
 def _normalize_confirmation_for_summary(value: str) -> str:
     normalized = value.strip().lower()
     normalized = re.sub(r"\s+", " ", normalized)
@@ -349,7 +364,7 @@ class Pipe:
 
     This variant adds a precompiler stage before ``engine.step(...)``:
     heuristic first, then Open WebUI-native LLM fallback.
-    Update decisions return deterministic acknowledgment text.
+    Update decisions forward with compiler-owned state injection.
     """
 
     class Valves(BaseModel):
@@ -439,6 +454,7 @@ class Pipe:
         state_after: object,
         llm_called: bool,
         preprocessor_output: str | None = None,
+        trace_details: list[str] | None = None,
     ) -> Any:
         if not self._trace_enabled():
             return response
@@ -451,6 +467,8 @@ class Pipe:
             preprocessor_output=preprocessor_output,
             llm_called=llm_called,
         )
+        if trace_details:
+            trace_text = "\n".join([trace_text, *trace_details])
         return self._append_trace_to_response(response, trace_text)
 
     def _is_model_not_found_text(self, value: object) -> bool:
@@ -837,6 +855,10 @@ class Pipe:
                 state_after=state_after,
                 preprocessor_output=precompiled,
                 llm_called=False,
+                trace_details=[
+                    f"- current state: {state_after!r}",
+                    "- downstream payload messages: not sent (clarify)",
+                ],
             )
         if near_miss_prompt is not None and kind == "passthrough":
             return self._with_trace(
@@ -848,12 +870,47 @@ class Pipe:
                 state_after=state_after,
                 preprocessor_output=precompiled,
                 llm_called=False,
+                trace_details=[
+                    f"- current state: {state_after!r}",
+                    "- downstream payload messages: not sent (clarify)",
+                ],
             )
         if kind == "passthrough":
             response = await self._forward_passthrough(
                 body,
                 __user__,
                 __request__,
+                base_model_id=base_model_id,
+            )
+            payload_messages = [dict(msg) for msg in messages]
+            return self._with_trace(
+                response,
+                original_input=latest_user_text,
+                compiler_input=compile_input,
+                decision=decision,
+                state_before=state_before,
+                state_after=state_after,
+                preprocessor_output=precompiled,
+                llm_called=base_model_id is not None,
+                trace_details=[
+                    f"- current state: {state_after!r}",
+                    "- payload state injection: no",
+                    "- downstream payload messages: "
+                    f"{_summarize_payload_messages_for_trace(payload_messages)}",
+                ],
+            )
+        if kind == "update":
+            _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
+            injected_state_block = _render_compiler_state_block(state_after)
+            payload_messages = _replace_compiler_system_message(
+                [dict(msg) for msg in messages],
+                injected_state_block,
+            )
+            response = await self._forward_update(
+                body,
+                __user__,
+                __request__,
+                state_after,
                 base_model_id=base_model_id,
             )
             return self._with_trace(
@@ -865,22 +922,13 @@ class Pipe:
                 state_after=state_after,
                 preprocessor_output=precompiled,
                 llm_called=base_model_id is not None,
-            )
-        if kind == "update":
-            _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            if is_confirmation_text(latest_user_text) and pending_before is not None:
-                result = _summarize_confirmation_update(latest_user_text, pending_before)
-            else:
-                result = _summarize_update_from_input(compile_input)
-            return self._with_trace(
-                result,
-                original_input=latest_user_text,
-                compiler_input=compile_input,
-                decision=decision,
-                state_before=state_before,
-                state_after=state_after,
-                preprocessor_output=precompiled,
-                llm_called=False,
+                trace_details=[
+                    f"- current state: {state_after!r}",
+                    f"- injected [[cc_state]] block: {injected_state_block!r}",
+                    "- payload state injection: yes",
+                    "- downstream payload messages: "
+                    f"{_summarize_payload_messages_for_trace(payload_messages)}",
+                ],
             )
 
         response = await self._forward_passthrough(

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -421,6 +421,14 @@ class Pipe:
                         if isinstance(content, str):
                             message["content"] = f"{content}\n\n{trace_text}"
                             return response
+        choices_attr = getattr(response, "choices", None)
+        if isinstance(choices_attr, list) and choices_attr:
+            first_choice = choices_attr[0]
+            message_attr = getattr(first_choice, "message", None)
+            content_attr = getattr(message_attr, "content", None)
+            if message_attr is not None and isinstance(content_attr, str):
+                message_attr.content = f"{content_attr}\n\n{trace_text}"
+                return response
         return response
 
     def _append_trace_to_stream(

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -18,6 +18,7 @@ Core decision handling remains the same as the base integration.
 """
 
 import inspect
+import json
 import logging
 import re
 from collections.abc import AsyncIterator
@@ -55,42 +56,6 @@ from experimental.preprocessor import (
     render_prompt,
 )
 
-try:
-    from host_support import is_confirmation_text, summarize_confirmation_update
-except ImportError:
-    import host_support.confirmation as _confirmation
-
-    is_confirmation_text = _confirmation.is_confirmation_text
-    summarize_confirmation_update = _confirmation.summarize_confirmation_update
-try:
-    from host_support import build_trace
-except ImportError:
-    try:
-        from host_support.observability import build_trace
-    except ImportError:
-
-        def build_trace(
-            *,
-            original_input: str,
-            compiler_input: str,
-            decision: object,
-            state_before: object,
-            state_after: object,
-            preprocessor_output: str | None = None,
-            llm_called: bool = False,
-        ) -> str:
-            del (
-                original_input,
-                compiler_input,
-                decision,
-                state_before,
-                state_after,
-                preprocessor_output,
-                llm_called,
-            )
-            return ""
-
-
 logger = logging.getLogger(__name__)
 
 _CC_MARKER = "[[cc_state]]"
@@ -101,8 +66,6 @@ _ENGINES_BY_CHAT_KEY: dict[str, Engine] = {}
 # or restart continuity for pending flows will be lost.
 _CHECKPOINTS_BY_CHAT_KEY: dict[str, str] = {}
 _PROMPTS_DIR = files("experimental.preprocessor").joinpath("prompts")
-_NEGATIVE_CONFIRMATION_TOKENS = {"no", "nope", "no thanks"}
-_TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
 
 
 def _is_directive_shaped_input(message: str) -> bool:
@@ -197,26 +160,89 @@ def _replace_compiler_system_message(
     ]
 
 
-def _summarize_payload_messages_for_trace(messages: list[dict[str, Any]]) -> str:
-    if not messages:
-        return "[]"
+def _normalize_state(value: object) -> State:
+    if isinstance(value, dict):
+        return cast(State, value)
+    return {"premise": None, "policies": {}, "version": 2}
+
+
+def _active_state_summary(state: object) -> str:
+    normalized = _normalize_state(state)
+    premise = get_premise_value(normalized)
+    use_items = sorted(get_policy_items(normalized, "use"))
+    prohibit_items = sorted(get_policy_items(normalized, "prohibit"))
     parts: list[str] = []
-    for message in messages:
-        role = message.get("role")
-        content = message.get("content")
-        if isinstance(content, str):
-            content_preview = f"{content[:57]}..." if len(content) > 60 else content
+    if premise is not None:
+        parts.append(f'premise="{premise}"')
+    if use_items:
+        parts.append("use " + ", ".join(use_items))
+    if prohibit_items:
+        parts.append("prohibit " + ", ".join(prohibit_items))
+    return "; ".join(parts) if parts else "none"
+
+
+def _compact_state_change(before: object, after: object) -> str:
+    before_state = _normalize_state(before)
+    after_state = _normalize_state(after)
+    before_premise = get_premise_value(before_state)
+    after_premise = get_premise_value(after_state)
+    before_use = set(get_policy_items(before_state, "use"))
+    after_use = set(get_policy_items(after_state, "use"))
+    before_prohibit = set(get_policy_items(before_state, "prohibit"))
+    after_prohibit = set(get_policy_items(after_state, "prohibit"))
+
+    parts: list[str] = []
+    if before_premise != after_premise:
+        if after_premise is None:
+            parts.append("-premise")
+        elif before_premise is None:
+            parts.append(f'+premise "{after_premise}"')
         else:
-            content_preview = repr(content)
-        parts.append(f"{role}:{content_preview!r}")
-    return "[" + ", ".join(parts) + "]"
+            parts.append(f'~premise "{after_premise}"')
+    for item in sorted(after_use - before_use):
+        parts.append(f"+use {item}")
+    for item in sorted(before_use - after_use):
+        parts.append(f"-use {item}")
+    for item in sorted(after_prohibit - before_prohibit):
+        parts.append(f"+prohibit {item}")
+    for item in sorted(before_prohibit - after_prohibit):
+        parts.append(f"-prohibit {item}")
+    return ", ".join(parts) if parts else "none"
 
 
-def _normalize_confirmation_for_summary(value: str) -> str:
-    normalized = value.strip().lower()
-    normalized = re.sub(r"\s+", " ", normalized)
-    normalized = _TRAILING_CONFIRM_PUNCT_RE.sub("", normalized).strip()
-    return re.sub(r"\s+", " ", normalized)
+def _build_compact_trace_text(
+    *,
+    decision: object,
+    state_before: object,
+    state_after: object,
+    llm_called: bool,
+    state_injected: str,
+) -> str:
+    kind_obj = decision.get("kind") if isinstance(decision, dict) else None
+    kind = kind_obj if isinstance(kind_obj, str) else "unknown"
+    lines = ["Context Compiler trace", "", f"decision kind: {kind}"]
+
+    if kind == "update":
+        lines.append(f"state change: {_compact_state_change(state_before, state_after)}")
+        lines.append(f"active state: {_active_state_summary(state_after)}")
+        lines.append(f"downstream LLM call: {'yes' if llm_called else 'no'}")
+        lines.append("")
+        lines.append(f"state injected: {state_injected}")
+        return "\n".join(lines)
+
+    if kind == "clarify":
+        prompt_obj = decision.get("prompt_to_user") if isinstance(decision, dict) else None
+        prompt = prompt_obj if isinstance(prompt_obj, str) else ""
+        lines.append(f"clarification prompt: {prompt}")
+        lines.append(f"active state: {_active_state_summary(state_after)}")
+        lines.append(f"downstream LLM call: {'yes' if llm_called else 'no'}")
+        lines.append("state injected: no")
+        return "\n".join(lines)
+
+    lines.append(f"active state: {_active_state_summary(state_after)}")
+    lines.append(f"downstream LLM call: {'yes' if llm_called else 'no'}")
+    lines.append("state injected: no")
+    return "\n".join(lines)
 
 
 def _render_item_label(value: str) -> str:
@@ -272,47 +298,6 @@ def _summarize_update_from_input(user_input: str) -> str:
         item = _render_item_label(remove_policy_match.group(1).rstrip(" .!?"))
         if item:
             return f"State updated: Removed policy {item}."
-
-    return "State updated."
-
-
-def _summarize_confirmation_update(user_input: str, pending: object) -> str:
-    summarize_fn = summarize_confirmation_update
-    if callable(summarize_fn):
-        return summarize_fn(user_input, pending)
-
-    normalized = _normalize_confirmation_for_summary(user_input)
-    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
-        return "State unchanged."
-    if not isinstance(pending, dict):
-        return "State updated."
-
-    replacement = pending.get("replacement")
-    if not isinstance(replacement, dict):
-        return "State updated."
-
-    kind = replacement.get("kind")
-    new_item = replacement.get("new_item")
-    old_item = replacement.get("old_item")
-    if kind == "use_only" and isinstance(new_item, str):
-        new_label = _render_item_label(new_item)
-        if new_label:
-            return f"State updated: Use {new_label}."
-        return "State updated."
-
-    if kind == "replace_use" and isinstance(new_item, str) and isinstance(old_item, str):
-        new_label = _render_item_label(new_item)
-        old_label = _render_item_label(old_item)
-        if not new_label or not old_label:
-            return "State updated."
-        prompt = pending.get("prompt_to_user")
-        prohibited_old_prompt = (
-            f'"{old_item}" is currently prohibited. '
-            f'Did you mean to remove it and use "{new_item}" instead?'
-        )
-        if prompt == prohibited_old_prompt:
-            return f"State updated: Removed prohibition on {old_label}; use {new_label}."
-        return f"State updated: Replaced {old_label} with {new_label}."
 
     return "State updated."
 
@@ -405,6 +390,12 @@ class Pipe:
         return bool(getattr(self.valves, "SHOW_CONTEXT_COMPILER_TRACE", False))
 
     def _append_trace_to_response(self, response: Any, trace_text: str) -> Any:
+        body_iterator = getattr(response, "body_iterator", None)
+        if body_iterator is not None and callable(getattr(body_iterator, "__aiter__", None)):
+            response.body_iterator = self._append_trace_to_stream(
+                cast(AsyncIterator[object], body_iterator), trace_text
+            )
+            return response
         aiter = getattr(response, "__aiter__", None)
         if callable(aiter):
             return self._append_trace_to_stream(cast(AsyncIterator[object], response), trace_text)
@@ -436,13 +427,35 @@ class Pipe:
     ) -> AsyncIterator[object]:
         async def _wrapped() -> AsyncIterator[object]:
             chunk_type: type[str] | type[bytes] | None = None
+            saw_done = False
+            trace_json = json.dumps({"choices": [{"delta": {"content": f"\n\n{trace_text}"}}]})
+            trace_event = f"data: {trace_json}\n\n"
+
+            def _matches_done(value: str) -> bool:
+                normalized = value.strip()
+                return normalized == "data: [DONE]" or normalized == "[DONE]"
+
             async for chunk in stream:
                 if chunk_type is None:
                     if isinstance(chunk, bytes):
                         chunk_type = bytes
                     elif isinstance(chunk, str):
                         chunk_type = str
+                if isinstance(chunk, bytes):
+                    decoded = chunk.decode("utf-8", errors="ignore")
+                    if _matches_done(decoded):
+                        saw_done = True
+                        yield trace_event.encode("utf-8")
+                        yield chunk
+                        continue
+                elif isinstance(chunk, str) and _matches_done(chunk):
+                    saw_done = True
+                    yield trace_event
+                    yield chunk
+                    continue
                 yield chunk
+            if saw_done:
+                return
             suffix = f"\n\n{trace_text}"
             if chunk_type is bytes:
                 yield suffix.encode("utf-8")
@@ -462,21 +475,18 @@ class Pipe:
         state_after: object,
         llm_called: bool,
         preprocessor_output: str | None = None,
-        trace_details: list[str] | None = None,
+        state_injected: str = "no",
     ) -> Any:
         if not self._trace_enabled():
             return response
-        trace_text = build_trace(
-            original_input=original_input,
-            compiler_input=compiler_input,
+        del original_input, compiler_input, preprocessor_output
+        trace_text = _build_compact_trace_text(
             decision=decision,
             state_before=state_before,
             state_after=state_after,
-            preprocessor_output=preprocessor_output,
             llm_called=llm_called,
+            state_injected=state_injected,
         )
-        if trace_details:
-            trace_text = "\n".join([trace_text, *trace_details])
         return self._append_trace_to_response(response, trace_text)
 
     def _is_model_not_found_text(self, value: object) -> bool:
@@ -863,10 +873,6 @@ class Pipe:
                 state_after=state_after,
                 preprocessor_output=precompiled,
                 llm_called=False,
-                trace_details=[
-                    f"- current state: {state_after!r}",
-                    "- downstream payload messages: not sent (clarify)",
-                ],
             )
         if near_miss_prompt is not None and kind == "passthrough":
             return self._with_trace(
@@ -878,10 +884,6 @@ class Pipe:
                 state_after=state_after,
                 preprocessor_output=precompiled,
                 llm_called=False,
-                trace_details=[
-                    f"- current state: {state_after!r}",
-                    "- downstream payload messages: not sent (clarify)",
-                ],
             )
         if kind == "passthrough":
             response = await self._forward_passthrough(
@@ -890,7 +892,6 @@ class Pipe:
                 __request__,
                 base_model_id=base_model_id,
             )
-            payload_messages = [dict(msg) for msg in messages]
             return self._with_trace(
                 response,
                 original_input=latest_user_text,
@@ -900,20 +901,9 @@ class Pipe:
                 state_after=state_after,
                 preprocessor_output=precompiled,
                 llm_called=base_model_id is not None,
-                trace_details=[
-                    f"- current state: {state_after!r}",
-                    "- payload state injection: no",
-                    "- downstream payload messages: "
-                    f"{_summarize_payload_messages_for_trace(payload_messages)}",
-                ],
             )
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            injected_state_block = _render_compiler_state_block(state_after)
-            payload_messages = _replace_compiler_system_message(
-                [dict(msg) for msg in messages],
-                injected_state_block,
-            )
             response = await self._forward_update(
                 body,
                 __user__,
@@ -930,13 +920,7 @@ class Pipe:
                 state_after=state_after,
                 preprocessor_output=precompiled,
                 llm_called=base_model_id is not None,
-                trace_details=[
-                    f"- current state: {state_after!r}",
-                    f"- injected [[cc_state]] block: {injected_state_block!r}",
-                    "- payload state injection: yes",
-                    "- downstream payload messages: "
-                    f"{_summarize_payload_messages_for_trace(payload_messages)}",
-                ],
+                state_injected=_active_state_summary(state_after),
             )
 
         response = await self._forward_passthrough(

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -245,6 +245,35 @@ def _build_compact_trace_text(
     return "\n".join(lines)
 
 
+def _strip_trace_block_from_text(content: str) -> str:
+    marker = "Context Compiler trace"
+    index = content.find(marker)
+    if index < 0:
+        return content
+    return content[:index].rstrip()
+
+
+def _strip_trace_blocks_from_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    cleaned: list[dict[str, Any]] = []
+    for message in messages:
+        msg = dict(message)
+        content = msg.get("content")
+        if isinstance(content, str):
+            msg["content"] = _strip_trace_block_from_text(content)
+        cleaned.append(msg)
+    return cleaned
+
+
+def _strip_existing_trace_from_chunk(chunk: object) -> object:
+    if isinstance(chunk, str):
+        return _strip_trace_block_from_text(chunk)
+    if isinstance(chunk, bytes):
+        decoded = chunk.decode("utf-8", errors="ignore")
+        cleaned = _strip_trace_block_from_text(decoded)
+        return cleaned.encode("utf-8")
+    return chunk
+
+
 def _render_item_label(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip().lower()
 
@@ -400,7 +429,8 @@ class Pipe:
         if callable(aiter):
             return self._append_trace_to_stream(cast(AsyncIterator[object], response), trace_text)
         if isinstance(response, str):
-            return f"{response}\n\n{trace_text}"
+            cleaned = _strip_trace_block_from_text(response)
+            return f"{cleaned}\n\n{trace_text}"
         if isinstance(response, dict):
             choices = response.get("choices")
             if isinstance(choices, list) and choices:
@@ -410,7 +440,8 @@ class Pipe:
                     if isinstance(message, dict):
                         content = message.get("content")
                         if isinstance(content, str):
-                            message["content"] = f"{content}\n\n{trace_text}"
+                            cleaned = _strip_trace_block_from_text(content)
+                            message["content"] = f"{cleaned}\n\n{trace_text}"
                             return response
         choices_attr = getattr(response, "choices", None)
         if isinstance(choices_attr, list) and choices_attr:
@@ -418,7 +449,8 @@ class Pipe:
             message_attr = getattr(first_choice, "message", None)
             content_attr = getattr(message_attr, "content", None)
             if message_attr is not None and isinstance(content_attr, str):
-                message_attr.content = f"{content_attr}\n\n{trace_text}"
+                cleaned = _strip_trace_block_from_text(content_attr)
+                message_attr.content = f"{cleaned}\n\n{trace_text}"
                 return response
         return response
 
@@ -453,7 +485,7 @@ class Pipe:
                     yield trace_event
                     yield chunk
                     continue
-                yield chunk
+                yield _strip_existing_trace_from_chunk(chunk)
             if saw_done:
                 return
             suffix = f"\n\n{trace_text}"
@@ -694,6 +726,11 @@ class Pipe:
             )
         payload = {**body}
         payload["model"] = base_model_id
+        raw_messages = body.get("messages")
+        if isinstance(raw_messages, list):
+            payload["messages"] = _strip_trace_blocks_from_messages(
+                [msg for msg in raw_messages if isinstance(msg, dict)]
+            )
         user = Users.get_user_by_id(user_payload["id"])
         if inspect.isawaitable(user):
             user = await user
@@ -733,7 +770,9 @@ class Pipe:
 
         raw_messages = body.get("messages")
         messages = (
-            [dict(msg) for msg in raw_messages if isinstance(msg, dict)]
+            _strip_trace_blocks_from_messages(
+                [msg for msg in raw_messages if isinstance(msg, dict)]
+            )
             if isinstance(raw_messages, list)
             else []
         )

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -3,7 +3,7 @@ title: Context Compiler Preprocessor Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.8.1
+version: 0.8.2
 requirements: context-compiler[experimental]>=0.6.14
 
 Open WebUI integration with Context Compiler preprocessor.

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -331,6 +331,16 @@ def _summarize_update_from_input(user_input: str) -> str:
     return "State updated."
 
 
+def _is_administrative_update_input(user_input: str) -> bool:
+    normalized = re.sub(r"\s+", " ", user_input.strip()).lower()
+    return (
+        normalized == "clear state"
+        or normalized == "clear premise"
+        or normalized == "reset policies"
+        or normalized.startswith("remove policy ")
+    )
+
+
 def _extract_completion_content(response: object) -> str | None:
     choices_attr = getattr(response, "choices", None)
     if isinstance(choices_attr, list) and choices_attr:
@@ -943,6 +953,17 @@ class Pipe:
             )
         if kind == "update":
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
+            if _is_administrative_update_input(compile_input):
+                return self._with_trace(
+                    _summarize_update_from_input(compile_input),
+                    original_input=latest_user_text,
+                    compiler_input=compile_input,
+                    decision=decision,
+                    state_before=state_before,
+                    state_after=state_after,
+                    preprocessor_output=precompiled,
+                    llm_called=False,
+                )
             response = await self._forward_update(
                 body,
                 __user__,

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -894,3 +894,191 @@ def test_pipe_trace_appends_on_streaming_response_wrapper_passthrough_and_update
         and payload["messages"][0]["content"].startswith("[[cc_state]]")
         for payload in forwarded_payloads
     )
+
+
+@pytest.mark.parametrize(
+    ("steps", "expected_state_injected"),
+    [
+        (
+            ["use docker", "clear state"],
+            "none",
+        ),
+        (
+            ["set premise concise replies", "clear premise"],
+            "none",
+        ),
+        (
+            ["use docker", "use pytest", "reset policies"],
+            "none",
+        ),
+        (
+            ["use docker", "remove policy docker"],
+            "none",
+        ),
+    ],
+)
+def test_pipe_trace_update_clear_reset_paths_single_and_consistent(
+    monkeypatch,
+    steps: list[str],
+    expected_state_injected: str,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_trace_clear_reset", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        del payload
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    module.generate_chat_completion = _chat_completion
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result: object = ""
+    for idx, user_input in enumerate(steps):
+        result = asyncio.run(
+            pipe.pipe(
+                {"model": "pipe-model", "messages": [{"role": "user", "content": user_input}]},
+                __user__={"id": "u1"},
+                __request__=object(),
+                __chat_id__=f"chat-trace-clear-reset-{hash(tuple(steps))}",
+            )
+        )
+        if idx < len(steps) - 1:
+            continue
+
+    assert isinstance(result, dict)
+    content = result["choices"][0]["message"]["content"]
+    assert content.count("Context Compiler trace") == 1
+    assert "decision kind: update" in content
+    assert "downstream LLM call: yes" in content
+    assert "downstream LLM call: no" not in content
+    assert "active state: none" in content
+    assert f"state injected: {expected_state_injected}" in content
+
+
+def test_pipe_clear_state_trace_not_duplicated_when_model_echoes_history(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_trace_echo_dedupe", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        messages = payload.get("messages")
+        echoed = ""
+        if isinstance(messages, list):
+            assistant_contents = [
+                str(msg.get("content", ""))
+                for msg in messages
+                if isinstance(msg, dict) and msg.get("role") == "assistant"
+            ]
+            echoed = "\n".join(assistant_contents)
+        content = "downstream"
+        if echoed:
+            content += f"\n{echoed}"
+        return {"choices": [{"message": {"content": content}}]}
+
+    module.generate_chat_completion = _chat_completion
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+    chat_id = "chat-trace-echo-dedupe"
+
+    first = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+    assert isinstance(first, dict)
+    first_content = first["choices"][0]["message"]["content"]
+    assert first_content.count("Context Compiler trace") == 1
+
+    second = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [
+                    {"role": "assistant", "content": first_content},
+                    {"role": "user", "content": "clear state"},
+                ],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+    assert isinstance(second, dict)
+    second_content = second["choices"][0]["message"]["content"]
+    assert second_content.count("Context Compiler trace") == 1
+    assert "decision kind: update" in second_content
+    assert "downstream LLM call: yes" in second_content
+    assert "downstream LLM call: no" not in second_content
+    assert "active state: none" in second_content
+    assert "state injected: none" in second_content
+
+
+def test_pipe_clear_state_strips_preexisting_contradictory_trace_from_model_output(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_trace_strip_contradiction", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    old_trace = (
+        "Context Compiler trace\n\n"
+        "decision kind: update\n"
+        "active state: none\n"
+        "downstream LLM call: no\n"
+        "\n"
+        "state injected: none"
+    )
+
+    call_count = 0
+
+    async def _chat_completion(
+        _: object,
+        payload: dict[str, object],
+        __: object,
+    ) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {"choices": [{"message": {"content": "downstream"}}]}
+        del payload
+        return {"choices": [{"message": {"content": f"downstream\n{old_trace}"}}]}
+
+    module.generate_chat_completion = _chat_completion
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+    chat_id = "chat-trace-strip-contradiction"
+
+    _ = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+
+    second = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "clear state"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+    assert isinstance(second, dict)
+    second_content = second["choices"][0]["message"]["content"]
+    assert second_content.count("Context Compiler trace") == 1
+    assert "downstream LLM call: yes" in second_content
+    assert "downstream LLM call: no" not in second_content

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -265,7 +265,7 @@ def test_pipe_supports_async_user_lookup(monkeypatch) -> None:
     assert isinstance(result, dict)
 
 
-def test_pipe_normal_update_returns_deterministic_ack_and_persists_checkpoint(monkeypatch) -> None:
+def test_pipe_normal_update_forwards_with_state_and_persists_checkpoint(monkeypatch) -> None:
     module = _load_module_with_openwebui_stubs("owui_pipe_update_forward", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
@@ -296,8 +296,11 @@ def test_pipe_normal_update_returns_deterministic_ack_and_persists_checkpoint(mo
         )
     )
 
-    assert result == "State updated: Prohibit peanuts."
-    assert len(forwarded_payloads) == 0
+    assert result == {"ok": True}
+    assert len(forwarded_payloads) == 1
+    first_messages = forwarded_payloads[0]["messages"]
+    assert isinstance(first_messages, list)
+    assert first_messages[0] == {"role": "system", "content": "[[cc_state]]\nProhibit: peanuts"}
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
@@ -315,27 +318,29 @@ def test_pipe_normal_update_returns_deterministic_ack_and_persists_checkpoint(mo
         )
     )
 
-    assert result == "State updated: Removed policy peanuts."
-    assert len(forwarded_payloads) == 0
+    assert result == {"ok": True}
+    assert len(forwarded_payloads) == 2
+    second_messages = forwarded_payloads[1]["messages"]
+    assert isinstance(second_messages, list)
+    assert second_messages[0] == {"role": "system", "content": "[[cc_state]]"}
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
     assert checkpoint["authoritative_state"]["policies"] == {}
 
 
-def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch) -> None:
-    module = _load_module_with_openwebui_stubs("owui_pipe_literal_replace_summary", monkeypatch)
+def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_update_shapes", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
 
-    downstream_calls = 0
+    forwarded_payloads: list[dict[str, object]] = []
 
     async def _track_downstream(
         _: object, payload: dict[str, object], __: object
     ) -> dict[str, object]:
-        nonlocal downstream_calls
-        downstream_calls += 1
-        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+        forwarded_payloads.append(payload)
+        return {"ok": True}
 
     module.generate_chat_completion = _track_downstream
 
@@ -350,7 +355,7 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
             __chat_id__="chat-use",
         )
     )
-    assert result == "State updated: Use docker."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -363,7 +368,7 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
             __chat_id__="chat-prohibit",
         )
     )
-    assert result == "State updated: Prohibit docker."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -376,7 +381,7 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
             __chat_id__="chat-remove",
         )
     )
-    assert result == "State updated: Removed policy docker."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -386,7 +391,7 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
             __chat_id__="chat-replace",
         )
     )
-    assert result == "State updated: Use docker."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -399,7 +404,7 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
             __chat_id__="chat-replace",
         )
     )
-    assert result == "State updated: Use kubectl."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -412,7 +417,7 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
             __chat_id__="chat-premise",
         )
     )
-    assert result == "State updated."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -422,7 +427,7 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
             __chat_id__="chat-premise",
         )
     )
-    assert result == "Premise cleared."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -435,8 +440,16 @@ def test_pipe_literal_replacement_update_summary_uses_new_item_only(monkeypatch)
             __chat_id__="chat-replace-noop",
         )
     )
-    assert result == "State updated: Use docker."
-    assert downstream_calls == 0
+    assert result == {"ok": True}
+    assert len(forwarded_payloads) == 8
+    assert all(
+        isinstance(payload.get("messages"), list)
+        and isinstance(payload["messages"][0], dict)
+        and payload["messages"][0].get("role") == "system"
+        and isinstance(payload["messages"][0].get("content"), str)
+        and payload["messages"][0]["content"].startswith("[[cc_state]]")
+        for payload in forwarded_payloads
+    )
 
 
 def test_pipe_near_miss_directives_return_deterministic_clarify_without_downstream(
@@ -486,32 +499,30 @@ def test_pipe_near_miss_directives_return_deterministic_clarify_without_downstre
 
 
 @pytest.mark.parametrize(
-    ("confirmation", "expected_policies", "expected_response"),
+    ("confirmation", "expected_policies"),
     [
-        ("yes", {"docker": "use"}, "State updated: Use docker."),
-        ("YES!", {"docker": "use"}, "State updated: Use docker."),
-        (" yes please ", {"docker": "use"}, "State updated: Use docker."),
-        ("no thanks.", {}, "State unchanged."),
+        ("yes", {"docker": "use"}),
+        ("YES!", {"docker": "use"}),
+        (" yes please ", {"docker": "use"}),
+        ("no thanks.", {}),
     ],
 )
-def test_pipe_confirmation_update_returns_ack_without_downstream_model_call(
+def test_pipe_confirmation_update_forwards_with_state(
     monkeypatch,
     confirmation: str,
     expected_policies: dict[str, str],
-    expected_response: str,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_pipe_confirmation_ack", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
 
-    downstream_calls = 0
+    forwarded_payloads: list[dict[str, object]] = []
 
     async def _track_downstream(
         _: object, payload: dict[str, object], __: object
     ) -> dict[str, object]:
-        nonlocal downstream_calls
-        downstream_calls += 1
-        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+        forwarded_payloads.append(payload)
+        return {"ok": True}
 
     module.generate_chat_completion = _track_downstream
 
@@ -545,8 +556,14 @@ def test_pipe_confirmation_update_returns_ack_without_downstream_model_call(
             __chat_id__=chat_key,
         )
     )
-    assert resumed == expected_response
-    assert downstream_calls == 0
+    assert resumed == {"ok": True}
+    assert len(forwarded_payloads) == 1
+    resumed_messages = forwarded_payloads[0]["messages"]
+    assert isinstance(resumed_messages, list)
+    assert isinstance(resumed_messages[0], dict)
+    assert resumed_messages[0].get("role") == "system"
+    assert isinstance(resumed_messages[0].get("content"), str)
+    assert resumed_messages[0]["content"].startswith("[[cc_state]]")
 
     resumed_engine = module._ENGINES_BY_CHAT_KEY[chat_key]
     assert resumed_engine.state == {
@@ -614,6 +631,8 @@ def test_pipe_trace_on_appends_trace_to_user_visible_output(monkeypatch) -> None
     assert "Context Compiler trace" in content
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
+    assert "payload state injection: no" in content
+    assert "downstream payload messages:" in content
 
 
 def test_pipe_trace_on_passthrough_stream_appends_trace_after_chunks(monkeypatch) -> None:
@@ -655,3 +674,89 @@ def test_pipe_trace_on_passthrough_stream_appends_trace_after_chunks(monkeypatch
     assert "Context Compiler trace" in content
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
+    assert "payload state injection: no" in content
+    assert "downstream payload messages:" in content
+
+
+def test_pipe_trace_on_update_shows_state_payload_and_downstream_call(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_trace_update", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    downstream_calls = 0
+
+    async def _track_downstream(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        del payload
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    module.generate_chat_completion = _track_downstream
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "prohibit peanuts"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-trace-update",
+        )
+    )
+    assert isinstance(result, dict)
+    content = result["choices"][0]["message"]["content"]
+    assert "downstream" in content
+    assert "Context Compiler trace" in content
+    assert "decision kind: update" in content
+    assert "downstream LLM call: yes" in content
+    assert "current state:" in content
+    assert "injected [[cc_state]] block: '[[cc_state]]\\nProhibit: peanuts'" in content
+    assert "payload state injection: yes" in content
+    assert "downstream payload messages:" in content
+    assert "[[cc_state]]\\nProhibit: peanuts" in content
+    assert downstream_calls == 1
+
+
+def test_pipe_trace_on_clarify_shows_prompt_and_no_downstream_call(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_trace_clarify", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    downstream_calls = 0
+
+    async def _track_downstream(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        del payload
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    module.generate_chat_completion = _track_downstream
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "set premise to concise answers"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-trace-clarify",
+        )
+    )
+    assert isinstance(result, str)
+    assert "decision kind: clarify" in result
+    assert "current state:" in result
+    assert "clarification prompt:" in result
+    assert "downstream LLM call: no" in result
+    assert "downstream payload messages: not sent (clarify)" in result
+    assert downstream_calls == 0

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -760,3 +760,69 @@ def test_pipe_trace_on_clarify_shows_prompt_and_no_downstream_call(monkeypatch) 
     assert "downstream LLM call: no" in result
     assert "downstream payload messages: not sent (clarify)" in result
     assert downstream_calls == 0
+
+
+def test_pipe_trace_appends_on_object_response_for_passthrough_and_update(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_trace_object_response", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    class _Message:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.message = _Message(content)
+
+    class _Response:
+        def __init__(self, content: str) -> None:
+            self.choices = [_Choice(content)]
+
+    forwarded_payloads: list[dict[str, object]] = []
+
+    async def _chat_completion(_: object, payload: dict[str, object], __: object) -> object:
+        forwarded_payloads.append(payload)
+        return _Response("downstream")
+
+    module.generate_chat_completion = _chat_completion
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    passthrough = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-object-passthrough",
+        )
+    )
+    assert hasattr(passthrough, "choices")
+    passthrough_content = passthrough.choices[0].message.content
+    assert "Context Compiler trace" in passthrough_content
+    assert "decision kind: passthrough" in passthrough_content
+    assert "downstream LLM call: yes" in passthrough_content
+
+    update = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-object-update",
+        )
+    )
+    assert hasattr(update, "choices")
+    update_content = update.choices[0].message.content
+    assert "Context Compiler trace" in update_content
+    assert "decision kind: update" in update_content
+    assert "downstream LLM call: yes" in update_content
+    assert "injected [[cc_state]] block:" in update_content
+    assert "[[cc_state]]" in update_content
+    assert any(
+        isinstance(payload.get("messages"), list)
+        and isinstance(payload["messages"][0], dict)
+        and isinstance(payload["messages"][0].get("content"), str)
+        and payload["messages"][0]["content"].startswith("[[cc_state]]")
+        for payload in forwarded_payloads
+    )

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -631,8 +631,8 @@ def test_pipe_trace_on_appends_trace_to_user_visible_output(monkeypatch) -> None
     assert "Context Compiler trace" in content
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
-    assert "payload state injection: no" in content
-    assert "downstream payload messages:" in content
+    assert "active state:" in content
+    assert "state injected: no" in content
 
 
 def test_pipe_trace_on_passthrough_stream_appends_trace_after_chunks(monkeypatch) -> None:
@@ -674,8 +674,8 @@ def test_pipe_trace_on_passthrough_stream_appends_trace_after_chunks(monkeypatch
     assert "Context Compiler trace" in content
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
-    assert "payload state injection: no" in content
-    assert "downstream payload messages:" in content
+    assert "active state:" in content
+    assert "state injected: no" in content
 
 
 def test_pipe_trace_on_update_shows_state_payload_and_downstream_call(monkeypatch) -> None:
@@ -713,11 +713,11 @@ def test_pipe_trace_on_update_shows_state_payload_and_downstream_call(monkeypatc
     assert "Context Compiler trace" in content
     assert "decision kind: update" in content
     assert "downstream LLM call: yes" in content
-    assert "current state:" in content
-    assert "injected [[cc_state]] block: '[[cc_state]]\\nProhibit: peanuts'" in content
-    assert "payload state injection: yes" in content
-    assert "downstream payload messages:" in content
-    assert "[[cc_state]]\\nProhibit: peanuts" in content
+    assert "state change:" in content
+    assert "active state:" in content
+    assert "state injected: prohibit peanuts" in content
+    assert "\n\ndecision kind: update" in content
+    assert "\n\nstate injected: prohibit peanuts" in content
     assert downstream_calls == 1
 
 
@@ -755,10 +755,10 @@ def test_pipe_trace_on_clarify_shows_prompt_and_no_downstream_call(monkeypatch) 
     )
     assert isinstance(result, str)
     assert "decision kind: clarify" in result
-    assert "current state:" in result
+    assert "active state:" in result
     assert "clarification prompt:" in result
     assert "downstream LLM call: no" in result
-    assert "downstream payload messages: not sent (clarify)" in result
+    assert "state injected: no" in result
     assert downstream_calls == 0
 
 
@@ -817,8 +817,76 @@ def test_pipe_trace_appends_on_object_response_for_passthrough_and_update(monkey
     assert "Context Compiler trace" in update_content
     assert "decision kind: update" in update_content
     assert "downstream LLM call: yes" in update_content
-    assert "injected [[cc_state]] block:" in update_content
-    assert "[[cc_state]]" in update_content
+    assert "state injected:" in update_content
+    assert any(
+        isinstance(payload.get("messages"), list)
+        and isinstance(payload["messages"][0], dict)
+        and isinstance(payload["messages"][0].get("content"), str)
+        and payload["messages"][0]["content"].startswith("[[cc_state]]")
+        for payload in forwarded_payloads
+    )
+
+
+def test_pipe_trace_appends_on_streaming_response_wrapper_passthrough_and_update(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_trace_streaming_wrapper", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    class _StreamingResponse:
+        def __init__(self, parts: tuple[str, ...]) -> None:
+            async def _iter() -> object:
+                for part in parts:
+                    yield part
+
+            self.body_iterator = _iter()
+
+    forwarded_payloads: list[dict[str, object]] = []
+
+    async def _chat_completion(_: object, payload: dict[str, object], __: object) -> object:
+        forwarded_payloads.append(payload)
+        return _StreamingResponse(("data: stub\n\n", "data: [DONE]\n\n"))
+
+    module.generate_chat_completion = _chat_completion
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    passthrough = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-stream-wrapper-passthrough",
+        )
+    )
+
+    async def _collect_stream(wrapper: object) -> str:
+        parts: list[str] = []
+        async for chunk in wrapper.body_iterator:
+            assert isinstance(chunk, str)
+            parts.append(chunk)
+        return "".join(parts)
+
+    passthrough_stream = asyncio.run(_collect_stream(passthrough))
+    assert "data: [DONE]" in passthrough_stream
+    assert "Context Compiler trace" in passthrough_stream
+    assert "decision kind: passthrough" in passthrough_stream
+
+    update = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-stream-wrapper-update",
+        )
+    )
+    update_stream = asyncio.run(_collect_stream(update))
+    assert "data: [DONE]" in update_stream
+    assert "Context Compiler trace" in update_stream
+    assert "decision kind: update" in update_stream
+    assert "state injected:" in update_stream
     assert any(
         isinstance(payload.get("messages"), list)
         and isinstance(payload["messages"][0], dict)

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -318,11 +318,8 @@ def test_pipe_normal_update_forwards_with_state_and_persists_checkpoint(monkeypa
         )
     )
 
-    assert result == {"ok": True}
-    assert len(forwarded_payloads) == 2
-    second_messages = forwarded_payloads[1]["messages"]
-    assert isinstance(second_messages, list)
-    assert second_messages[0] == {"role": "system", "content": "[[cc_state]]"}
+    assert result == "State updated: Removed policy peanuts."
+    assert len(forwarded_payloads) == 1
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
@@ -372,20 +369,20 @@ def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatc
 
     result = asyncio.run(
         pipe.pipe(
-            {
-                "model": "pipe-model",
-                "messages": [{"role": "user", "content": "remove policy DOCKER"}],
-            },
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
             __user__={"id": "u1"},
             __request__=object(),
-            __chat_id__="chat-remove",
+            __chat_id__="chat-idempotent",
         )
     )
     assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
-            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "use docker"}],
+            },
             __user__={"id": "u1"},
             __request__=object(),
             __chat_id__="chat-replace",
@@ -427,7 +424,7 @@ def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatc
             __chat_id__="chat-premise",
         )
     )
-    assert result == {"ok": True}
+    assert result == "Premise cleared."
 
     result = asyncio.run(
         pipe.pipe(
@@ -441,7 +438,7 @@ def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatc
         )
     )
     assert result == {"ok": True}
-    assert len(forwarded_payloads) == 8
+    assert len(forwarded_payloads) == 7
     assert all(
         isinstance(payload.get("messages"), list)
         and isinstance(payload["messages"][0], dict)
@@ -897,38 +894,42 @@ def test_pipe_trace_appends_on_streaming_response_wrapper_passthrough_and_update
 
 
 @pytest.mark.parametrize(
-    ("steps", "expected_state_injected"),
+    ("steps", "expected_ack"),
     [
         (
             ["use docker", "clear state"],
-            "none",
+            "State cleared.",
         ),
         (
             ["set premise concise replies", "clear premise"],
-            "none",
+            "Premise cleared.",
         ),
         (
             ["use docker", "use pytest", "reset policies"],
-            "none",
+            "Policies reset.",
         ),
         (
             ["use docker", "remove policy docker"],
-            "none",
+            "State updated: Removed policy docker.",
         ),
     ],
 )
 def test_pipe_trace_update_clear_reset_paths_single_and_consistent(
     monkeypatch,
     steps: list[str],
-    expected_state_injected: str,
+    expected_ack: str,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_pipe_trace_clear_reset", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
 
+    downstream_calls = 0
+
     async def _chat_completion(
         _: object, payload: dict[str, object], __: object
     ) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
         del payload
         return {"choices": [{"message": {"content": "downstream"}}]}
 
@@ -950,14 +951,16 @@ def test_pipe_trace_update_clear_reset_paths_single_and_consistent(
         if idx < len(steps) - 1:
             continue
 
-    assert isinstance(result, dict)
-    content = result["choices"][0]["message"]["content"]
+    assert isinstance(result, str)
+    assert result.startswith(expected_ack)
+    content = result
     assert content.count("Context Compiler trace") == 1
     assert "decision kind: update" in content
-    assert "downstream LLM call: yes" in content
-    assert "downstream LLM call: no" not in content
+    assert "downstream LLM call: no" in content
+    assert "downstream LLM call: yes" not in content
     assert "active state: none" in content
-    assert f"state injected: {expected_state_injected}" in content
+    assert "state injected: no" in content
+    assert downstream_calls == len(steps) - 1
 
 
 def test_pipe_clear_state_trace_not_duplicated_when_model_echoes_history(monkeypatch) -> None:
@@ -1014,14 +1017,14 @@ def test_pipe_clear_state_trace_not_duplicated_when_model_echoes_history(monkeyp
             __chat_id__=chat_id,
         )
     )
-    assert isinstance(second, dict)
-    second_content = second["choices"][0]["message"]["content"]
+    assert isinstance(second, str)
+    second_content = second
     assert second_content.count("Context Compiler trace") == 1
     assert "decision kind: update" in second_content
-    assert "downstream LLM call: yes" in second_content
-    assert "downstream LLM call: no" not in second_content
+    assert "downstream LLM call: no" in second_content
+    assert "downstream LLM call: yes" not in second_content
     assert "active state: none" in second_content
-    assert "state injected: none" in second_content
+    assert "state injected: no" in second_content
 
 
 def test_pipe_clear_state_strips_preexisting_contradictory_trace_from_model_output(
@@ -1077,8 +1080,8 @@ def test_pipe_clear_state_strips_preexisting_contradictory_trace_from_model_outp
             __chat_id__=chat_id,
         )
     )
-    assert isinstance(second, dict)
-    second_content = second["choices"][0]["message"]["content"]
+    assert isinstance(second, str)
+    second_content = second
     assert second_content.count("Context Compiler trace") == 1
-    assert "downstream LLM call: yes" in second_content
-    assert "downstream LLM call: no" not in second_content
+    assert "downstream LLM call: no" in second_content
+    assert "downstream LLM call: yes" not in second_content

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -1181,13 +1181,12 @@ def test_preprocessor_pipe_trace_on_appends_trace_to_user_visible_output(monkeyp
     assert "downstream" in content
     assert "Context Compiler trace" in content
     assert "decision kind: update" in content
-    assert "preprocessor output: prohibit peanuts" in content
+    assert "preprocessor output:" not in content
     assert "downstream LLM call: yes" in content
-    assert "current state:" in content
-    assert "injected [[cc_state]] block: '[[cc_state]]\\nProhibit: peanuts'" in content
-    assert "payload state injection: yes" in content
-    assert "downstream payload messages:" in content
-    assert "[[cc_state]]\\nProhibit: peanuts" in content
+    assert "state change:" in content
+    assert "active state:" in content
+    assert "state injected: prohibit peanuts" in content
+    assert "\n\nstate injected: prohibit peanuts" in content
 
 
 def test_preprocessor_pipe_trace_on_passthrough_appends_trace_to_llm_content(monkeypatch) -> None:
@@ -1222,8 +1221,8 @@ def test_preprocessor_pipe_trace_on_passthrough_appends_trace_to_llm_content(mon
     assert "Context Compiler trace" in content
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
-    assert "payload state injection: no" in content
-    assert "downstream payload messages:" in content
+    assert "active state:" in content
+    assert "state injected: no" in content
 
 
 def test_preprocessor_pipe_trace_on_passthrough_stream_appends_trace_after_chunks(
@@ -1272,8 +1271,8 @@ def test_preprocessor_pipe_trace_on_passthrough_stream_appends_trace_after_chunk
     assert "Context Compiler trace" in content
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
-    assert "payload state injection: no" in content
-    assert "downstream payload messages:" in content
+    assert "active state:" in content
+    assert "state injected: no" in content
 
 
 def test_preprocessor_pipe_trace_on_clarify_shows_prompt_and_no_downstream_call(
@@ -1317,10 +1316,10 @@ def test_preprocessor_pipe_trace_on_clarify_shows_prompt_and_no_downstream_call(
     )
     assert isinstance(result, str)
     assert "decision kind: clarify" in result
-    assert "current state:" in result
+    assert "active state:" in result
     assert "clarification prompt:" in result
     assert "downstream LLM call: no" in result
-    assert "downstream payload messages: not sent (clarify)" in result
+    assert "state injected: no" in result
     assert downstream_calls == 0
 
 
@@ -1389,8 +1388,86 @@ def test_preprocessor_pipe_trace_appends_on_object_response_for_passthrough_and_
     assert "Context Compiler trace" in update_content
     assert "decision kind: update" in update_content
     assert "downstream LLM call: yes" in update_content
-    assert "injected [[cc_state]] block:" in update_content
-    assert "[[cc_state]]" in update_content
+    assert "state injected:" in update_content
+    assert any(
+        isinstance(payload.get("messages"), list)
+        and isinstance(payload["messages"][0], dict)
+        and isinstance(payload["messages"][0].get("content"), str)
+        and payload["messages"][0]["content"].startswith("[[cc_state]]")
+        for payload in forwarded_payloads
+    )
+
+
+def test_preprocessor_pipe_trace_appends_on_streaming_response_wrapper_passthrough_and_update(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_trace_streaming_wrapper", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    class _StreamingResponse:
+        def __init__(self, parts: tuple[str, ...]) -> None:
+            async def _iter() -> object:
+                for part in parts:
+                    yield part
+
+            self.body_iterator = _iter()
+
+    def _heuristic(text: str) -> dict[str, object]:
+        if "use docker" in text.lower():
+            return {"outcome": module.PRECOMPILE_OUTCOME_DIRECTIVE, "directive": "use docker"}
+        return {"outcome": "no_directive", "directive": None}
+
+    monkeypatch.setattr(module, "precompile_heuristic", _heuristic)
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
+
+    forwarded_payloads: list[dict[str, object]] = []
+
+    async def _chat_completion(_: object, payload: dict[str, object], __: object) -> object:
+        forwarded_payloads.append(payload)
+        return _StreamingResponse(("data: stub\n\n", "data: [DONE]\n\n"))
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    passthrough = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-stream-wrapper-passthrough",
+        )
+    )
+
+    async def _collect_stream(wrapper: object) -> str:
+        parts: list[str] = []
+        async for chunk in wrapper.body_iterator:
+            assert isinstance(chunk, str)
+            parts.append(chunk)
+        return "".join(parts)
+
+    passthrough_stream = asyncio.run(_collect_stream(passthrough))
+    assert "data: [DONE]" in passthrough_stream
+    assert "Context Compiler trace" in passthrough_stream
+    assert "decision kind: passthrough" in passthrough_stream
+
+    update = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-stream-wrapper-update",
+        )
+    )
+    update_stream = asyncio.run(_collect_stream(update))
+    assert "data: [DONE]" in update_stream
+    assert "Context Compiler trace" in update_stream
+    assert "decision kind: update" in update_stream
+    assert "state injected:" in update_stream
     assert any(
         isinstance(payload.get("messages"), list)
         and isinstance(payload["messages"][0], dict)

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -1700,7 +1700,7 @@ def test_preprocessor_pipe_clear_state_strips_preexisting_contradictory_trace_fr
     assert "downstream LLM call: yes" not in second_content
 
 
-def test_preprocessor_pipe_natural_language_directive_update_trace_and_injection(
+def test_preprocessor_pipe_update_trace_and_injection_when_heuristic_emits_directive(
     monkeypatch,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_nl_use_docker", monkeypatch)
@@ -1762,7 +1762,7 @@ def test_preprocessor_pipe_natural_language_directive_update_trace_and_injection
     )
 
 
-def test_preprocessor_pipe_natural_language_replacement_update_trace_and_injection(
+def test_preprocessor_pipe_replacement_update_trace_and_injection_when_heuristic_emits_directive(
     monkeypatch,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_nl_replace", monkeypatch)
@@ -1887,6 +1887,51 @@ def test_preprocessor_pipe_ambiguous_text_passthrough_trace_streaming(monkeypatc
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
     assert "downstream LLM call: no" not in content
+    assert "state injected: no" in content
+
+
+def test_preprocessor_pipe_natural_language_abstention_can_passthrough_with_trace(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_nl_abstention", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    # Use the real heuristic behavior for this phrase (unknown/no_directive),
+    # and force fallback to abstain so runtime stays conservative.
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda _value, **_kwargs: None)
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        if payload.get("model") == "prep-model":
+            return {"choices": [{"message": {"content": "no_directive"}}]}
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "i think we should use docker"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-nl-abstention",
+        )
+    )
+    assert isinstance(result, dict)
+    content = result["choices"][0]["message"]["content"]
+    assert content.count("Context Compiler trace") == 1
+    assert "decision kind: passthrough" in content
+    assert "active state: none" in content
+    assert "downstream LLM call: yes" in content
     assert "state injected: no" in content
 
 

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -643,11 +643,8 @@ def test_preprocessor_pipe_normal_update_forwards_with_state_and_persists_checkp
         )
     )
 
-    assert result == {"ok": True}
-    assert len(forwarded_payloads) == 2
-    second_messages = forwarded_payloads[1]["messages"]
-    assert isinstance(second_messages, list)
-    assert second_messages[0] == {"role": "system", "content": "[[cc_state]]"}
+    assert result == "State updated: Removed policy peanuts."
+    assert len(forwarded_payloads) == 1
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
@@ -700,20 +697,20 @@ def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shap
 
     result = asyncio.run(
         pipe.pipe(
-            {
-                "model": "pipe-model",
-                "messages": [{"role": "user", "content": "remove policy DOCKER"}],
-            },
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
             __user__={"id": "u1"},
             __request__=object(),
-            __chat_id__="chat-remove",
+            __chat_id__="chat-idempotent",
         )
     )
     assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
-            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "use docker"}],
+            },
             __user__={"id": "u1"},
             __request__=object(),
             __chat_id__="chat-replace",
@@ -749,10 +746,10 @@ def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shap
 
     result = asyncio.run(
         pipe.pipe(
-            {"model": "pipe-model", "messages": [{"role": "user", "content": "clear premise"}]},
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
             __user__={"id": "u1"},
             __request__=object(),
-            __chat_id__="chat-premise",
+            __chat_id__="chat-idempotent",
         )
     )
     assert result == {"ok": True}
@@ -1478,30 +1475,30 @@ def test_preprocessor_pipe_trace_appends_on_streaming_response_wrapper_passthrou
 
 
 @pytest.mark.parametrize(
-    ("steps", "expected_state_injected"),
+    ("steps", "expected_ack"),
     [
         (
             ["use docker", "clear state"],
-            "none",
+            "State cleared.",
         ),
         (
             ["set premise concise replies", "clear premise"],
-            "none",
+            "Premise cleared.",
         ),
         (
             ["use docker", "use pytest", "reset policies"],
-            "none",
+            "Policies reset.",
         ),
         (
             ["use docker", "remove policy docker"],
-            "none",
+            "State updated: Removed policy docker.",
         ),
     ],
 )
 def test_preprocessor_pipe_trace_update_clear_reset_paths_single_and_consistent(
     monkeypatch,
     steps: list[str],
-    expected_state_injected: str,
+    expected_ack: str,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_trace_clear_reset", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
@@ -1514,11 +1511,15 @@ def test_preprocessor_pipe_trace_update_clear_reset_paths_single_and_consistent(
     )
     monkeypatch.setattr(module, "parse_precompiler_output", lambda _value, **_kwargs: None)
 
+    downstream_calls = 0
+
     async def _chat_completion(
         _: object, payload: dict[str, object], __: object
     ) -> dict[str, object]:
+        nonlocal downstream_calls
         if payload.get("model") == "prep-model":
             return {"choices": [{"message": {"content": "no_directive"}}]}
+        downstream_calls += 1
         return {"choices": [{"message": {"content": "downstream"}}]}
 
     monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
@@ -1541,14 +1542,16 @@ def test_preprocessor_pipe_trace_update_clear_reset_paths_single_and_consistent(
         if idx < len(steps) - 1:
             continue
 
-    assert isinstance(result, dict)
-    content = result["choices"][0]["message"]["content"]
+    assert isinstance(result, str)
+    assert result.startswith(expected_ack)
+    content = result
     assert content.count("Context Compiler trace") == 1
     assert "decision kind: update" in content
-    assert "downstream LLM call: yes" in content
-    assert "downstream LLM call: no" not in content
+    assert "downstream LLM call: no" in content
+    assert "downstream LLM call: yes" not in content
     assert "active state: none" in content
-    assert f"state injected: {expected_state_injected}" in content
+    assert "state injected: no" in content
+    assert downstream_calls == len(steps) - 1
 
 
 def test_preprocessor_pipe_clear_state_trace_not_duplicated_when_model_echoes_history(
@@ -1616,14 +1619,14 @@ def test_preprocessor_pipe_clear_state_trace_not_duplicated_when_model_echoes_hi
             __chat_id__=chat_id,
         )
     )
-    assert isinstance(second, dict)
-    second_content = second["choices"][0]["message"]["content"]
+    assert isinstance(second, str)
+    second_content = second
     assert second_content.count("Context Compiler trace") == 1
     assert "decision kind: update" in second_content
-    assert "downstream LLM call: yes" in second_content
-    assert "downstream LLM call: no" not in second_content
+    assert "downstream LLM call: no" in second_content
+    assert "downstream LLM call: yes" not in second_content
     assert "active state: none" in second_content
-    assert "state injected: none" in second_content
+    assert "state injected: no" in second_content
 
 
 def test_preprocessor_pipe_clear_state_strips_preexisting_contradictory_trace_from_model_output(
@@ -1690,11 +1693,11 @@ def test_preprocessor_pipe_clear_state_strips_preexisting_contradictory_trace_fr
             __chat_id__=chat_id,
         )
     )
-    assert isinstance(second, dict)
-    second_content = second["choices"][0]["message"]["content"]
+    assert isinstance(second, str)
+    second_content = second
     assert second_content.count("Context Compiler trace") == 1
-    assert "downstream LLM call: yes" in second_content
-    assert "downstream LLM call: no" not in second_content
+    assert "downstream LLM call: no" in second_content
+    assert "downstream LLM call: yes" not in second_content
 
 
 def test_preprocessor_pipe_natural_language_directive_update_trace_and_injection(

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -1322,3 +1322,79 @@ def test_preprocessor_pipe_trace_on_clarify_shows_prompt_and_no_downstream_call(
     assert "downstream LLM call: no" in result
     assert "downstream payload messages: not sent (clarify)" in result
     assert downstream_calls == 0
+
+
+def test_preprocessor_pipe_trace_appends_on_object_response_for_passthrough_and_update(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_trace_object_response", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    class _Message:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.message = _Message(content)
+
+    class _Response:
+        def __init__(self, content: str) -> None:
+            self.choices = [_Choice(content)]
+
+    def _heuristic(text: str) -> dict[str, object]:
+        if "use docker" in text.lower():
+            return {"outcome": module.PRECOMPILE_OUTCOME_DIRECTIVE, "directive": "use docker"}
+        return {"outcome": "no_directive", "directive": None}
+
+    monkeypatch.setattr(module, "precompile_heuristic", _heuristic)
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
+
+    forwarded_payloads: list[dict[str, object]] = []
+
+    async def _chat_completion(_: object, payload: dict[str, object], __: object) -> object:
+        forwarded_payloads.append(payload)
+        return _Response("downstream")
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    passthrough = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "hello"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-object-passthrough",
+        )
+    )
+    passthrough_content = passthrough.choices[0].message.content
+    assert "Context Compiler trace" in passthrough_content
+    assert "decision kind: passthrough" in passthrough_content
+    assert "downstream LLM call: yes" in passthrough_content
+
+    update = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-object-update",
+        )
+    )
+    update_content = update.choices[0].message.content
+    assert "Context Compiler trace" in update_content
+    assert "decision kind: update" in update_content
+    assert "downstream LLM call: yes" in update_content
+    assert "injected [[cc_state]] block:" in update_content
+    assert "[[cc_state]]" in update_content
+    assert any(
+        isinstance(payload.get("messages"), list)
+        and isinstance(payload["messages"][0], dict)
+        and isinstance(payload["messages"][0].get("content"), str)
+        and payload["messages"][0]["content"].startswith("[[cc_state]]")
+        for payload in forwarded_payloads
+    )

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -1475,3 +1475,489 @@ def test_preprocessor_pipe_trace_appends_on_streaming_response_wrapper_passthrou
         and payload["messages"][0]["content"].startswith("[[cc_state]]")
         for payload in forwarded_payloads
     )
+
+
+@pytest.mark.parametrize(
+    ("steps", "expected_state_injected"),
+    [
+        (
+            ["use docker", "clear state"],
+            "none",
+        ),
+        (
+            ["set premise concise replies", "clear premise"],
+            "none",
+        ),
+        (
+            ["use docker", "use pytest", "reset policies"],
+            "none",
+        ),
+        (
+            ["use docker", "remove policy docker"],
+            "none",
+        ),
+    ],
+)
+def test_preprocessor_pipe_trace_update_clear_reset_paths_single_and_consistent(
+    monkeypatch,
+    steps: list[str],
+    expected_state_injected: str,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_trace_clear_reset", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    monkeypatch.setattr(
+        module,
+        "precompile_heuristic",
+        lambda _text: {"outcome": "no_directive", "directive": None},
+    )
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda _value, **_kwargs: None)
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        if payload.get("model") == "prep-model":
+            return {"choices": [{"message": {"content": "no_directive"}}]}
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result: object = ""
+    for idx, user_input in enumerate(steps):
+        result = asyncio.run(
+            pipe.pipe(
+                {"model": "pipe-model", "messages": [{"role": "user", "content": user_input}]},
+                __user__={"id": "u1"},
+                __request__=object(),
+                __chat_id__=f"chat-preproc-trace-clear-reset-{hash(tuple(steps))}",
+            )
+        )
+        if idx < len(steps) - 1:
+            continue
+
+    assert isinstance(result, dict)
+    content = result["choices"][0]["message"]["content"]
+    assert content.count("Context Compiler trace") == 1
+    assert "decision kind: update" in content
+    assert "downstream LLM call: yes" in content
+    assert "downstream LLM call: no" not in content
+    assert "active state: none" in content
+    assert f"state injected: {expected_state_injected}" in content
+
+
+def test_preprocessor_pipe_clear_state_trace_not_duplicated_when_model_echoes_history(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_trace_echo_dedupe", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    monkeypatch.setattr(
+        module,
+        "precompile_heuristic",
+        lambda _text: {"outcome": "no_directive", "directive": None},
+    )
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda _value, **_kwargs: None)
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        messages = payload.get("messages")
+        echoed = ""
+        if isinstance(messages, list):
+            assistant_contents = [
+                str(msg.get("content", ""))
+                for msg in messages
+                if isinstance(msg, dict) and msg.get("role") == "assistant"
+            ]
+            echoed = "\n".join(assistant_contents)
+        content = "downstream"
+        if echoed:
+            content += f"\n{echoed}"
+        return {"choices": [{"message": {"content": content}}]}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+    chat_id = "chat-preproc-trace-echo-dedupe"
+
+    first = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+    assert isinstance(first, dict)
+    first_content = first["choices"][0]["message"]["content"]
+    assert first_content.count("Context Compiler trace") == 1
+
+    second = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [
+                    {"role": "assistant", "content": first_content},
+                    {"role": "user", "content": "clear state"},
+                ],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+    assert isinstance(second, dict)
+    second_content = second["choices"][0]["message"]["content"]
+    assert second_content.count("Context Compiler trace") == 1
+    assert "decision kind: update" in second_content
+    assert "downstream LLM call: yes" in second_content
+    assert "downstream LLM call: no" not in second_content
+    assert "active state: none" in second_content
+    assert "state injected: none" in second_content
+
+
+def test_preprocessor_pipe_clear_state_strips_preexisting_contradictory_trace_from_model_output(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs(
+        "owui_preproc_trace_strip_contradiction", monkeypatch
+    )
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    monkeypatch.setattr(
+        module,
+        "precompile_heuristic",
+        lambda _text: {"outcome": "no_directive", "directive": None},
+    )
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda _value, **_kwargs: None)
+
+    old_trace = (
+        "Context Compiler trace\n\n"
+        "decision kind: update\n"
+        "active state: none\n"
+        "downstream LLM call: no\n"
+        "\n"
+        "state injected: none"
+    )
+
+    call_count = 0
+
+    async def _chat_completion(
+        _: object,
+        payload: dict[str, object],
+        __: object,
+    ) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {"choices": [{"message": {"content": "downstream"}}]}
+        del payload
+        return {"choices": [{"message": {"content": f"downstream\n{old_trace}"}}]}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+    chat_id = "chat-preproc-trace-strip-contradiction"
+
+    _ = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+
+    second = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "clear state"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+    assert isinstance(second, dict)
+    second_content = second["choices"][0]["message"]["content"]
+    assert second_content.count("Context Compiler trace") == 1
+    assert "downstream LLM call: yes" in second_content
+    assert "downstream LLM call: no" not in second_content
+
+
+def test_preprocessor_pipe_natural_language_directive_update_trace_and_injection(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_nl_use_docker", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    monkeypatch.setattr(
+        module,
+        "precompile_heuristic",
+        lambda text: (
+            {"outcome": module.PRECOMPILE_OUTCOME_DIRECTIVE, "directive": "use docker"}
+            if "i think we should use docker" in text.lower()
+            else {"outcome": "no_directive", "directive": None}
+        ),
+    )
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
+
+    forwarded_payloads: list[dict[str, object]] = []
+
+    async def _chat_completion(
+        _: object,
+        payload: dict[str, object],
+        __: object,
+    ) -> dict[str, object]:
+        forwarded_payloads.append(payload)
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "i think we should use docker"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-nl-use-docker",
+        )
+    )
+    assert isinstance(result, dict)
+    content = result["choices"][0]["message"]["content"]
+    assert content.count("Context Compiler trace") == 1
+    assert "decision kind: update" in content
+    assert "downstream LLM call: yes" in content
+    assert "downstream LLM call: no" not in content
+    assert "active state: use docker" in content
+    assert "state injected: use docker" in content
+    assert any(
+        isinstance(payload.get("messages"), list)
+        and isinstance(payload["messages"][0], dict)
+        and payload["messages"][0].get("content") == "[[cc_state]]\nUse: docker"
+        for payload in forwarded_payloads
+    )
+
+
+def test_preprocessor_pipe_natural_language_replacement_update_trace_and_injection(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_nl_replace", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    monkeypatch.setattr(
+        module,
+        "precompile_heuristic",
+        lambda text: (
+            {"outcome": module.PRECOMPILE_OUTCOME_DIRECTIVE, "directive": "use docker"}
+            if text.strip().lower() == "use docker"
+            else (
+                {
+                    "outcome": module.PRECOMPILE_OUTCOME_DIRECTIVE,
+                    "directive": "use podman instead of docker",
+                }
+                if "switch to podman instead of docker" in text.lower()
+                else {"outcome": "no_directive", "directive": None}
+            )
+        ),
+    )
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
+
+    async def _chat_completion(
+        _: object,
+        payload: dict[str, object],
+        __: object,
+    ) -> dict[str, object]:
+        del payload
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+    chat_id = "chat-preproc-nl-replace"
+
+    _ = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "use docker"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "switch to podman instead of docker"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+    assert isinstance(result, dict)
+    content = result["choices"][0]["message"]["content"]
+    assert content.count("Context Compiler trace") == 1
+    assert "decision kind: update" in content
+    assert "downstream LLM call: yes" in content
+    assert "downstream LLM call: no" not in content
+    assert "active state: use podman" in content
+    assert "state injected: use podman" in content
+
+
+def test_preprocessor_pipe_ambiguous_text_passthrough_trace_streaming(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs(
+        "owui_preproc_ambiguous_passthrough_stream", monkeypatch
+    )
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    monkeypatch.setattr(module, "precompile_heuristic", lambda _text: {"outcome": "no_directive"})
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda _value, **_kwargs: None)
+
+    class _StreamingResponse:
+        def __init__(self) -> None:
+            async def _iter() -> object:
+                for part in ("data: downstream\n\n", "data: [DONE]\n\n"):
+                    yield part
+
+            self.body_iterator = _iter()
+
+    async def _chat_completion(_: object, payload: dict[str, object], __: object) -> object:
+        if payload.get("model") == "prep-model":
+            return {"choices": [{"message": {"content": "no_directive"}}]}
+        return _StreamingResponse()
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "docker is interesting"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-ambiguous-stream",
+        )
+    )
+
+    async def _collect_stream(wrapper: object) -> str:
+        parts: list[str] = []
+        async for chunk in wrapper.body_iterator:
+            assert isinstance(chunk, str)
+            parts.append(chunk)
+        return "".join(parts)
+
+    content = asyncio.run(_collect_stream(result))
+    assert content.count("Context Compiler trace") == 1
+    assert "decision kind: passthrough" in content
+    assert "downstream LLM call: yes" in content
+    assert "downstream LLM call: no" not in content
+    assert "state injected: no" in content
+
+
+def test_preprocessor_pipe_pending_clarification_bypasses_preprocessing_for_ambiguous_yes(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_pending_yeah_probably", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    heuristic_calls: list[str] = []
+
+    def _heuristic(text: str) -> dict[str, object]:
+        if text.strip().lower() == "yeah probably":
+            raise AssertionError("heuristic precompile should be bypassed while pending")
+        heuristic_calls.append(text)
+        if "use podman instead of kubectl" in text.lower():
+            return {
+                "outcome": module.PRECOMPILE_OUTCOME_DIRECTIVE,
+                "directive": "use podman instead of kubectl",
+            }
+        return {"outcome": "no_directive", "directive": None}
+
+    monkeypatch.setattr(module, "precompile_heuristic", _heuristic)
+    monkeypatch.setattr(module, "parse_precompiler_output", lambda value, **_kwargs: value)
+
+    downstream_calls = 0
+
+    async def _chat_completion(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        del payload
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+    chat_id = "chat-preproc-pending-yeah-probably"
+
+    first = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "use podman instead of kubectl"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+    assert isinstance(first, str)
+    assert first.count("Context Compiler trace") == 1
+    assert "decision kind: clarify" in first
+    assert "downstream LLM call: no" in first
+    assert "state injected: no" in first
+
+    second = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "yeah probably"}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+    assert isinstance(second, str)
+    assert second.count("Context Compiler trace") == 1
+    assert "decision kind: clarify" in second
+    assert "downstream LLM call: no" in second
+    assert "downstream LLM call: yes" not in second
+    assert "state injected: no" in second
+    assert downstream_calls == 0
+    assert heuristic_calls == ["use podman instead of kubectl"]

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -164,7 +164,7 @@ def test_pipe_debug_false_missing_base_blocks_without_llm_calls(monkeypatch) -> 
     assert llm_calls == 0
 
 
-def test_pipe_debug_true_missing_base_allows_update_without_llm_calls(monkeypatch) -> None:
+def test_pipe_debug_true_missing_base_skips_update_forwarding_call(monkeypatch) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_debug_true_allowed", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
@@ -195,7 +195,9 @@ def test_pipe_debug_true_missing_base_allows_update_without_llm_calls(monkeypatc
         )
     )
 
-    assert result == "State updated: Use docker."
+    assert result == (
+        "Context Compiler debug mode: BASE_MODEL_ID is empty; skipping model passthrough."
+    )
     assert llm_calls == 0
 
 
@@ -568,7 +570,7 @@ def test_preprocessor_pipe_restore_and_persist_checkpoint_points(monkeypatch) ->
     assert module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] == "ckpt-keep"
 
 
-def test_preprocessor_pipe_normal_update_returns_deterministic_ack_and_persists_checkpoint(
+def test_preprocessor_pipe_normal_update_forwards_with_state_and_persists_checkpoint(
     monkeypatch,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_update_forward", monkeypatch)
@@ -619,8 +621,11 @@ def test_preprocessor_pipe_normal_update_returns_deterministic_ack_and_persists_
         )
     )
 
-    assert result == "State updated: Prohibit peanuts."
-    assert len(forwarded_payloads) == 0
+    assert result == {"ok": True}
+    assert len(forwarded_payloads) == 1
+    first_messages = forwarded_payloads[0]["messages"]
+    assert isinstance(first_messages, list)
+    assert first_messages[0] == {"role": "system", "content": "[[cc_state]]\nProhibit: peanuts"}
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
@@ -638,29 +643,31 @@ def test_preprocessor_pipe_normal_update_returns_deterministic_ack_and_persists_
         )
     )
 
-    assert result == "State updated: Removed policy peanuts."
-    assert len(forwarded_payloads) == 0
+    assert result == {"ok": True}
+    assert len(forwarded_payloads) == 2
+    second_messages = forwarded_payloads[1]["messages"]
+    assert isinstance(second_messages, list)
+    assert second_messages[0] == {"role": "system", "content": "[[cc_state]]"}
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
     assert checkpoint["authoritative_state"]["policies"] == {}
 
 
-def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only(
+def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shapes(
     monkeypatch,
 ) -> None:
-    module = _load_module_with_openwebui_stubs("owui_preproc_literal_replace_summary", monkeypatch)
+    module = _load_module_with_openwebui_stubs("owui_preproc_update_shapes", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
 
-    downstream_calls = 0
+    forwarded_payloads: list[dict[str, object]] = []
 
     async def _track_downstream(
         _: object, payload: dict[str, object], __: object
     ) -> dict[str, object]:
-        nonlocal downstream_calls
-        downstream_calls += 1
-        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+        forwarded_payloads.append(payload)
+        return {"ok": True}
 
     monkeypatch.setattr(module, "generate_chat_completion", _track_downstream)
 
@@ -676,7 +683,7 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
             __chat_id__="chat-use",
         )
     )
-    assert result == "State updated: Use docker."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -689,7 +696,7 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
             __chat_id__="chat-prohibit",
         )
     )
-    assert result == "State updated: Prohibit docker."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -702,7 +709,7 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
             __chat_id__="chat-remove",
         )
     )
-    assert result == "State updated: Removed policy docker."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -712,7 +719,7 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
             __chat_id__="chat-replace",
         )
     )
-    assert result == "State updated: Use docker."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -725,7 +732,7 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
             __chat_id__="chat-replace",
         )
     )
-    assert result == "State updated: Use kubectl."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -738,7 +745,7 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
             __chat_id__="chat-premise",
         )
     )
-    assert result == "State updated."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -748,7 +755,7 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
             __chat_id__="chat-premise",
         )
     )
-    assert result == "Premise cleared."
+    assert result == {"ok": True}
 
     result = asyncio.run(
         pipe.pipe(
@@ -761,19 +768,27 @@ def test_preprocessor_pipe_literal_replacement_update_summary_uses_new_item_only
             __chat_id__="chat-replace-noop",
         )
     )
-    assert result == "State updated: Use docker."
-    assert downstream_calls == 0
+    assert result == {"ok": True}
+    assert len(forwarded_payloads) == 8
+    assert all(
+        isinstance(payload.get("messages"), list)
+        and isinstance(payload["messages"][0], dict)
+        and payload["messages"][0].get("role") == "system"
+        and isinstance(payload["messages"][0].get("content"), str)
+        and payload["messages"][0]["content"].startswith("[[cc_state]]")
+        for payload in forwarded_payloads
+    )
 
 
 @pytest.mark.parametrize(
-    ("confirmation", "expected_response"),
+    ("confirmation",),
     [
-        ("yes", "State updated: Use kubectl."),
-        ("no", "State unchanged."),
+        ("yes",),
+        ("no",),
     ],
 )
 def test_preprocessor_pipe_bypasses_precompile_while_pending(
-    monkeypatch, confirmation: str, expected_response: str
+    monkeypatch, confirmation: str
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_pending_bypass", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
@@ -819,12 +834,15 @@ def test_preprocessor_pipe_bypasses_precompile_while_pending(
 
     monkeypatch.setattr(module, "precompile_heuristic", _fail_precompile)
 
-    async def _fail_downstream_model(
+    forwarded_payloads: list[dict[str, Any]] = []
+
+    async def _track_downstream_model(
         _: object, payload: dict[str, Any], __: object
     ) -> dict[str, object]:
-        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+        forwarded_payloads.append(payload)
+        return {"ok": True}
 
-    monkeypatch.setattr(module, "generate_chat_completion", _fail_downstream_model)
+    monkeypatch.setattr(module, "generate_chat_completion", _track_downstream_model)
 
     pipe = module.Pipe()
     pipe.valves.BASE_MODEL_ID = "base-model"
@@ -839,23 +857,29 @@ def test_preprocessor_pipe_bypasses_precompile_while_pending(
         )
     )
 
-    assert result == expected_response
+    assert result == {"ok": True}
     assert engine.step_inputs == [confirmation]
     assert module._CHECKPOINTS_BY_CHAT_KEY["chat-pending"] == "ckpt-out"
+    assert len(forwarded_payloads) == 1
+    first_messages = forwarded_payloads[0]["messages"]
+    assert isinstance(first_messages, list)
+    assert isinstance(first_messages[0], dict)
+    assert first_messages[0].get("role") == "system"
+    assert isinstance(first_messages[0].get("content"), str)
+    assert first_messages[0]["content"].startswith("[[cc_state]]")
 
 
 @pytest.mark.parametrize(
-    ("confirmation", "expected_policies", "expected_response"),
+    ("confirmation", "expected_policies"),
     [
-        ("yes", {"kubectl": "use"}, "State updated: Use kubectl."),
-        ("no", {}, "State unchanged."),
+        ("yes", {"kubectl": "use"}),
+        ("no", {}),
     ],
 )
 def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
     monkeypatch,
     confirmation: str,
     expected_policies: dict[str, str],
-    expected_response: str,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_resume_e2e", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
@@ -893,12 +917,15 @@ def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
 
     module._ENGINES_BY_CHAT_KEY.clear()
 
-    async def _fail_downstream_model(
+    forwarded_payloads: list[dict[str, Any]] = []
+
+    async def _track_downstream_model(
         _: object, payload: dict[str, Any], __: object
     ) -> dict[str, object]:
-        raise AssertionError(f"downstream model should not be called: {payload.get('model')}")
+        forwarded_payloads.append(payload)
+        return {"ok": True}
 
-    monkeypatch.setattr(module, "generate_chat_completion", _fail_downstream_model)
+    monkeypatch.setattr(module, "generate_chat_completion", _track_downstream_model)
 
     resumed = asyncio.run(
         pipe.pipe(
@@ -911,7 +938,7 @@ def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
             __chat_id__=chat_key,
         )
     )
-    assert resumed == expected_response
+    assert resumed == {"ok": True}
     resumed_engine = cast(Any, module._ENGINES_BY_CHAT_KEY[chat_key])
     assert resumed_engine.state == {
         "premise": None,
@@ -920,6 +947,13 @@ def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
     }
     resumed_checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert resumed_checkpoint["pending"] is None
+    assert len(forwarded_payloads) == 1
+    resumed_messages = forwarded_payloads[0]["messages"]
+    assert isinstance(resumed_messages, list)
+    assert isinstance(resumed_messages[0], dict)
+    assert resumed_messages[0].get("role") == "system"
+    assert isinstance(resumed_messages[0].get("content"), str)
+    assert resumed_messages[0]["content"].startswith("[[cc_state]]")
 
 
 @pytest.mark.parametrize(
@@ -1142,12 +1176,18 @@ def test_preprocessor_pipe_trace_on_appends_trace_to_user_visible_output(monkeyp
             __chat_id__="chat-preproc-trace-on",
         )
     )
-    assert isinstance(result, str)
-    assert "State updated: Prohibit peanuts." in result
-    assert "Context Compiler trace" in result
-    assert "decision kind: update" in result
-    assert "preprocessor output: prohibit peanuts" in result
-    assert "downstream LLM call: no" in result
+    assert isinstance(result, dict)
+    content = result["choices"][0]["message"]["content"]
+    assert "downstream" in content
+    assert "Context Compiler trace" in content
+    assert "decision kind: update" in content
+    assert "preprocessor output: prohibit peanuts" in content
+    assert "downstream LLM call: yes" in content
+    assert "current state:" in content
+    assert "injected [[cc_state]] block: '[[cc_state]]\\nProhibit: peanuts'" in content
+    assert "payload state injection: yes" in content
+    assert "downstream payload messages:" in content
+    assert "[[cc_state]]\\nProhibit: peanuts" in content
 
 
 def test_preprocessor_pipe_trace_on_passthrough_appends_trace_to_llm_content(monkeypatch) -> None:
@@ -1182,6 +1222,8 @@ def test_preprocessor_pipe_trace_on_passthrough_appends_trace_to_llm_content(mon
     assert "Context Compiler trace" in content
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
+    assert "payload state injection: no" in content
+    assert "downstream payload messages:" in content
 
 
 def test_preprocessor_pipe_trace_on_passthrough_stream_appends_trace_after_chunks(
@@ -1230,3 +1272,53 @@ def test_preprocessor_pipe_trace_on_passthrough_stream_appends_trace_after_chunk
     assert "Context Compiler trace" in content
     assert "decision kind: passthrough" in content
     assert "downstream LLM call: yes" in content
+    assert "payload state injection: no" in content
+    assert "downstream payload messages:" in content
+
+
+def test_preprocessor_pipe_trace_on_clarify_shows_prompt_and_no_downstream_call(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_trace_clarify", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    monkeypatch.setattr(
+        module,
+        "precompile_heuristic",
+        lambda _text: {"outcome": "no_directive", "directive": None},
+    )
+
+    downstream_calls = 0
+
+    async def _downstream(_: object, payload: dict[str, Any], __: object) -> dict[str, object]:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        del payload
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _downstream)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    pipe.valves.SHOW_CONTEXT_COMPILER_TRACE = True
+
+    result = asyncio.run(
+        pipe.pipe(
+            {
+                "model": "pipe-model",
+                "messages": [{"role": "user", "content": "set premise to concise answers"}],
+            },
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-trace-clarify",
+        )
+    )
+    assert isinstance(result, str)
+    assert "decision kind: clarify" in result
+    assert "current state:" in result
+    assert "clarification prompt:" in result
+    assert "downstream LLM call: no" in result
+    assert "downstream payload messages: not sent (clarify)" in result
+    assert downstream_calls == 0


### PR DESCRIPTION
## What changed

- tightened OpenWebUI pipe update handling to split `update` outcomes into two host behaviors:
  - state-affecting updates (`use`, `prohibit`, `set/change premise`, `use X instead of Y`, confirmation-resolved updates) now forward to downstream LLM with authoritative `[[cc_state]]` injection
  - administrative updates (`clear state`, `clear premise`, `reset policies`, `remove policy <item>`) now return deterministic local acknowledgments and do not call downstream LLM
- fixed trace propagation so trace is appended reliably for forwarded passthrough/update responses across response shapes, including streaming/body-iterator paths
- simplified trace formatting to concise user-visible evidence (decision kind, state summary/change, downstream-call yes/no, state-injected yes/no/value) and removed noisy payload-history dumping
- preserved single-trace-per-turn behavior by stripping prior trace blocks from forwarded payload messages/chunks before appending current-turn trace
- aligned preprocessor integration expectations/docs with conservative runtime behavior:
  - added regression coverage showing mixed-prose natural language can abstain to passthrough
  - clarified README that heuristic-first preprocessing may abstain unless fallback yields a validated canonical directive
- updated/expanded OpenWebUI tests (base + preprocessor) to assert:
  - update/passthrough/clarify LLM-call contracts
  - authoritative `[[cc_state]]` injection for forwarded state-affecting updates
  - no LLM call for clarify and administrative updates
  - trace presence/consistency in non-stream and stream paths
  - no duplicate/contradictory trace blocks

## Why

- manual OpenWebUI behavior exposed gaps between expected and visible integration behavior:
  - forwarded responses were not consistently showing trace in real UI paths
  - administrative state-clearing/removal commands produced confusing UX when routed like content updates
  - some tests overclaimed natural-language preprocessor conversions that conservative runtime heuristics intentionally abstain from
- these changes keep compiler semantics intact while making host behavior deterministic, inspectable, and aligned with real OpenWebUI runtime behavior

Fixes #123

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
