### PR TITLE
docs: add documentation style guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,26 @@ Do not change specification documents unless explicitly instructed.
 
 If implementation behavior does not match the specification, report the mismatch instead of modifying the specification.
 
+## Documentation style
+
+For README, demo, integration, and package-listing docs, explain user-visible behavior before architecture.
+
+Prefer plain, concrete wording when accurate. Examples:
+- "rules and corrections that stick"
+- "saved compiler state"
+- "stored premise and policy rules"
+- "fixed, repeatable"
+- "explicit instructions stay consistent across turns"
+
+Avoid describing features only in architectural terms when a behavior-first explanation is possible.
+
+Specification and contract documents are different:
+- preserve precise terminology
+- preserve unambiguous behavioral guarantees
+- do not weaken formal semantics for readability
+
+Do not rewrite captured outputs, fixture-sensitive examples, or eval evidence unless explicitly asked.
+
 ## Tooling
 Use the project's existing tooling:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,20 @@ pre-commit run --all-files
 - keep pull requests focused
 - include tests if behavior changes
 - open an issue first for large design changes
+
+## Documentation Style
+
+For README, demo, integration, and package-listing docs, explain user-visible behavior before architecture.
+
+Prefer plain, concrete wording when accurate. For example:
+- "rules and corrections that stick"
+- "saved compiler state"
+- "stored premise and policy rules"
+- "fixed, repeatable"
+- "explicit instructions stay consistent across turns"
+
+Avoid describing features only in architectural terms when a behavior-first explanation is possible.
+
+Specification and contract documents are different: preserve precise terminology and unambiguous behavioral guarantees. Do not simplify formal docs in ways that weaken guarantees or change meaning.
+
+Do not rewrite captured outputs, fixture-sensitive examples, or eval evidence unless explicitly asked.


### PR DESCRIPTION
## What changed

- Added a `Documentation style` section to `AGENTS.md`.
- Added a matching `Documentation Style` section to `CONTRIBUTING.md`.
- Guidance is scoped to docs wording only (behavior-first explanations, plain concrete terms, and explicit boundaries for spec/contract docs and fixture/eval-sensitive text).

## Why

- Keep future documentation updates consistent with the newer behavior-first style.
- Make contributor expectations explicit so readability improvements do not weaken formal guarantees.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
