### PR TITLE
feat: add pending clarification query and tighten checkpoint boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Meaning:
 | `compile_transcript(messages: Transcript)` | Replay a transcript from a fresh engine and return either final state or a confirmation prompt. |
 | `engine.apply_transcript(messages: Transcript)` | Replay a transcript onto the current engine state and return either final state or a confirmation prompt. |
 | `engine.state` | Read current authoritative in-memory state snapshot. |
+| `engine.has_pending_clarification()` | Return whether a confirmation-required clarification is currently pending. |
 | `get_premise_value(state)` | Read the current premise value from a state snapshot. |
 | `get_policy_items(state, value=None)` | Read policy items from a state snapshot (all, `use`, or `prohibit`). |
 | `engine.export_json()` | Export authoritative state as JSON (`str`) for state transport/persistence. |

--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -22,12 +22,14 @@ from context_compiler import State, get_policy_items, get_premise_value
 from context_compiler.engine import Engine
 
 try:
-    from host_support import is_confirmation_text, summarize_confirmation_update
+    from host_support import is_confirmation_text
 except ImportError:
     import host_support.confirmation as _confirmation
 
     is_confirmation_text = _confirmation.is_confirmation_text
-    summarize_confirmation_update = _confirmation.summarize_confirmation_update
+
+from host_support.confirmation import summarize_confirmation_update
+
 try:
     from host_support import build_trace
 except ImportError:
@@ -215,44 +217,8 @@ def _near_miss_directive_clarify(value: str) -> str | None:
 
 
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:
-    summarize_fn = summarize_confirmation_update
-    if callable(summarize_fn):
-        return summarize_fn(user_input, pending)
-
-    normalized = _normalize_confirmation_for_summary(user_input)
-    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
-        return "State unchanged."
-    if not isinstance(pending, dict):
-        return "State updated."
-
-    replacement = pending.get("replacement")
-    if not isinstance(replacement, dict):
-        return "State updated."
-
-    kind = replacement.get("kind")
-    new_item = replacement.get("new_item")
-    old_item = replacement.get("old_item")
-    if kind == "use_only" and isinstance(new_item, str):
-        new_label = _render_item_label(new_item)
-        if new_label:
-            return f"State updated: Use {new_label}."
-        return "State updated."
-
-    if kind == "replace_use" and isinstance(new_item, str) and isinstance(old_item, str):
-        new_label = _render_item_label(new_item)
-        old_label = _render_item_label(old_item)
-        if not new_label or not old_label:
-            return "State updated."
-        prompt = pending.get("prompt_to_user")
-        prohibited_old_prompt = (
-            f'"{old_item}" is currently prohibited. '
-            f'Did you mean to remove it and use "{new_item}" instead?'
-        )
-        if prompt == prohibited_old_prompt:
-            return f"State updated: Removed prohibition on {old_label}; use {new_label}."
-        return f"State updated: Replaced {old_label} with {new_label}."
-
-    return "State updated."
+    summarize_fn: Callable[[str, object], str] = summarize_confirmation_update
+    return summarize_fn(user_input, pending)
 
 
 def _summarize_update_from_input(user_input: str) -> str:

--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -182,6 +182,14 @@ def _persist_session_checkpoint_if_needed(
     _CHECKPOINTS_BY_SESSION_KEY[session_key] = engine.export_checkpoint_json()
 
 
+def _has_pending_clarification(engine: Engine) -> bool:
+    checker = getattr(engine, "has_pending_clarification", None)
+    if callable(checker):
+        return bool(checker())
+    checkpoint = engine.export_checkpoint()
+    return checkpoint.get("pending") is not None
+
+
 def _normalize_confirmation_for_summary(value: str) -> str:
     normalized = value.strip().lower()
     normalized = re.sub(r"\s+", " ", normalized)
@@ -312,8 +320,10 @@ def _append_trace(
 
 def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = None) -> str:
     _restore_session_checkpoint_if_needed(engine, session_key)
-    checkpoint_before = engine.export_checkpoint()
-    pending_before = checkpoint_before.get("pending")
+    state_before = engine.state
+    pending_before = (
+        engine.export_checkpoint().get("pending") if _has_pending_clarification(engine) else None
+    )
     logger.debug("litellm_basic: engine_input=%s", f"user_input len={len(user_input)}")
     decision = engine.step(user_input)
     kind = cast(str, decision["kind"])
@@ -328,7 +338,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             original_input=user_input,
             compiler_input=user_input,
             decision=decision,
-            state_before=checkpoint_before.get("authoritative_state"),
+            state_before=state_before,
             state_after=engine.state,
             llm_called=False,
         )
