### PR TITLE
feat: add controller preview foundation

### DIFF
--- a/src/context_compiler/__init__.py
+++ b/src/context_compiler/__init__.py
@@ -1,5 +1,6 @@
 from importlib.metadata import version
 
+from .controller import PreviewResult, StepResult, StructuralDiff, preview, state_diff, step
 from .decision_constants import DECISION_CLARIFY, DECISION_PASSTHROUGH, DECISION_UPDATE
 from .engine import (
     ApplyResult,
@@ -25,11 +26,17 @@ __all__ = [
     "DECISION_PASSTHROUGH",
     "DECISION_UPDATE",
     "Engine",
+    "PreviewResult",
     "State",
+    "StepResult",
+    "StructuralDiff",
     "Transcript",
     "TranscriptMessage",
     "compile_transcript",
     "create_engine",
     "get_premise_value",
     "get_policy_items",
+    "preview",
+    "state_diff",
+    "step",
 ]

--- a/src/context_compiler/controller.py
+++ b/src/context_compiler/controller.py
@@ -1,0 +1,125 @@
+"""Stateless controller helpers layered above the authoritative engine."""
+
+from typing import Literal, TypedDict
+
+from .engine import Decision, Engine, State
+
+OUTPUT_VERSION: Literal[1] = 1
+
+
+class PremiseDiff(TypedDict):
+    before: str | None
+    after: str | None
+    changed: bool
+
+
+class ChangedPolicyDiff(TypedDict):
+    before: Literal["use", "prohibit"]
+    after: Literal["use", "prohibit"]
+
+
+class PoliciesDiff(TypedDict):
+    added: dict[str, Literal["use", "prohibit"]]
+    removed: dict[str, Literal["use", "prohibit"]]
+    changed: dict[str, ChangedPolicyDiff]
+
+
+class StructuralDiff(TypedDict):
+    changed: bool
+    premise: PremiseDiff
+    policies: PoliciesDiff
+
+
+class StepResult(TypedDict):
+    output_version: Literal[1]
+    mode: Literal["step"]
+    decision: Decision
+    state: State
+
+
+class PreviewResult(TypedDict):
+    output_version: Literal[1]
+    mode: Literal["preview"]
+    decision: Decision
+    state_before: State
+    state_after: State
+    diff: StructuralDiff
+    would_mutate: bool
+
+
+def state_diff(before: State, after: State) -> StructuralDiff:
+    before_premise = before["premise"]
+    after_premise = after["premise"]
+    premise_changed = before_premise != after_premise
+
+    before_policies = before["policies"]
+    after_policies = after["policies"]
+
+    added: dict[str, Literal["use", "prohibit"]] = {}
+    removed: dict[str, Literal["use", "prohibit"]] = {}
+    changed: dict[str, ChangedPolicyDiff] = {}
+
+    for key, value in after_policies.items():
+        if key not in before_policies:
+            added[key] = value
+            continue
+        before_value = before_policies[key]
+        if before_value != value:
+            changed[key] = {"before": before_value, "after": value}
+
+    for key, value in before_policies.items():
+        if key not in after_policies:
+            removed[key] = value
+
+    any_policy_change = bool(added or removed or changed)
+    return {
+        "changed": premise_changed or any_policy_change,
+        "premise": {
+            "before": before_premise,
+            "after": after_premise,
+            "changed": premise_changed,
+        },
+        "policies": {
+            "added": added,
+            "removed": removed,
+            "changed": changed,
+        },
+    }
+
+
+def step(engine: Engine, user_input: str) -> StepResult:
+    decision = engine.step(user_input)
+    return {
+        "output_version": OUTPUT_VERSION,
+        "mode": "step",
+        "decision": decision,
+        "state": engine.state,
+    }
+
+
+def preview(engine: Engine, user_input: str) -> PreviewResult:
+    checkpoint = engine.export_checkpoint()
+    state_before = engine.state
+
+    decision: Decision | None = None
+    state_after: State | None = None
+    try:
+        decision = engine.step(user_input)
+        state_after = engine.state
+    finally:
+        engine.import_checkpoint(checkpoint)
+
+    assert decision is not None
+    assert state_after is not None
+
+    diff = state_diff(state_before, state_after)
+    would_mutate = diff["changed"]
+    return {
+        "output_version": OUTPUT_VERSION,
+        "mode": "preview",
+        "decision": decision,
+        "state_before": state_before,
+        "state_after": state_after,
+        "diff": diff,
+        "would_mutate": would_mutate,
+    }

--- a/tests/fixtures/controller/preview_clarify_no_mutation.json
+++ b/tests/fixtures/controller/preview_clarify_no_mutation.json
@@ -1,0 +1,13 @@
+{
+  "id": "controller_preview_clarify_no_mutation",
+  "kind": "controller_preview",
+  "input": "use kubectl instead of docker",
+  "expected": {
+    "decision_kind": "clarify",
+    "would_mutate": false,
+    "diff_changed": false,
+    "state_before_equals_after": true,
+    "engine_state_unchanged_after_preview": true
+  }
+}
+

--- a/tests/fixtures/controller/preview_idempotent_no_mutation.json
+++ b/tests/fixtures/controller/preview_idempotent_no_mutation.json
@@ -1,0 +1,16 @@
+{
+  "id": "controller_preview_idempotent_no_mutation",
+  "kind": "controller_preview",
+  "prelude": [
+    "use docker"
+  ],
+  "input": "use docker",
+  "expected": {
+    "decision_kind": "update",
+    "would_mutate": false,
+    "diff_changed": false,
+    "state_before_equals_after": true,
+    "engine_state_unchanged_after_preview": true
+  }
+}
+

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -175,3 +175,34 @@ def test_controller_result_surface_contract_stability() -> None:
     assert preview_result["output_version"] == 1
     assert preview_result["mode"] == "preview"
     assert preview_result["would_mutate"] is preview_result["diff"]["changed"]
+
+
+@pytest.mark.parametrize(
+    ("confirmation", "expected_state", "expected_would_mutate"),
+    [
+        ("yes", {"premise": None, "policies": {"kubectl": "use"}, "version": 2}, True),
+        ("no", {"premise": None, "policies": {}, "version": 2}, False),
+    ],
+)
+def test_preview_pending_confirmation_user_flow(
+    confirmation: str,
+    expected_state: dict[str, object],
+    expected_would_mutate: bool,
+) -> None:
+    engine = create_engine()
+    initial = engine.step("use kubectl instead of docker")
+    assert initial["kind"] == "clarify"
+    assert engine.has_pending_clarification() is True
+
+    preview_result = preview(engine, confirmation)
+    assert preview_result["decision"]["kind"] == "update"
+    assert preview_result["state_after"] == expected_state
+    assert preview_result["would_mutate"] is expected_would_mutate
+
+    assert engine.has_pending_clarification() is True
+    assert engine.state == {"premise": None, "policies": {}, "version": 2}
+
+    final = step(engine, confirmation)
+    assert final["decision"]["kind"] == "update"
+    assert final["state"] == expected_state
+    assert engine.has_pending_clarification() is False

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,153 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from context_compiler import create_engine
+from context_compiler.controller import preview, state_diff, step
+
+_CONTROLLER_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "controller"
+
+
+def test_step_wrapper_returns_state_snapshot_and_contract_shape() -> None:
+    engine = create_engine()
+    result = step(engine, "set premise concise replies")
+
+    assert result["output_version"] == 1
+    assert result["mode"] == "step"
+    assert result["decision"]["kind"] == "update"
+    assert result["state"] == engine.state
+    assert result["state"] == {
+        "premise": "concise replies",
+        "policies": {},
+        "version": 2,
+    }
+
+
+def test_preview_update_does_not_mutate_engine_state() -> None:
+    engine = create_engine()
+    before = engine.state
+
+    result = preview(engine, "set premise concise replies")
+
+    assert result["mode"] == "preview"
+    assert result["decision"]["kind"] == "update"
+    assert result["state_before"] == before
+    assert result["state_after"] == {
+        "premise": "concise replies",
+        "policies": {},
+        "version": 2,
+    }
+    assert result["would_mutate"] is True
+    assert result["would_mutate"] is result["diff"]["changed"]
+    assert engine.state == before
+    assert engine.has_pending_clarification() is False
+
+
+def test_preview_clarify_path_and_pending_are_restored() -> None:
+    engine = create_engine()
+    result = preview(engine, "use kubectl instead of docker")
+
+    assert result["decision"]["kind"] == "clarify"
+    assert result["state_before"] == result["state_after"]
+    assert result["diff"]["changed"] is False
+    assert result["would_mutate"] is False
+    assert engine.has_pending_clarification() is False
+
+    yes = engine.step("yes")
+    assert yes["kind"] == "passthrough"
+
+
+def test_preview_pending_resolution_restores_existing_pending_state() -> None:
+    engine = create_engine()
+    first = engine.step("use kubectl instead of docker")
+    assert first["kind"] == "clarify"
+    assert engine.has_pending_clarification() is True
+
+    result = preview(engine, "maybe")
+    assert result["decision"]["kind"] == "clarify"
+    assert result["would_mutate"] is False
+    assert engine.has_pending_clarification() is True
+
+    yes = engine.step("yes")
+    assert yes["kind"] == "update"
+    assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
+
+
+def test_preview_idempotent_update_is_not_a_mutation() -> None:
+    engine = create_engine()
+    engine.step("use docker")
+    before = engine.state
+
+    result = preview(engine, "use docker")
+
+    assert result["decision"]["kind"] == "update"
+    assert result["state_before"] == result["state_after"]
+    assert result["diff"]["changed"] is False
+    assert result["would_mutate"] is False
+    assert engine.state == before
+
+
+def test_state_diff_structural_changes() -> None:
+    before = {
+        "premise": "concise",
+        "policies": {"docker": "use", "pytest": "prohibit"},
+        "version": 2,
+    }
+    after = {
+        "premise": "formal",
+        "policies": {"docker": "prohibit", "uv": "use"},
+        "version": 2,
+    }
+
+    diff = state_diff(before, after)
+    assert diff == {
+        "changed": True,
+        "premise": {
+            "before": "concise",
+            "after": "formal",
+            "changed": True,
+        },
+        "policies": {
+            "added": {"uv": "use"},
+            "removed": {"pytest": "prohibit"},
+            "changed": {"docker": {"before": "use", "after": "prohibit"}},
+        },
+    }
+
+
+def test_preview_fails_when_checkpoint_restore_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = create_engine()
+
+    def _boom(_: object) -> None:
+        raise RuntimeError("restore failed")
+
+    monkeypatch.setattr(engine, "import_checkpoint", _boom)
+    with pytest.raises(RuntimeError, match="restore failed"):
+        preview(engine, "set premise concise replies")
+
+
+def test_controller_preview_fixtures() -> None:
+    for path in sorted(_CONTROLLER_FIXTURES_DIR.glob("*.json")):
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+        fixture_id = fixture["id"]
+        assert fixture["kind"] == "controller_preview", fixture_id
+
+        engine = create_engine()
+        for prior in fixture.get("prelude", []):
+            engine.step(prior)
+        before = engine.state
+        result = preview(engine, fixture["input"])
+        expected = fixture["expected"]
+
+        assert result["decision"]["kind"] == expected["decision_kind"], fixture_id
+        assert result["would_mutate"] is expected["would_mutate"], fixture_id
+        assert result["diff"]["changed"] is expected["diff_changed"], fixture_id
+        assert (result["state_before"] == result["state_after"]) is expected[
+            "state_before_equals_after"
+        ], fixture_id
+        assert (engine.state == before) is expected["engine_state_unchanged_after_preview"], (
+            fixture_id
+        )

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -151,3 +151,27 @@ def test_controller_preview_fixtures() -> None:
         assert (engine.state == before) is expected["engine_state_unchanged_after_preview"], (
             fixture_id
         )
+
+
+def test_controller_result_surface_contract_stability() -> None:
+    engine = create_engine()
+
+    step_result = step(engine, "set premise concise replies")
+    assert set(step_result.keys()) == {"output_version", "mode", "decision", "state"}
+    assert step_result["output_version"] == 1
+    assert step_result["mode"] == "step"
+    assert isinstance(step_result["state"], dict)
+
+    preview_result = preview(engine, "use docker")
+    assert set(preview_result.keys()) == {
+        "output_version",
+        "mode",
+        "decision",
+        "state_before",
+        "state_after",
+        "diff",
+        "would_mutate",
+    }
+    assert preview_result["output_version"] == 1
+    assert preview_result["mode"] == "preview"
+    assert preview_result["would_mutate"] is preview_result["diff"]["changed"]


### PR DESCRIPTION
## What changed

- Added a new stateless controller module above the engine:
  - `step(engine, user_input) -> StepResult`
  - `preview(engine, user_input) -> PreviewResult`
  - `state_diff(before, after) -> StructuralDiff`
- Implemented checkpoint-based preview orchestration only:
  1. export checkpoint
  2. run `engine.step(...)`
  3. capture decision/state/diff
  4. restore checkpoint in `finally`
  5. fail preview if restore fails
- Added controller result/diff typed contracts and exported controller APIs/types from package root.
- Added focused controller tests covering:
  - contract shape stability (`output_version`, `mode`, required keys)
  - non-mutation guarantees
  - clarify/pending behavior
  - idempotent/no-op behavior
  - restore-failure behavior
  - pending confirmation user-flow narrative (`yes`/`no` preview then real confirmation)
- Added small Python-local controller fixtures under `tests/fixtures/controller/` for preview behavior checks.

Part of #84

## Why

- Establish the 0.7 controller/preview foundation while preserving engine authority and structural contracts.
- Provide deterministic, inspectable dry-run behavior without adding a second semantic layer.
- Keep host-facing orchestration logic minimal and stateless.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
