### PR TITLE
feat: add decision kind constants for host ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ those forms.
 
 Or in code:
 ```python
-from context_compiler import create_engine
+from context_compiler import DECISION_CLARIFY, DECISION_UPDATE, create_engine
 
 engine = create_engine()
 
 user_input = "prohibit peanuts"
 decision = engine.step(user_input)
 
-if decision["kind"] == "clarify":
+if decision["kind"] == DECISION_CLARIFY:
     show_to_user(decision["prompt_to_user"])
-elif decision["kind"] == "update":
+elif decision["kind"] == DECISION_UPDATE:
     messages = build_messages(engine.state, user_input)
     render(call_llm(messages))
 else:

--- a/demos/common.py
+++ b/demos/common.py
@@ -4,7 +4,15 @@ import os
 import re
 from typing import Literal, NotRequired, TypedDict
 
-from context_compiler import Decision, State, create_engine, get_policy_items, get_premise_value
+from context_compiler import (
+    DECISION_CLARIFY,
+    DECISION_UPDATE,
+    Decision,
+    State,
+    create_engine,
+    get_policy_items,
+    get_premise_value,
+)
 from demos.llm_client import Message
 
 VERBOSE_ENV_VAR = "CONTEXT_COMPILER_DEMO_VERBOSE"
@@ -71,10 +79,10 @@ def print_decision(title: str, decision: Decision, state: State) -> None:
     if not is_verbose():
         return
     print(f"Compiler decision ({title}):")
-    if decision["kind"] == "update":
+    if decision["kind"] == DECISION_UPDATE:
         print("result: updated")
         _print_state_summary(state)
-    elif decision["kind"] == "clarify":
+    elif decision["kind"] == DECISION_CLARIFY:
         print("result: clarify")
         prompt = decision["prompt_to_user"]
         if prompt:
@@ -251,10 +259,10 @@ def compact_user_turns(
 
     for turn in user_turns:
         decision = engine.step(turn)
-        if decision["kind"] == "update":
+        if decision["kind"] == DECISION_UPDATE:
             continue
         compacted_turns.append(turn)
-        if decision["kind"] == "clarify":
+        if decision["kind"] == DECISION_CLARIFY:
             prompt_to_user = decision["prompt_to_user"]
             break
 

--- a/examples/05_llm_integration_pattern.py
+++ b/examples/05_llm_integration_pattern.py
@@ -2,7 +2,14 @@
 
 from _util import print_decision_summary, print_state_summary
 
-from context_compiler import Engine, State, create_engine
+from context_compiler import (
+    DECISION_CLARIFY,
+    DECISION_PASSTHROUGH,
+    DECISION_UPDATE,
+    Engine,
+    State,
+    create_engine,
+)
 
 
 def fake_llm(state: State | None, user_input: str) -> str:
@@ -20,13 +27,13 @@ def handle_turn(engine_input: str, engine: Engine) -> None:
     print(f"User: {engine_input}")
     print_decision_summary(decision)
 
-    if decision["kind"] == "passthrough":
+    if decision["kind"] == DECISION_PASSTHROUGH:
         print("Host action: passthrough -> call fake_llm() without state")
         fake_llm(None, engine_input)
-    elif decision["kind"] == "update":
+    elif decision["kind"] == DECISION_UPDATE:
         print("Host action: update -> call fake_llm() with compiled state")
         fake_llm(decision["state"], engine_input)
-    elif decision["kind"] == "clarify":
+    elif decision["kind"] == DECISION_CLARIFY:
         print("Host action: clarify -> show prompt, DO NOT call LLM")
         print("clarify prompt:", decision["prompt_to_user"])
     print()

--- a/examples/_util.py
+++ b/examples/_util.py
@@ -1,7 +1,12 @@
 import json
 from typing import Any, Literal
 
-from context_compiler import get_policy_items, get_premise_value
+from context_compiler import (
+    DECISION_CLARIFY,
+    DECISION_UPDATE,
+    get_policy_items,
+    get_premise_value,
+)
 
 
 def canonical_json(obj: Any) -> str:
@@ -29,14 +34,14 @@ def print_state_summary(state: Any, label: str = "state") -> None:
 
 def print_decision_summary(decision: Any) -> None:
     kind = decision.get("kind")
-    if kind == "update":
+    if kind == DECISION_UPDATE:
         print("result: updated")
         state = decision.get("state")
         assert isinstance(state, dict)
         print_state_summary(state, "compiled state")
         return
 
-    if kind == "clarify":
+    if kind == DECISION_CLARIFY:
         print("result: clarify")
         prompt = decision.get("prompt_to_user")
         if isinstance(prompt, str) and prompt:

--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -18,7 +18,14 @@ from collections.abc import Callable, Mapping, Sequence
 from importlib import import_module
 from typing import TypedDict, cast
 
-from context_compiler import State, get_policy_items, get_premise_value
+from context_compiler import (
+    DECISION_CLARIFY,
+    DECISION_PASSTHROUGH,
+    DECISION_UPDATE,
+    State,
+    get_policy_items,
+    get_premise_value,
+)
 from context_compiler.engine import Engine
 
 try:
@@ -296,7 +303,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
     logger.debug("litellm_basic: decision=%s", kind)
     near_miss_prompt = _near_miss_directive_clarify(user_input)
 
-    if kind == "clarify":
+    if kind == DECISION_CLARIFY:
         _persist_session_checkpoint_if_needed(engine, kind, session_key)
         response_text = near_miss_prompt or decision["prompt_to_user"] or ""
         return _append_trace(
@@ -308,7 +315,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             state_after=engine.state,
             llm_called=False,
         )
-    if near_miss_prompt is not None and kind == "passthrough":
+    if near_miss_prompt is not None and kind == DECISION_PASSTHROUGH:
         return _append_trace(
             near_miss_prompt,
             original_input=user_input,
@@ -319,7 +326,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             llm_called=False,
         )
     _persist_session_checkpoint_if_needed(engine, kind, session_key)
-    if kind == "update" and is_confirmation_text(user_input) and pending_before is not None:
+    if kind == DECISION_UPDATE and is_confirmation_text(user_input) and pending_before is not None:
         response_text = _summarize_confirmation_update(user_input, pending_before)
         return _append_trace(
             response_text,
@@ -330,7 +337,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             state_after=engine.state,
             llm_called=False,
         )
-    if kind == "update":
+    if kind == DECISION_UPDATE:
         response_text = _summarize_update_from_input(user_input)
         return _append_trace(
             response_text,

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -24,7 +24,14 @@ from importlib.resources import as_file, files
 from importlib.resources.abc import Traversable
 from typing import TypedDict, cast
 
-from context_compiler import State, get_policy_items, get_premise_value
+from context_compiler import (
+    DECISION_CLARIFY,
+    DECISION_PASSTHROUGH,
+    DECISION_UPDATE,
+    State,
+    get_policy_items,
+    get_premise_value,
+)
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
     PREPROCESS_OUTCOME_DIRECTIVE,
@@ -419,7 +426,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
     logger.debug("preprocessor: decision=%s", kind)
     near_miss_prompt = _near_miss_directive_clarify(user_input)
 
-    if kind == "clarify":
+    if kind == DECISION_CLARIFY:
         _persist_session_checkpoint_if_needed(engine, kind, session_key)
         response_text = near_miss_prompt or decision["prompt_to_user"] or ""
         return _append_trace(
@@ -432,7 +439,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             state_after=engine.state,
             llm_called=False,
         )
-    if near_miss_prompt is not None and kind == "passthrough":
+    if near_miss_prompt is not None and kind == DECISION_PASSTHROUGH:
         return _append_trace(
             near_miss_prompt,
             original_input=user_input,
@@ -444,7 +451,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             llm_called=False,
         )
     _persist_session_checkpoint_if_needed(engine, kind, session_key)
-    if kind == "update" and is_confirmation_text(user_input) and pending_before is not None:
+    if kind == DECISION_UPDATE and is_confirmation_text(user_input) and pending_before is not None:
         response_text = _summarize_confirmation_update(user_input, pending_before)
         return _append_trace(
             response_text,
@@ -456,7 +463,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             state_after=engine.state,
             llm_called=False,
         )
-    if kind == "update":
+    if kind == DECISION_UPDATE:
         response_text = _summarize_update_from_input(compile_input)
         return _append_trace(
             response_text,

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -44,7 +44,15 @@ except ModuleNotFoundError:
         return default
 
 
-from context_compiler import State, create_engine, get_policy_items, get_premise_value
+from context_compiler import (
+    DECISION_CLARIFY,
+    DECISION_PASSTHROUGH,
+    DECISION_UPDATE,
+    State,
+    create_engine,
+    get_policy_items,
+    get_premise_value,
+)
 from context_compiler.engine import Engine
 
 logger = logging.getLogger(__name__)
@@ -221,7 +229,7 @@ def _build_compact_trace_text(
     kind = kind_obj if isinstance(kind_obj, str) else "unknown"
     lines = ["Context Compiler trace", "", f"decision kind: {kind}"]
 
-    if kind == "update":
+    if kind == DECISION_UPDATE:
         lines.append(f"state change: {_compact_state_change(state_before, state_after)}")
         lines.append(f"active state: {_active_state_summary(state_after)}")
         lines.append(f"downstream LLM call: {'yes' if llm_called else 'no'}")
@@ -229,7 +237,7 @@ def _build_compact_trace_text(
         lines.append(f"state injected: {state_injected}")
         return "\n".join(lines)
 
-    if kind == "clarify":
+    if kind == DECISION_CLARIFY:
         prompt_obj = decision.get("prompt_to_user") if isinstance(decision, dict) else None
         prompt = prompt_obj if isinstance(prompt_obj, str) else ""
         lines.append(f"clarification prompt: {prompt}")
@@ -634,7 +642,7 @@ class Pipe:
         if state_after is None:
             state_after = engine.state
 
-        if kind == "clarify":
+        if kind == DECISION_CLARIFY:
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
             return self._with_trace(
                 near_miss_prompt or decision["prompt_to_user"] or "",
@@ -645,7 +653,7 @@ class Pipe:
                 state_after=state_after,
                 llm_called=False,
             )
-        if near_miss_prompt is not None and kind == "passthrough":
+        if near_miss_prompt is not None and kind == DECISION_PASSTHROUGH:
             return self._with_trace(
                 near_miss_prompt,
                 original_input=latest_user_text,
@@ -655,7 +663,7 @@ class Pipe:
                 state_after=state_after,
                 llm_called=False,
             )
-        if kind == "passthrough":
+        if kind == DECISION_PASSTHROUGH:
             response = await self._forward_passthrough(body, __user__, __request__)
             return self._with_trace(
                 response,
@@ -666,7 +674,7 @@ class Pipe:
                 state_after=state_after,
                 llm_called=True,
             )
-        if kind == "update":
+        if kind == DECISION_UPDATE:
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
             if _is_administrative_update_input(latest_user_text):
                 return self._with_trace(

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -47,7 +47,15 @@ except ModuleNotFoundError:
         return default
 
 
-from context_compiler import State, create_engine, get_policy_items, get_premise_value
+from context_compiler import (
+    DECISION_CLARIFY,
+    DECISION_PASSTHROUGH,
+    DECISION_UPDATE,
+    State,
+    create_engine,
+    get_policy_items,
+    get_premise_value,
+)
 from context_compiler.engine import Engine
 from experimental.preprocessor import (
     PREPROCESS_OUTCOME_DIRECTIVE,
@@ -230,7 +238,7 @@ def _build_compact_trace_text(
     kind = kind_obj if isinstance(kind_obj, str) else "unknown"
     lines = ["Context Compiler trace", "", f"decision kind: {kind}"]
 
-    if kind == "update":
+    if kind == DECISION_UPDATE:
         lines.append(f"state change: {_compact_state_change(state_before, state_after)}")
         lines.append(f"active state: {_active_state_summary(state_after)}")
         lines.append(f"downstream LLM call: {'yes' if llm_called else 'no'}")
@@ -238,7 +246,7 @@ def _build_compact_trace_text(
         lines.append(f"state injected: {state_injected}")
         return "\n".join(lines)
 
-    if kind == "clarify":
+    if kind == DECISION_CLARIFY:
         prompt_obj = decision.get("prompt_to_user") if isinstance(decision, dict) else None
         prompt = prompt_obj if isinstance(prompt_obj, str) else ""
         lines.append(f"clarification prompt: {prompt}")
@@ -917,7 +925,7 @@ class Pipe:
         if state_after is None:
             state_after = engine.state
 
-        if kind == "clarify":
+        if kind == DECISION_CLARIFY:
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
             return self._with_trace(
                 near_miss_prompt or decision["prompt_to_user"] or "",
@@ -929,7 +937,7 @@ class Pipe:
                 preprocessor_output=preprocessd,
                 llm_called=False,
             )
-        if near_miss_prompt is not None and kind == "passthrough":
+        if near_miss_prompt is not None and kind == DECISION_PASSTHROUGH:
             return self._with_trace(
                 near_miss_prompt,
                 original_input=latest_user_text,
@@ -940,7 +948,7 @@ class Pipe:
                 preprocessor_output=preprocessd,
                 llm_called=False,
             )
-        if kind == "passthrough":
+        if kind == DECISION_PASSTHROUGH:
             response = await self._forward_passthrough(
                 body,
                 __user__,
@@ -957,7 +965,7 @@ class Pipe:
                 preprocessor_output=preprocessd,
                 llm_called=base_model_id is not None,
             )
-        if kind == "update":
+        if kind == DECISION_UPDATE:
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
             if _is_administrative_update_input(compile_input):
                 return self._with_trace(

--- a/src/context_compiler/__init__.py
+++ b/src/context_compiler/__init__.py
@@ -1,5 +1,6 @@
 from importlib.metadata import version
 
+from .decision_constants import DECISION_CLARIFY, DECISION_PASSTHROUGH, DECISION_UPDATE
 from .engine import (
     ApplyResult,
     Checkpoint,
@@ -20,6 +21,9 @@ __all__ = [
     "ApplyResult",
     "Checkpoint",
     "Decision",
+    "DECISION_CLARIFY",
+    "DECISION_PASSTHROUGH",
+    "DECISION_UPDATE",
     "Engine",
     "State",
     "Transcript",

--- a/src/context_compiler/decision_constants.py
+++ b/src/context_compiler/decision_constants.py
@@ -1,0 +1,5 @@
+"""Public decision-kind string constants for host-side branching ergonomics."""
+
+DECISION_PASSTHROUGH = "passthrough"
+DECISION_UPDATE = "update"
+DECISION_CLARIFY = "clarify"

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -4,6 +4,7 @@ from typing import TextIO
 from experimental.preprocessor.output_validation import parse_preprocessor_output
 
 from . import __version__, create_engine, get_policy_items, get_premise_value
+from .decision_constants import DECISION_CLARIFY, DECISION_PASSTHROUGH
 from .engine import Decision, DecisionKind, Engine, State
 
 _EXIT_TOKENS = {"exit", "quit"}
@@ -76,9 +77,9 @@ def _render_state_lines(state: State) -> list[str]:
 
 def _render_decision_lines(decision: Decision) -> list[str]:
     kind = decision["kind"]
-    if kind == "passthrough":
+    if kind == DECISION_PASSTHROUGH:
         return ["passthrough"]
-    if kind == "clarify":
+    if kind == DECISION_CLARIFY:
         prompt = decision["prompt_to_user"] or ""
         prompt_lines = prompt.splitlines() if prompt else [""]
         if prompt.endswith("?"):

--- a/tests/fixtures/conformance/api/public-api-v1.json
+++ b/tests/fixtures/conformance/api/public-api-v1.json
@@ -8,6 +8,9 @@
     "compile_transcript",
     "get_premise_value",
     "get_policy_items",
+    "DECISION_PASSTHROUGH",
+    "DECISION_UPDATE",
+    "DECISION_CLARIFY",
     "TranscriptMessage",
     "Transcript",
     "ApplyResult"

--- a/tests/test_decision_constants.py
+++ b/tests/test_decision_constants.py
@@ -1,0 +1,7 @@
+from context_compiler import DECISION_CLARIFY, DECISION_PASSTHROUGH, DECISION_UPDATE
+
+
+def test_decision_constants_match_decision_kind_literals() -> None:
+    assert DECISION_PASSTHROUGH == "passthrough"
+    assert DECISION_UPDATE == "update"
+    assert DECISION_CLARIFY == "clarify"


### PR DESCRIPTION
## What changed

- Added public decision-kind constants in a dedicated module:
  - `DECISION_PASSTHROUGH = "passthrough"`
  - `DECISION_UPDATE = "update"`
  - `DECISION_CLARIFY = "clarify"`
- Exported those constants from package root (`context_compiler`).
- Added a small value test to assert constant values match the Decision kind strings.
- Updated the public API contract fixture required exports for the new constants.
- Made minimal readability updates in README and one host-facing example to use the constants.
- Follow-up cleanup: replaced raw decision-kind string comparisons with constants across user-facing branching code in `examples/`, `demos/`, Open WebUI/LiteLLM integration examples, and REPL rendering logic.

## Why

- Reduce repeated semantic string literals in host-facing branching.
- Lower typo risk while preserving the existing structural `Decision`/`State` contracts and JSON portability.
- Keep ergonomics improvement intentionally small without adding helper predicates or broader abstractions.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