@@ -338,7 +348,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             original_input=user_input,
             compiler_input=user_input,
             decision={"kind": "clarify", "prompt_to_user": near_miss_prompt},
-            state_before=checkpoint_before.get("authoritative_state"),
+            state_before=state_before,
             state_after=engine.state,
             llm_called=False,
         )
@@ -350,7 +360,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             original_input=user_input,
             compiler_input=user_input,
             decision=decision,
-            state_before=checkpoint_before.get("authoritative_state"),
+            state_before=state_before,
             state_after=engine.state,
             llm_called=False,
         )
@@ -361,7 +371,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             original_input=user_input,
             compiler_input=user_input,
             decision=decision,
-            state_before=checkpoint_before.get("authoritative_state"),
+            state_before=state_before,
             state_after=engine.state,
             llm_called=False,
         )
@@ -374,7 +384,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
         original_input=user_input,
         compiler_input=user_input,
         decision=decision,
-        state_before=checkpoint_before.get("authoritative_state"),
+        state_before=state_before,
         state_after=compiled_state,
         llm_called=True,
     )

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -34,12 +34,14 @@ from experimental.preprocessor import (
 )
 
 try:
-    from host_support import is_confirmation_text, summarize_confirmation_update
+    from host_support import is_confirmation_text
 except ImportError:
     import host_support.confirmation as _confirmation
 
     is_confirmation_text = _confirmation.is_confirmation_text
-    summarize_confirmation_update = _confirmation.summarize_confirmation_update
+
+from host_support.confirmation import summarize_confirmation_update
+
 try:
     from host_support import build_trace
 except ImportError:
@@ -326,44 +328,8 @@ def _near_miss_directive_clarify(value: str) -> str | None:
 
 
 def _summarize_confirmation_update(user_input: str, pending: object) -> str:
-    summarize_fn = summarize_confirmation_update
-    if callable(summarize_fn):
-        return summarize_fn(user_input, pending)
-
-    normalized = _normalize_confirmation_for_summary(user_input)
-    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
-        return "State unchanged."
-    if not isinstance(pending, dict):
-        return "State updated."
-
-    replacement = pending.get("replacement")
-    if not isinstance(replacement, dict):
-        return "State updated."
-
-    kind = replacement.get("kind")
-    new_item = replacement.get("new_item")
-    old_item = replacement.get("old_item")
-    if kind == "use_only" and isinstance(new_item, str):
-        new_label = _render_item_label(new_item)
-        if new_label:
-            return f"State updated: Use {new_label}."
-        return "State updated."
-
-    if kind == "replace_use" and isinstance(new_item, str) and isinstance(old_item, str):
-        new_label = _render_item_label(new_item)
-        old_label = _render_item_label(old_item)
-        if not new_label or not old_label:
-            return "State updated."
-        prompt = pending.get("prompt_to_user")
-        prohibited_old_prompt = (
-            f'"{old_item}" is currently prohibited. '
-            f'Did you mean to remove it and use "{new_item}" instead?'
-        )
-        if prompt == prohibited_old_prompt:
-            return f"State updated: Removed prohibition on {old_label}; use {new_label}."
-        return f"State updated: Replaced {old_label} with {new_label}."
-
-    return "State updated."
+    summarize_fn: Callable[[str, object], str] = summarize_confirmation_update
+    return summarize_fn(user_input, pending)
 
 
 def _summarize_update_from_input(user_input: str) -> str:

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -293,6 +293,14 @@ def _persist_session_checkpoint_if_needed(
     _CHECKPOINTS_BY_SESSION_KEY[session_key] = engine.export_checkpoint_json()
 
 
+def _has_pending_clarification(engine: Engine) -> bool:
+    checker = getattr(engine, "has_pending_clarification", None)
+    if callable(checker):
+        return bool(checker())
+    checkpoint = engine.export_checkpoint()
+    return checkpoint.get("pending") is not None
+
+
 def _normalize_confirmation_for_summary(value: str) -> str:
     normalized = value.strip().lower()
     normalized = re.sub(r"\s+", " ", normalized)
@@ -425,10 +433,12 @@ def _append_trace(
 
 def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = None) -> str:
     _restore_session_checkpoint_if_needed(engine, session_key)
-    checkpoint_before = engine.export_checkpoint()
-    pending_before = checkpoint_before.get("pending")
+    state_before = engine.state
+    pending_before = (
+        engine.export_checkpoint().get("pending") if _has_pending_clarification(engine) else None
+    )
     preprocessd: str | None = None
-    if pending_before is not None:
+    if _has_pending_clarification(engine):
         compile_input = user_input
     else:
         preprocessd = _preprocess_user_input(user_input, engine.state)
@@ -452,7 +462,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             compiler_input=compile_input,
             preprocessor_output=preprocessd,
             decision=decision,
-            state_before=checkpoint_before.get("authoritative_state"),
+            state_before=state_before,
             state_after=engine.state,
             llm_called=False,
         )
