### PR TITLE
docs: add design philosophy reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,12 @@ For a full documentation map, see [docs/README.md](docs/README.md).
 
 ---
 
+## Design Rationale
+
+- [Design philosophy](docs/DesignPhilosophy.md)
+
+---
+
 ## Design Notes
 
 More detailed design and milestone documents are available in:

--- a/docs/DesignPhilosophy.md
+++ b/docs/DesignPhilosophy.md
@@ -1,0 +1,42 @@
+# Design Philosophy
+
+## The Problem with Implicit State
+
+Modern LLM applications typically manage conversational state implicitly — the model reads the transcript, infers what constraints are active, and generates a response accordingly. This works well for short conversations and simple tasks.
+
+It breaks down reliably in longer conversations, correction flows, and multi-turn constraint management. Constraints drift. Corrections get partially applied or treated as additive rather than authoritative replacements. Contradictions accumulate instead of resolving. The model interprets intent rather than enforcing it.
+
+Transcript-only context forces the model to infer which prior statements are still active, which were corrections, and which should override earlier instructions. Context Compiler replaces that implicit reconstruction step with explicit stored rules.
+
+This is not a capability gap that better models will eventually close. It is a structural property of delegating state authority to a probabilistic system. A more capable model drifts more gracefully, but it still drifts.
+
+## Explicit State Management
+
+Explicit state management is not a new idea. Earlier AI systems maintained structured representations of what was known and what constraints were active. State changed only through deterministic transitions. The system could be inspected, replayed, and reasoned about precisely.
+
+The core insight is simple: maintain an explicit active set of rules rather than inferring the relevant context from history each time. What is in the active set is known with certainty. What is not in it is not active.
+
+These approaches succeeded in narrow, well-defined domains precisely because explicit state gives you guarantees that implicit inference cannot. The limitation was not the state management approach — it was that handling natural language and ambiguity was extraordinarily difficult. Those problems consumed most of the design effort.
+
+Modern LLMs handle natural language interpretation and generation far more effectively than earlier systems. This changes the calculus: the language interface problem is largely addressed. As end-to-end neural approaches became dominant, many systems shifted toward transcript-driven implicit state management, assuming a capable model could handle state implicitly.
+
+That assumption is incorrect in practice, for the structural reason described above.
+
+## The Synthesis
+
+Context Compiler applies explicit state management to the modern LLM context, with a clear division of responsibilities:
+
+- The LLM handles what it is genuinely good at — language understanding, reasoning, generation, handling ambiguity in user intent
+- The deterministic engine handles what probabilistic systems handle poorly — maintaining explicit state across turns, enforcing constraints, guaranteeing that corrections replace rather than compete with prior state
+
+The preprocessor layer bridges the two: it uses the LLM's language understanding to translate natural language directive intent into canonical form, which the deterministic engine can then process reliably. Fuzzy where it needs to be fuzzy, deterministic where determinism matters.
+
+This is not a workaround for LLM limitations. It is an appropriate allocation of responsibilities based on what each component is actually suited for.
+
+## Why Determinism Matters
+
+A deterministic state layer is inspectable, reproducible, and auditable in ways that transcript-dependent implicit state is not.
+
+Identical input sequences always produce identical state. State changes only through explicit user directives. Model responses never modify stored state. These are invariants, not tendencies.
+
+This matters for debugging, for testing, for building reliable applications, and for giving users confidence that what they said was actually heard. When a constraint is set, it stays set — not because the model is trying to remember it, but because the system is structured to enforce it.


### PR DESCRIPTION
## What changed

- Added a design philosophy document at `docs/DesignPhilosophy.md`.
- Updated `README.md` to link to the design philosophy document.

## Why

- Make the project’s guiding principles easier to find from the top-level README.
- Provide a single reference for design intent that helps contributors understand decisions.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
