### PR TITLE
docs: simplify onboarding and demo explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/context-compiler)](https://pypi.org/project/context-compiler/)
 [![License](https://img.shields.io/pypi/l/context-compiler)](https://pypi.org/project/context-compiler/)
 
-A deterministic directive engine that converts explicit user instructions
-into structured conversational state for LLM applications.
+Context Compiler lets users set rules and corrections that actually stick.
+It helps applications keep explicit user instructions consistent across turns.
+It stores premise and policy rules outside the model, so corrections do not drift or conflict over time.
 
-LLMs are good at reasoning but unreliable at maintaining consistent state. Constraints drift, corrections compete, and long conversations accumulate contradictions.
+LLMs are good at conversation, but bad at consistently following long-term rules and corrections. Constraints drift, corrections conflict, and long chats can become inconsistent.
 
-The **Context Compiler** introduces a deterministic state layer that governs authoritative conversational state independently of the model.
+The model writes responses. The compiler stores premise and policy rules.
 
-The model performs reasoning and generation while the compiler manages premise and policies. Once accepted, directives remain authoritative until explicitly corrected or reset.
+Context Compiler is a deterministic control layer for LLM applications. It processes explicit user instructions before model calls so applications can reliably enforce premise and policy constraints.
 
 ## Does it work?
 
@@ -87,7 +88,7 @@ uv run pytest
 
 ## Why “Compiler”?
 
-Context Compiler treats explicit user directives as inputs to a deterministic process.
+Context Compiler treats explicit user directives as inputs to a fixed, repeatable process.
 
 Instead of relying on the LLM to remember constraints across a conversation, user instructions are compiled into structured state before the model runs.
 
@@ -111,7 +112,7 @@ Later in the conversation:
 User: how should I make this curry?
 ```
 
-The host supplies the authoritative state to the model so the constraint persists across turns.
+Your app sends the saved state to the model so the rule still applies on later turns.
 
 ---
 
@@ -162,7 +163,7 @@ Host Application
  └─ update → call LLM with compiled state
 ```
 
-The compiler governs authoritative state and never calls the LLM.
+The compiler owns state updates and never calls the LLM.
 The host decides whether to call the model based on the returned `Decision`.
 
 ---
@@ -210,7 +211,7 @@ Meaning:
 
 ## State Model
 
-The compiler maintains an authoritative state snapshot.
+The compiler keeps a current state snapshot that your app can trust.
 
 - Premise is a single value that can be set or replaced
 - Policies are per-item (`use` or `prohibit`)

--- a/demos/README.md
+++ b/demos/README.md
@@ -100,7 +100,7 @@ Notes:
 
 ### Demo 05 example (prompt drift under longer context)
 
-Demo 05 measures prompt drift versus authoritative compiled state on a longer transcript.
+Demo 05 measures prompt drift versus saved compiler state on a longer transcript.
 Representative run: `PROVIDER=ollama MODEL='ollama/llama3.1:8b' uv run python demos/05_llm_prompt_drift_vs_state.py --turns 30`
 
 ```text
@@ -117,7 +117,7 @@ compiler: PASS
 compiler+compact: PASS
 ```
 
-The baseline drifted under the longer transcript, while both compiler-mediated paths preserved the authoritative premise.
+The baseline drifted under the longer transcript, while both compiler-mediated paths preserved the saved premise.
 
 ## Provider throttling
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -6,23 +6,25 @@ They compare normal prompting with an approach where the application tracks
 important instructions explicitly instead of relying only on the conversation
 history. The scripts are designed to produce consistent results so the
 behavior is easy to see.
+This demo set shows what users notice: rules and corrections keep applying
+later in the conversation instead of fading over time.
 
 Scored demos now compare three paths:
 - baseline
-- compiler-mediated (full transcript + injected state)
-- compiler+compact (compacted transcript + injected state)
+- compiler-mediated (full transcript + saved compiler state added to the prompt)
+- compiler+compact (compacted transcript + saved compiler state added to the prompt)
 
 ## Demo overview
 
 | Demo | Behavior | Concept | Most visible with |
 | :--: | --- | :--: | --- |
 | [01](./01_llm_contradiction_clarify.py) | Contradiction blocking | clarification gate | small instruct models |
-| [02](./02_llm_constraint_guardrail.py) | Constraint drift | persistent policy enforcement | small or quantized models |
-| [03](./03_llm_premise_guardrail.py) | Premise update drift | deterministic premise updates | models that summarize conversation |
+| [02](./02_llm_constraint_guardrail.py) | Rules stop applying over time | persistent policy enforcement | small or quantized models |
+| [03](./03_llm_premise_guardrail.py) | Premise updates stop sticking | fixed, repeatable premise updates | models that summarize conversation |
 | [04](./04_llm_tool_denylist_guardrail.py) | Tool governance | host-side denylist | general assistant models |
 | [05](./05_llm_prompt_drift_vs_state.py) | Prompt drift | long transcript failure | weaker long-context models ([see Demo 5 note](#demo-5-stress-ladder-turns)) |
-| [06](./06_llm_context_compaction.py) | Context compaction | compiled state replacing transcript | small or local models |
-| [07](./07_llm_prompt_vs_state.py) | Prompt engineering comparison | prompting vs compiled state | any model with long transcript sensitivity |
+| [06](./06_llm_context_compaction.py) | Context compaction | saved compiler state replacing transcript context | small or local models |
+| [07](./07_llm_prompt_vs_state.py) | Prompt engineering comparison | prompting vs saved compiler state | any model with long transcript sensitivity |
 
 Stronger frontier models may show these behaviors less often, but the same
 patterns still appear in real applications.
@@ -41,7 +43,7 @@ Environment variables (strict provider mode contract):
 - `MODEL` (optional)
 - `OPENAI_API_KEY` (required in normal `openai` mode)
 - `OPENAI_BASE_URL` (explicit endpoint override; required for explicit `openai_compatible`)
-Note: Demos prefer deterministic decoding (`temperature=0`) for reproducible PASS/FAIL behavior.
+Note: Demos prefer fixed decoding (`temperature=0`) for reproducible PASS/FAIL behavior.
 If a model rejects that parameter (for example, some `gpt-5` paths), the demo client retries once without it.
 
 Default (openai):
@@ -96,7 +98,7 @@ The canonical cross-model results matrix is maintained in [docs/demos-results.md
 Notes:
 - There are **6 scored demos** (`01`–`05`, `07`). `06_context_compaction` is informational and excluded from PASS/FAIL totals.
 - Anthropic runs in this repo are executed through the `openai_compatible` provider path.
-- `PASS` means the demo-specific oracle/checker for that path succeeded; `FAIL` means it did not.
+- `PASS` means the demo-specific expected-behavior check for that path succeeded; `FAIL` means it did not.
 
 ### Demo 05 example (prompt drift under longer context)
 
@@ -117,7 +119,7 @@ compiler: PASS
 compiler+compact: PASS
 ```
 
-The baseline drifted under the longer transcript, while both compiler-mediated paths preserved the saved premise.
+The baseline lost the earlier rule under the longer transcript, while both compiler-mediated paths kept the saved premise.
 
 ## Provider throttling
 
@@ -142,7 +144,7 @@ Running against a local OpenAI-compatible endpoint avoids provider rate limits.
     - `compiler+compact: PASS|FAIL`
   - expected behavior
   - actual outcome
-  - `result: ...` (short deterministic description)
+  - `result: ...` (short fixed, repeatable description)
   - for `06_llm_context_compaction`:
     - `context scaling: ...`
     - `compacted transcript: <baseline> → <compacted> chars`
@@ -153,15 +155,15 @@ Running against a local OpenAI-compatible endpoint avoids provider rate limits.
     - informational summary lines for `06_llm_context_compaction` (non-scored)
 - `Verbose (--verbose)`:
   - user inputs
-  - compiler decisions and compiled state
+  - compiler decisions and saved compiler state
   - prompts/messages sent to the LLM
   - output excerpts
   - host checks and final verdict
   - for `06_llm_context_compaction`, also:
     - raw transcript context
-    - compiled context
+    - context with saved compiler state
     - compacted transcript context
-    - baseline and compiled prompts
+    - baseline and compiler-state prompts
     - compacted prompt
     - context and prompt size comparisons (state-only and compacted variants)
 

--- a/docs/DescriptionAndMilestones.md
+++ b/docs/DescriptionAndMilestones.md
@@ -1,30 +1,28 @@
 # Context Compiler
 
-Deterministic state management for LLM interactions
+Reliable state handling for LLM conversations
 
 ## Project Purpose
 
-Modern LLM systems are powerful at reasoning but unreliable at
-maintaining consistent state across interactions. Corrections compete
-with prior statements instead of replacing them, topics bleed between
-conversations, and long-term state accumulates contradictions rather
-than resolving them.
-This project introduces a deterministic state layer that governs
-authoritative state independently of the model. The model performs
-interpretation and generation, while the state engine manages deterministic authoritative state (premise and policies). By separating reasoning
-from state authority, the system improves reliability without requiring
-model retraining. The system never derives authoritative state from
-model responses; only user directives modify state.
+LLM systems are strong at reasoning, but they can lose consistency across turns.
+Corrections may compete with earlier instructions, topics can leak between
+conversations, and state can conflict over time.
+This project adds a deterministic state layer that is independent of the model.
+The model handles interpretation and generation; the engine handles premise and
+policies. Only explicit user directives can change state.
+By separating reasoning from state authority, the system improves reliability
+without requiring model retraining. The system never derives authoritative state
+from model responses.
 The goal is not to make the model smarter, but to make interactions
 predictable: once a statement is corrected or scoped, future responses
 must respect that change.
 
-The engine is a deterministic state machine, not a semantic memory or
-reasoning system.
+The engine is a deterministic state machine. It is not a memory or
+reasoning layer.
 
 ## Architectural Principle
 
-The state engine is authoritative and model-independent.
+The state engine is the source of truth and is model-independent.
 Model output is never interpreted to derive or modify state.
 All state transitions originate from explicit user directives.
 
@@ -36,7 +34,7 @@ Behavioral details are authoritative in `docs/DirectiveGrammarSpec.md`.
 
 **Goal**
 Explicit user commitments persist reliably within a conversation.
-A change directive means replacing previously set authoritative state, not evaluating conversational accuracy.
+A change directive replaces previously set state. It does not judge whether earlier conversation content was "correct."
 
 M1 established deterministic state transitions and explicit clarification behavior.
 The current authoritative state shape and directive semantics are defined in `DirectiveGrammarSpec.md` (0.5 / schema version 2).
@@ -46,7 +44,7 @@ The current authoritative state shape and directive semantics are defined in `Di
 - Recognize explicit user directives that mutate premise or policies
 - Apply explicit state changes as deterministic replacements
 - Block ambiguous updates until clarified
-- Maintain an authoritative state independent of prior messages
+- Maintain a source-of-truth state that does not depend on prior model wording
 - Provide structured state for host-provided model context
 
 **Deliverables:**
@@ -84,7 +82,7 @@ Extend host-level workflows around persisted exported state safely and intention
 
 **User-visible outcome:**
 
-Assistant remembers decisions across sessions without resurrecting contradictions.
+When hosts persist exported state, assistants can carry decisions across sessions without reintroducing old conflicts.
 Pending confirmation-required flows can be resumed when the host persists checkpoints.
 
 `export_json()` / `import_json()` remain authoritative-state only.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 - [Project README](../README.md)
 
 ## Core Concepts
-- [Directive Grammar](DirectiveGrammarSpec.md)
+- [Directive Grammar (exact command forms the engine accepts)](DirectiveGrammarSpec.md)
 
 ## Integrations
 - [Open WebUI integration](../examples/integrations/openwebui/README.md)

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -4,7 +4,7 @@ These examples show how to integrate Context Compiler with external systems.
 
 ## LiteLLM (SDK)
 
-Minimal example showing how to run Context Compiler before an LLM call with LiteLLM.
+Minimal example showing how to run Context Compiler before sending a request to the LLM with LiteLLM.
 
 Files:
 - Examples (basic + preprocessor): [litellm/README.md](litellm/README.md)
@@ -28,7 +28,7 @@ See the LiteLLM examples README for setup and usage:
 
 - Context Compiler runs before any LLM call.
 - If clarification is required, no LLM call is made.
-- Otherwise, compiled state is injected into the prompt before calling the model.
+- Otherwise, saved compiler state is added to the prompt before calling the model.
 
 ## LiteLLM Proxy
 

--- a/examples/integrations/litellm/README.md
+++ b/examples/integrations/litellm/README.md
@@ -1,6 +1,6 @@
 # LiteLLM examples
 
-This directory contains two minimal Context Compiler + LiteLLM integrations:
+This directory contains two small Context Compiler + LiteLLM integration examples:
 
 - `basic.py`: compiler-only flow (no preprocessor)
 - `with_preprocessor.py`: heuristic-first preprocessor with optional LLM fallback before `engine.step(...)`
@@ -118,7 +118,7 @@ These files are importable integration references for host applications.
   continuity requires external persistence (DB/Redis/etc.).
 - Display the returned assistant text.
 
-Note: In these LiteLLM example integrations, update decisions are rendered deterministically and do not call the downstream LLM. This makes state transitions explicit. Production hosts may choose different rendering behavior.
+Note: In these LiteLLM example integrations, update decisions are rendered locally in a fixed, repeatable way and do not call the downstream LLM. This makes state transitions explicit. Production hosts may choose different rendering behavior.
 
 ## Troubleshooting
 
@@ -135,7 +135,7 @@ Note: In these LiteLLM example integrations, update decisions are rendered deter
   - If heuristic returns a directive, that directive is passed to `engine.step(...)`.
   - If heuristic does not produce a directive (`no_directive` or `unknown`), LLM fallback prompt conversion runs.
   - If fallback yields nothing usable or errors, behavior safely remains equivalent to basic.
-  - Behavior is reject-first and does not expand directive grammar.
+  - Behavior is reject-first and does not broaden the directive grammar.
 
 ## Example checks
 

--- a/examples/integrations/litellm_proxy/README.md
+++ b/examples/integrations/litellm_proxy/README.md
@@ -1,7 +1,7 @@
 # LiteLLM Proxy (pre-call hook)
 
 This example shows how to run Context Compiler inside a LiteLLM proxy pre-call hook.
-The hook enforces deterministic state handling before any upstream model call.
+The hook applies fixed, repeatable state handling before any upstream model call.
 
 Available hook files:
 
@@ -84,7 +84,7 @@ curl http://localhost:4000/v1/chat/completions \
 
 - User messages are replayed through Context Compiler before the model call.
 - If clarification is required, the proxy returns the clarification text as the response instead of calling the model.
-- Otherwise, compiled state is injected into a system message.
+- Otherwise, compiler state is added as a system message.
 
 Preprocessor-enabled variant behavior:
 

--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -1,6 +1,6 @@
 # Open WebUI Pipe Integration
 
-Open WebUI Pipe Function examples for Context Compiler.
+Examples of Open WebUI Pipe Functions that run Context Compiler.
 
 Tested target: Open WebUI `v0.8.12` (latest at time of testing).
 Runtime-validated on stock Docker Open WebUI with a real backend model provider.
@@ -11,7 +11,7 @@ These examples support both sync (`0.8.x`) and async (`0.9.x`) user lookup.
 ## Files
 
 - `open_webui_pipe.py`: basic integration, no preprocessor layer (recommended/default).
-- `open_webui_pipe_with_preprocessor.py`: optional/experimental preprocessor layer (heuristic first, then model fallback) before `engine.step(...)`.
+- `open_webui_pipe_with_preprocessor.py`: optional/experimental preprocessor layer (rule-based check first, then optional model fallback) before `engine.step(...)`.
 
 ## Setup
 
@@ -85,7 +85,7 @@ Use the Open WebUI model picker/list to copy exact model ids for `BASE_MODEL_ID`
 ## Manual Validation
 
 Validate clarify short-circuit, passthrough forwarding without state injection,
-update forwarding with authoritative `[[cc_state]]` injection, chat isolation
+update forwarding with compiler state (`[[cc_state]]`) added to the request, chat isolation
 with real chat ids, restart state loss, and non-text bypass behavior.
 
 Note: In the OpenWebUI example pipes, `update` decisions call the downstream
@@ -104,7 +104,7 @@ active state, downstream LLM call/no-call, and whether state was injected.
 - base model: “To adjust the tone… provide the original content…”
 - basic pipe: `No premise exists yet. Use 'set premise ...' first.`
 - preprocessor pipe: `No premise exists yet. Use 'set premise ...' first.`
-- why this is a real win: lifecycle rule is enforced deterministically; base model drifts into generic rewriting help.
+- why this is a real win: lifecycle rule is enforced in a fixed, repeatable way; base model drifts into generic rewriting help.
 
 **Case 2**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.19"
+version = "0.6.20"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.19"
+version = "0.6.20"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- Simplified the top-level onboarding language in `README.md` to be behavior-first and easier for new users to scan.
- Clarified wording in core docs:
  - `docs/README.md`
  - `docs/DescriptionAndMilestones.md`
- Simplified integration documentation phrasing in:
  - `examples/integrations/README.md`
  - `examples/integrations/openwebui/README.md`
  - `examples/integrations/litellm/README.md`
  - `examples/integrations/litellm_proxy/README.md`
- Performed a conservative clarity pass on demo-facing docs in `demos/README.md` (user-facing explanation text only).
- Bumped package version to `0.6.20` in `pyproject.toml` and the corresponding `uv.lock` entry.

## Why

- Make the project easier to understand for first-time users without changing behavior, contracts, or evidence.
- Replace abstract phrasing with smaller, concrete wording where safe.
- Improve demo readability so users can quickly see what behavior changes they should notice.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