@@ -463,7 +473,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             compiler_input=compile_input,
             preprocessor_output=preprocessd,
             decision={"kind": "clarify", "prompt_to_user": near_miss_prompt},
-            state_before=checkpoint_before.get("authoritative_state"),
+            state_before=state_before,
             state_after=engine.state,
             llm_called=False,
         )
@@ -476,7 +486,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             compiler_input=compile_input,
             preprocessor_output=preprocessd,
             decision=decision,
-            state_before=checkpoint_before.get("authoritative_state"),
+            state_before=state_before,
             state_after=engine.state,
             llm_called=False,
         )
@@ -488,7 +498,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             compiler_input=compile_input,
             preprocessor_output=preprocessd,
             decision=decision,
-            state_before=checkpoint_before.get("authoritative_state"),
+            state_before=state_before,
             state_after=engine.state,
             llm_called=False,
         )
@@ -502,7 +512,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
         compiler_input=compile_input,
         preprocessor_output=preprocessd,
         decision=decision,
-        state_before=checkpoint_before.get("authoritative_state"),
+        state_before=state_before,
         state_after=compiled_state,
         llm_called=True,
     )

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -624,13 +624,12 @@ class Pipe:
                 engine.import_checkpoint_json(checkpoint)
             _ENGINES_BY_CHAT_KEY[chat_key] = engine
 
-        checkpoint_before = engine.export_checkpoint()
+        state_before = engine.state
         logger.debug("pipe: engine_input=%r", latest_user_text)
         decision = engine.step(latest_user_text)
         kind = decision["kind"]
         logger.debug("pipe: decision=%s", kind)
         near_miss_prompt = _near_miss_directive_clarify(latest_user_text)
-        state_before = checkpoint_before.get("authoritative_state")
         state_after = decision.get("state") if isinstance(decision, dict) else None
         if state_after is None:
             state_after = engine.state

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -116,6 +116,14 @@ def _extract_latest_user_text(messages: list[dict[str, Any]]) -> str | None:
     return None
 
 
+def _has_pending_clarification(engine: Engine) -> bool:
+    checker = getattr(engine, "has_pending_clarification", None)
+    if callable(checker):
+        return bool(checker())
+    checkpoint = engine.export_checkpoint()
+    return checkpoint.get("pending") is not None
+
+
 def _render_compiler_state_block(state: State) -> str:
     lines: list[str] = [_CC_MARKER]
 
@@ -879,12 +887,11 @@ class Pipe:
                 engine.import_checkpoint_json(checkpoint)
             _ENGINES_BY_CHAT_KEY[chat_key] = engine
 
-        checkpoint_before = engine.export_checkpoint()
-        pending_before = checkpoint_before.get("pending")
+        state_before = engine.state
 
         preprocessd: str | None = None
         preprocess_error: str | None = None
-        if pending_before is None:
+        if not _has_pending_clarification(engine):
             preprocessd, preprocess_error = await self._preprocess_user_input(
                 latest_user_text,
                 engine.state,
@@ -906,7 +913,6 @@ class Pipe:
         kind = decision["kind"]
         logger.debug("preprocessor: decision=%s", kind)
         near_miss_prompt = _near_miss_directive_clarify(latest_user_text)
-        state_before = checkpoint_before.get("authoritative_state")
         state_after = decision.get("state") if isinstance(decision, dict) else None
         if state_after is None:
             state_after = engine.state

--- a/host_support/__init__.py
+++ b/host_support/__init__.py
@@ -1,6 +1,6 @@
 """Host-side shared helpers."""
 
-from .confirmation import is_confirmation_text, summarize_confirmation_update
+from .confirmation import is_confirmation_text
 from .observability import build_trace
 from .provider_mode import ProviderConfig, print_startup_config, resolve_provider_config
 
@@ -10,5 +10,4 @@ __all__ = [
     "is_confirmation_text",
     "print_startup_config",
     "resolve_provider_config",
-    "summarize_confirmation_update",
 ]

--- a/host_support/confirmation.py
+++ b/host_support/confirmation.py
@@ -37,20 +37,7 @@ def is_confirmation_text(value: str) -> bool:
     return _normalize_confirmation_text(value) in CONFIRMATION_TOKENS
 
 
-def summarize_confirmation_update(user_input: str, pending: object) -> str:
-    """Return deterministic host summary text for confirmation-only updates.
-
-    This helper is intentionally conservative:
-    - negative confirmations always return ``State unchanged.``
-    - affirmative confirmations return an exact deterministic summary only when
-      pending metadata unambiguously identifies the confirmed transition
-    - otherwise it falls back to ``State updated.``
-    """
-    normalized = _normalize_confirmation_text(user_input)
-    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
-        return "State unchanged."
-    if normalized not in _AFFIRMATIVE_CONFIRMATION_TOKENS:
-        return "State updated."
+def _summarize_pending_confirmation_update(pending: object) -> str:
     if not isinstance(pending, dict):
         return "State updated."
 
@@ -84,3 +71,20 @@ def summarize_confirmation_update(user_input: str, pending: object) -> str:
         return f"State updated: Replaced {old_label} with {new_label}."
 
     return "State updated."
+
+
+def summarize_confirmation_update(user_input: str, pending: object) -> str:
+    """Return deterministic host summary text for confirmation-only updates.
+
+    This helper is intentionally conservative:
+    - negative confirmations always return ``State unchanged.``
+    - affirmative confirmations return an exact deterministic summary only when
+      pending metadata unambiguously identifies the confirmed transition
+    - otherwise it falls back to ``State updated.``
+    """
+    normalized = _normalize_confirmation_text(user_input)
+    if normalized in _NEGATIVE_CONFIRMATION_TOKENS:
+        return "State unchanged."
+    if normalized not in _AFFIRMATIVE_CONFIRMATION_TOKENS:
+        return "State updated."
+    return _summarize_pending_confirmation_update(pending)

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -150,6 +150,9 @@ class Engine:
     def state(self) -> State:
         return deepcopy(self._state)
 
+    def has_pending_clarification(self) -> bool:
+        return self._pending_replacement is not None
+
     def export_json(self) -> str:
         return json.dumps(self._state, sort_keys=True, separators=(",", ":"))
 

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -151,6 +151,7 @@ class Engine:
         return deepcopy(self._state)
 
     def has_pending_clarification(self) -> bool:
+        """Return whether a confirmation-required clarification is pending."""
         return self._pending_replacement is not None
 
     def export_json(self) -> str:

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -98,8 +98,7 @@ def _print_decision_lines(decision: Decision, out_stream: TextIO, *, leading_bla
 
 
 def _has_pending_clarification(engine: Engine) -> bool:
-    checkpoint = engine.export_checkpoint()
-    return checkpoint["pending"] is not None
+    return engine.has_pending_clarification()
 
 
 def _compile_input(raw_input: str, engine: Engine, *, use_preprocessor: bool) -> str:

--- a/tests/fixtures/conformance/checkpoint/005_import_checkpoint_invalid_authoritative_state_rejected_atomically.json
+++ b/tests/fixtures/conformance/checkpoint/005_import_checkpoint_invalid_authoritative_state_rejected_atomically.json
@@ -26,6 +26,7 @@
       "type": "ValueError",
       "message_contains": "Invalid state payload"
     },
+    "has_pending_clarification": true,
     "state": {
       "premise": null,
       "policies": {},

--- a/tests/fixtures/conformance/checkpoint/006_import_checkpoint_pending_null_clears_existing_pending.json
+++ b/tests/fixtures/conformance/checkpoint/006_import_checkpoint_pending_null_clears_existing_pending.json
@@ -24,6 +24,7 @@
     }
   },
   "expected": {
+    "has_pending_clarification": false,
     "state": {
       "premise": "baseline",
       "policies": {

--- a/tests/fixtures/conformance/checkpoint/007_import_checkpoint_pending_absent_clears_existing_pending.json
+++ b/tests/fixtures/conformance/checkpoint/007_import_checkpoint_pending_absent_clears_existing_pending.json
@@ -23,6 +23,7 @@
     }
   },
   "expected": {
+    "has_pending_clarification": false,
     "state": {
       "premise": "baseline",
       "policies": {

--- a/tests/fixtures/conformance/step/008_replace_missing_source_clarify_prompt.json
+++ b/tests/fixtures/conformance/step/008_replace_missing_source_clarify_prompt.json
@@ -13,6 +13,7 @@
       "prompt_to_user": "Did you mean to use \"kubectl\" instead?",
       "state": null
     },
+    "has_pending_clarification": true,
     "state": {
       "premise": null,
       "policies": {},

--- a/tests/fixtures/conformance/step/009_pending_affirmative_normalized_token.json
+++ b/tests/fixtures/conformance/step/009_pending_affirmative_normalized_token.json
@@ -22,6 +22,7 @@
         "version": 2
       }
     },
+    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/010_pending_negative_normalized_token.json
+++ b/tests/fixtures/conformance/step/010_pending_negative_normalized_token.json
@@ -20,6 +20,7 @@
         "version": 2
       }
     },
+    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {},

--- a/tests/fixtures/conformance/step/011_pending_unmatched_reuses_prompt.json
+++ b/tests/fixtures/conformance/step/011_pending_unmatched_reuses_prompt.json
@@ -18,6 +18,7 @@
       "prompt_to_user": "\"kubectl\" is currently prohibited. Did you mean to remove \"docker\" and use \"kubectl\" instead?",
       "state": null
     },
+    "has_pending_clarification": true,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/018_pending_affirmative_punctuation_token.json
+++ b/tests/fixtures/conformance/step/018_pending_affirmative_punctuation_token.json
@@ -22,6 +22,7 @@
         "version": 2
       }
     },
+    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/019_pending_negative_punctuation_token.json
+++ b/tests/fixtures/conformance/step/019_pending_negative_punctuation_token.json
@@ -20,6 +20,7 @@
         "version": 2
       }
     },
+    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {},

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -18,6 +18,7 @@ def test_decision_kind_strenum_behavior() -> None:
 def test_initial_state_and_helpers() -> None:
     engine = create_engine()
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
+    assert engine.has_pending_clarification() is False
     assert get_premise_value(engine.state) is None
     assert get_policy_items(engine.state) == []
 
@@ -228,6 +229,7 @@ def test_export_checkpoint_serializes_pending_replacement_state_for_exact_resume
     engine = create_engine()
     clarify = engine.step("use kubectl instead of docker")
     assert clarify["kind"] == "clarify"
+    assert engine.has_pending_clarification() is True
 
     checkpoint = engine.export_checkpoint()
     assert checkpoint["pending"] == {
@@ -292,10 +294,12 @@ def test_import_checkpoint_restores_pending_clarification_and_unmatched_input_re
 
     target = create_engine()
     target.import_checkpoint(checkpoint)
+    assert target.has_pending_clarification() is True
     before = target.state
     second = target.step("maybe")
 
     assert second == first
+    assert target.has_pending_clarification() is True
     assert target.state == before
 
 
@@ -326,10 +330,23 @@ def test_import_checkpoint_restores_pending_clarification_and_resolves_yes() -> 
 
     target = create_engine()
     target.import_checkpoint(checkpoint)
+    assert target.has_pending_clarification() is True
     decision = target.step("yes")
 
     assert decision["kind"] == "update"
+    assert target.has_pending_clarification() is False
     assert target.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
+
+
+def test_has_pending_clarification_clears_on_negative_confirmation() -> None:
+    engine = create_engine()
+    decision = engine.step("use kubectl instead of docker")
+    assert decision["kind"] == "clarify"
+    assert engine.has_pending_clarification() is True
+
+    no_decision = engine.step("no")
+    assert no_decision["kind"] == "update"
+    assert engine.has_pending_clarification() is False
 
 
 def test_import_checkpoint_invalid_json_and_invalid_object_payload_are_rejected() -> None:
@@ -526,6 +543,17 @@ def test_import_checkpoint_is_all_or_nothing_when_authoritative_state_is_invalid
     assert engine.state == before
 
 
+def test_has_pending_clarification_clears_after_import_json() -> None:
+    engine = create_engine()
+    clarify = engine.step("use kubectl instead of docker")
+    assert clarify["kind"] == "clarify"
+    assert engine.has_pending_clarification() is True
+
+    engine.import_json('{"policies":{},"premise":null,"version":2}')
+
+    assert engine.has_pending_clarification() is False
+
+
 def test_replace_use_clarifies_when_old_policy_is_not_use_in_invalid_internal_state() -> None:
     engine = create_engine()
     # Defensive-path coverage for impossible external state values.
@@ -546,6 +574,7 @@ def test_replace_use_clarifies_when_old_policy_is_not_use_in_invalid_internal_st
 def test_import_checkpoint_with_pending_none_clears_existing_pending() -> None:
     engine = create_engine()
     engine.step("use kubectl instead of docker")
+    assert engine.has_pending_clarification() is True
 
     engine.import_checkpoint(
         {
@@ -558,6 +587,7 @@ def test_import_checkpoint_with_pending_none_clears_existing_pending() -> None:
             "pending": None,
         }
     )
+    assert engine.has_pending_clarification() is False
 
     yes_decision = engine.step("yes")
     assert yes_decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
@@ -568,6 +598,7 @@ def test_import_checkpoint_with_pending_none_clears_existing_pending() -> None:
 def test_import_checkpoint_with_pending_absent_clears_existing_pending() -> None:
     engine = create_engine()
     engine.step("use kubectl instead of docker")
+    assert engine.has_pending_clarification() is True
 
     engine.import_checkpoint(
         {
@@ -579,6 +610,7 @@ def test_import_checkpoint_with_pending_absent_clears_existing_pending() -> None
             },
         }
     )
+    assert engine.has_pending_clarification() is False
 
     yes_decision = engine.step("yes")
     assert yes_decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -25,6 +25,17 @@ def _load(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _assert_optional_pending_flag(expected_obj: object, engine: object, fixture_id: object) -> None:
+    if not isinstance(expected_obj, dict):
+        return
+    if "has_pending_clarification" not in expected_obj:
+        return
+
+    expected_pending = expected_obj["has_pending_clarification"]
+    assert isinstance(expected_pending, bool), fixture_id
+    assert engine.has_pending_clarification() is expected_pending, fixture_id
+
+
 def test_step_fixtures() -> None:
     for path in _json_files(_STEP_FIXTURES_DIR):
         fixture = _load(path)
@@ -58,6 +69,7 @@ def test_step_fixtures() -> None:
             assert decision["state"] == engine.state, fixture_id
 
         assert engine.state == expected["state"], fixture_id
+        _assert_optional_pending_flag(expected, engine, fixture_id)
 
 
 def test_transcript_fixtures() -> None:
@@ -147,9 +159,11 @@ def test_checkpoint_fixtures() -> None:
             raise AssertionError(f"Unknown checkpoint action: {fn}")
 
         assert engine.state == expected["state"], fixture_id
+        _assert_optional_pending_flag(expected, engine, fixture_id)
 
         followup = expected.get("followup")
         if followup is not None:
             decision = engine.step(followup["input"])
             assert decision == followup["decision"], fixture_id
             assert engine.state == followup["state"], fixture_id
+            _assert_optional_pending_flag(followup, engine, fixture_id)


### PR DESCRIPTION
## What changed

- Added `Engine.has_pending_clarification()` as a small public query for host/runtime gating without exposing pending payload internals.
- Updated REPL pending detection to use `engine.has_pending_clarification()` instead of reading `export_checkpoint()["pending"]`.
- Added focused engine tests covering pending query behavior across clarify resolution and import paths.
- Updated README API reference to document `engine.has_pending_clarification()`.
- Updated touched integration examples to prefer pending gating via `has_pending_clarification()` and to use `engine.state` snapshots for before/after runtime inspection in touched tracing paths.
- Follow-up refactor: made checkpoint-payload parsing in host confirmation flow explicitly internal (`_summarize_pending_confirmation_update`) and stopped re-exporting `summarize_confirmation_update` from `host_support` package root.
- Added narrow portable conformance coverage for `has_pending_clarification` by introducing optional assertions only in existing pending-related `conformance/step` and `conformance/checkpoint` fixtures, with minimal fixture runner support.

## Why

- 0.7 boundary-hardening direction: host/runtime inspection should use `engine.state` and small engine query methods, not checkpoint schema lookups.
- Reduce accidental checkpoint-schema coupling in host-facing runtime code while preserving checkpoint APIs for persistence/restore and contract tests.
- Clarify internal vs public helper boundaries with minimal mechanical changes and no checkpoint contract behavior changes.
- Add portable parity checks for pending-query behavior without creating a new fixture family or exposing pending internals.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
