### PR TITLE
feat: add repl command layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,22 @@ Meaning:
 | `engine.export_checkpoint_json()` | Export checkpoint as canonical JSON (`str`). |
 | `engine.import_checkpoint_json(payload)` | Restore checkpoint from JSON (`str`) and return `None`. |
 
+### Controller API (Reusable Outside REPL)
+
+These controller-layer APIs are public package exports and can be used directly
+in host code (not just inside the REPL).
+
+| API | Description |
+|---|---|
+| `step(engine, user_input)` | Run one turn through the engine and return `StepResult` (`output_version`, `mode`, `decision`, `state`). |
+| `preview(engine, user_input)` | Run deterministic dry-run preview and return `PreviewResult` (`output_version`, `mode`, `decision`, `state_before`, `state_after`, `diff`, `would_mutate`). Live engine state is restored after preview. |
+| `state_diff(state_before, state_after)` | Return a structural `StructuralDiff` (`changed`, premise before/after, policies added/removed/changed). |
+
+Decision-kind constants are also exported for host branching readability:
+- `DECISION_PASSTHROUGH`
+- `DECISION_UPDATE`
+- `DECISION_CLARIFY`
+
 ---
 
 ## State Model

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ context-compiler --with-preprocessor
 passed through to the engine, which continues to return clarify behavior for
 those forms.
 
+REPL command-layer commands (host/controller layer, not engine directives):
+- `state` shows current authoritative state.
+- `preview <input>` runs deterministic dry-run without mutating live state.
+- `step <input>` is an explicit alias of normal bare-input step behavior.
+
+Bare REPL input behavior remains unchanged.
+
 Or in code:
 ```python
 from context_compiler import DECISION_CLARIFY, DECISION_UPDATE, create_engine

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -17,7 +17,7 @@ _AFFIRMATIVE_CONFIRMATIONS = {"yes", "yes please", "yep", "yeah", "sure", "ok", 
 _NEGATIVE_CONFIRMATIONS = {"no", "nope", "no thanks"}
 _STEP_PENDING_CONFIRMATION_ERROR = (
     "step command only accepts confirmation while clarification is pending.\n"
-    "Use yes/no (or variants), or use preview/explain/state."
+    "Use yes/no (or variants), or use preview/state."
 )
 _CLI_HELP_TEXT = """Usage:
   context-compiler [--help] [--version] [--with-preprocessor]
@@ -50,6 +50,10 @@ def _multi_command_decision() -> Decision:
 
 def _print_interactive_help(out_stream: TextIO) -> None:
     print("Commands: help/? exit/quit", file=out_stream)
+    print("REPL command layer (not engine directives):", file=out_stream)
+    print("  state", file=out_stream)
+    print("  preview <input>", file=out_stream)
+    print("  step <input>     (explicit alias of bare input behavior)", file=out_stream)
     print("Directives (exact prefix only):", file=out_stream)
     print("  set premise <value>", file=out_stream)
     print("  change premise to <value>", file=out_stream)
@@ -60,6 +64,8 @@ def _print_interactive_help(out_stream: TextIO) -> None:
     print("  clear premise", file=out_stream)
     print("  reset policies", file=out_stream)
     print("  clear state", file=out_stream)
+    print("Bare input behavior remains unchanged.", file=out_stream)
+    print("preview is a deterministic dry-run and never mutates live state.", file=out_stream)
     print("Only question prompts accept yes/no confirmations", file=out_stream)
     print("Other clarify prompts are errors and do not accept yes/no", file=out_stream)
 
@@ -231,26 +237,20 @@ def run_repl(in_stream: TextIO, out_stream: TextIO, *, use_preprocessor: bool = 
                     _print_decision_lines(result["decision"], out_stream, leading_blank=True)
                     continue
 
-            preview_command: str | None = None
+            preview_command = None
             payload = ""
             if user_input.startswith("preview "):
                 preview_command = "preview"
                 payload = user_input[len("preview ") :]
             elif token == "preview":
                 preview_command = "preview"
-            elif user_input.startswith("explain "):
-                preview_command = "explain"
-                payload = user_input[len("explain ") :]
-            elif token == "explain":
-                preview_command = "explain"
 
-            if preview_command is not None:
+            if preview_command == "preview":
                 if payload.strip() == "":
-                    message = f"{preview_command} requires input.\nUse '{preview_command} <input>'."
                     _print_command_error(
                         out_stream,
                         leading_blank=True,
-                        message=message,
+                        message="preview requires input.\nUse 'preview <input>'.",
                     )
                     continue
                 compile_input = _compile_input(payload, engine, use_preprocessor=use_preprocessor)
@@ -311,19 +311,13 @@ def run_repl(in_stream: TextIO, out_stream: TextIO, *, use_preprocessor: bool = 
             payload = user_input[len("preview ") :]
         elif token == "preview":
             preview_command = "preview"
-        elif user_input.startswith("explain "):
-            preview_command = "explain"
-            payload = user_input[len("explain ") :]
-        elif token == "explain":
-            preview_command = "explain"
 
-        if preview_command is not None:
+        if preview_command == "preview":
             if payload.strip() == "":
-                message = f"{preview_command} requires input.\nUse '{preview_command} <input>'."
                 _print_command_error(
                     out_stream,
                     leading_blank=False,
-                    message=message,
+                    message="preview requires input.\nUse 'preview <input>'.",
                 )
                 continue
             compile_input = _compile_input(payload, engine, use_preprocessor=use_preprocessor)

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -4,12 +4,21 @@ from typing import TextIO
 from experimental.preprocessor.output_validation import parse_preprocessor_output
 
 from . import __version__, create_engine, get_policy_items, get_premise_value
+from .controller import PreviewResult, StepResult
+from .controller import preview as controller_preview
+from .controller import step as controller_step
 from .decision_constants import DECISION_CLARIFY, DECISION_PASSTHROUGH
 from .engine import Decision, DecisionKind, Engine, State
 
 _EXIT_TOKENS = {"exit", "quit"}
 _HELP_TOKENS = {"help", "?"}
 _MULTI_COMMAND_PROMPT = "Multiple commands detected.\nEnter one command per line."
+_AFFIRMATIVE_CONFIRMATIONS = {"yes", "yes please", "yep", "yeah", "sure", "ok", "okay"}
+_NEGATIVE_CONFIRMATIONS = {"no", "nope", "no thanks"}
+_STEP_PENDING_CONFIRMATION_ERROR = (
+    "step command only accepts confirmation while clarification is pending.\n"
+    "Use yes/no (or variants), or use preview/explain/state."
+)
 _CLI_HELP_TEXT = """Usage:
   context-compiler [--help] [--version] [--with-preprocessor]
 
@@ -98,8 +107,65 @@ def _print_decision_lines(decision: Decision, out_stream: TextIO, *, leading_bla
         print(line, file=out_stream)
 
 
+def _render_diff_lines(preview_result: PreviewResult) -> list[str]:
+    diff = preview_result["diff"]
+    lines = [f"would_mutate: {'yes' if preview_result['would_mutate'] else 'no'}", "diff:"]
+
+    premise = diff["premise"]
+    if premise["changed"]:
+        before = "(none)" if premise["before"] is None else premise["before"]
+        after = "(none)" if premise["after"] is None else premise["after"]
+        lines.append(f"- premise: {before} -> {after}")
+
+    policies = diff["policies"]
+    for item, value in sorted(policies["added"].items()):
+        lines.append(f"- + {value} {item}")
+    for item, value in sorted(policies["removed"].items()):
+        lines.append(f"- - {value} {item}")
+    for item, change in sorted(policies["changed"].items()):
+        lines.append(f"- ~ {change['before']} {item} -> {change['after']} {item}")
+
+    if len(lines) == 2:
+        lines.append("- (none)")
+    return lines
+
+
+def _print_preview_lines(
+    preview_result: PreviewResult,
+    out_stream: TextIO,
+    *,
+    leading_blank: bool,
+    command_name: str,
+) -> None:
+    if leading_blank:
+        print("", file=out_stream)
+    print(command_name, file=out_stream)
+    for line in _render_decision_lines(preview_result["decision"]):
+        print(line, file=out_stream)
+    for line in _render_diff_lines(preview_result):
+        print(line, file=out_stream)
+
+
+def _print_command_error(out_stream: TextIO, *, leading_blank: bool, message: str) -> None:
+    if leading_blank:
+        print("", file=out_stream)
+    print(f"error: {message}", file=out_stream)
+
+
 def _has_pending_clarification(engine: Engine) -> bool:
     return engine.has_pending_clarification()
+
+
+def _normalize_confirmation_token(value: str) -> str:
+    normalized = value.strip().lower()
+    while normalized and normalized[-1] in ".,!?":
+        normalized = normalized[:-1]
+    return " ".join(normalized.split())
+
+
+def _is_confirmation_input(value: str) -> bool:
+    normalized = _normalize_confirmation_token(value)
+    return normalized in _AFFIRMATIVE_CONFIRMATIONS or normalized in _NEGATIVE_CONFIRMATIONS
 
 
 def _compile_input(raw_input: str, engine: Engine, *, use_preprocessor: bool) -> str:
@@ -135,9 +201,71 @@ def run_repl(in_stream: TextIO, out_stream: TextIO, *, use_preprocessor: bool = 
                 _print_interactive_help(out_stream)
                 continue
 
+            if token == "state":
+                print("", file=out_stream)
+                for line in _render_state_lines(engine.state):
+                    print(line, file=out_stream)
+                continue
+
+            if user_input.startswith("step"):
+                payload = user_input[4:].lstrip() if user_input != "step" else ""
+                if token == "step" and payload == "":
+                    _print_command_error(
+                        out_stream,
+                        leading_blank=True,
+                        message="step requires input.\nUse 'step <input>'.",
+                    )
+                    continue
+                if payload != "" and (user_input == "step" or user_input.startswith("step ")):
+                    if _has_pending_clarification(engine) and not _is_confirmation_input(payload):
+                        _print_command_error(
+                            out_stream,
+                            leading_blank=True,
+                            message=_STEP_PENDING_CONFIRMATION_ERROR,
+                        )
+                        continue
+                    compile_input = _compile_input(
+                        payload, engine, use_preprocessor=use_preprocessor
+                    )
+                    result: StepResult = controller_step(engine, compile_input)
+                    _print_decision_lines(result["decision"], out_stream, leading_blank=True)
+                    continue
+
+            preview_command: str | None = None
+            payload = ""
+            if user_input.startswith("preview "):
+                preview_command = "preview"
+                payload = user_input[len("preview ") :]
+            elif token == "preview":
+                preview_command = "preview"
+            elif user_input.startswith("explain "):
+                preview_command = "explain"
+                payload = user_input[len("explain ") :]
+            elif token == "explain":
+                preview_command = "explain"
+
+            if preview_command is not None:
+                if payload.strip() == "":
+                    message = f"{preview_command} requires input.\nUse '{preview_command} <input>'."
+                    _print_command_error(
+                        out_stream,
+                        leading_blank=True,
+                        message=message,
+                    )
+                    continue
+                compile_input = _compile_input(payload, engine, use_preprocessor=use_preprocessor)
+                preview_result = controller_preview(engine, compile_input)
+                _print_preview_lines(
+                    preview_result,
+                    out_stream,
+                    leading_blank=True,
+                    command_name=preview_command,
+                )
+                continue
+
             compile_input = _compile_input(user_input, engine, use_preprocessor=use_preprocessor)
-            decision = engine.step(compile_input)
-            _print_decision_lines(decision, out_stream, leading_blank=True)
+            result = controller_step(engine, compile_input)
+            _print_decision_lines(result["decision"], out_stream, leading_blank=True)
         return
 
     for line in in_stream:
@@ -147,9 +275,70 @@ def run_repl(in_stream: TextIO, out_stream: TextIO, *, use_preprocessor: bool = 
         user_input = line.rstrip("\n")
         if user_input.strip().lower() in _EXIT_TOKENS:
             return
+
+        token = user_input.strip().lower()
+        if token == "state":
+            for state_line in _render_state_lines(engine.state):
+                print(state_line, file=out_stream)
+            continue
+
+        if user_input.startswith("step"):
+            payload = user_input[4:].lstrip() if user_input != "step" else ""
+            if token == "step" and payload == "":
+                _print_command_error(
+                    out_stream,
+                    leading_blank=False,
+                    message="step requires input.\nUse 'step <input>'.",
+                )
+                continue
+            if payload != "" and (user_input == "step" or user_input.startswith("step ")):
+                if _has_pending_clarification(engine) and not _is_confirmation_input(payload):
+                    _print_command_error(
+                        out_stream,
+                        leading_blank=False,
+                        message=_STEP_PENDING_CONFIRMATION_ERROR,
+                    )
+                    continue
+                compile_input = _compile_input(payload, engine, use_preprocessor=use_preprocessor)
+                result = controller_step(engine, compile_input)
+                _print_decision_lines(result["decision"], out_stream, leading_blank=False)
+                continue
+
+        preview_command = None
+        payload = ""
+        if user_input.startswith("preview "):
+            preview_command = "preview"
+            payload = user_input[len("preview ") :]
+        elif token == "preview":
+            preview_command = "preview"
+        elif user_input.startswith("explain "):
+            preview_command = "explain"
+            payload = user_input[len("explain ") :]
+        elif token == "explain":
+            preview_command = "explain"
+
+        if preview_command is not None:
+            if payload.strip() == "":
+                message = f"{preview_command} requires input.\nUse '{preview_command} <input>'."
+                _print_command_error(
+                    out_stream,
+                    leading_blank=False,
+                    message=message,
+                )
+                continue
+            compile_input = _compile_input(payload, engine, use_preprocessor=use_preprocessor)
+            preview_result = controller_preview(engine, compile_input)
+            _print_preview_lines(
+                preview_result,
+                out_stream,
+                leading_blank=False,
+                command_name=preview_command,
+            )
+            continue
+
         compile_input = _compile_input(user_input, engine, use_preprocessor=use_preprocessor)
-        decision = engine.step(compile_input)
-        _print_decision_lines(decision, out_stream, leading_blank=False)
+        result = controller_step(engine, compile_input)
+        _print_decision_lines(result["decision"], out_stream, leading_blank=False)
 
 
 def main() -> int:  # pragma: no cover

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -216,6 +216,10 @@ def test_repl_interactive_help_commands() -> None:
     lines = out.getvalue().splitlines()
     expected_help = [
         "Commands: help/? exit/quit",
+        "REPL command layer (not engine directives):",
+        "  state",
+        "  preview <input>",
+        "  step <input>     (explicit alias of bare input behavior)",
         "Directives (exact prefix only):",
         "  set premise <value>",
         "  change premise to <value>",
@@ -226,13 +230,16 @@ def test_repl_interactive_help_commands() -> None:
         "  clear premise",
         "  reset policies",
         "  clear state",
+        "Bare input behavior remains unchanged.",
+        "preview is a deterministic dry-run and never mutates live state.",
         "Only question prompts accept yes/no confirmations",
         "Other clarify prompts are errors and do not accept yes/no",
     ]
     assert lines[0] == "Context Compiler REPL (0.5). Type help for commands."
     assert lines[1] == "Non-directive input is passthrough."
-    assert lines[2:15] == expected_help
-    assert lines[15:28] == expected_help
+    expected_help_len = len(expected_help)
+    assert lines[2 : 2 + expected_help_len] == expected_help
+    assert lines[2 + expected_help_len : 2 + (2 * expected_help_len)] == expected_help
 
 
 def test_repl_non_interactive_uses_human_readable_output() -> None:
@@ -281,21 +288,6 @@ def test_repl_non_interactive_preview_decline_reports_no_mutation() -> None:
     assert _contains_subsequence(lines, ["would_mutate: no", "diff:", "- (none)"])
 
 
-def test_repl_non_interactive_explain_alias_matches_preview() -> None:
-    preview_out = StringIO()
-    run_repl(StringIO("preview set premise concise\nquit\n"), preview_out)
-
-    explain_out = StringIO()
-    run_repl(StringIO("explain set premise concise\nquit\n"), explain_out)
-
-    preview_lines = [line for line in preview_out.getvalue().splitlines() if line.strip()]
-    explain_lines = [line for line in explain_out.getvalue().splitlines() if line.strip()]
-
-    assert preview_lines[1:] == explain_lines[1:]
-    assert preview_lines[0] == "preview"
-    assert explain_lines[0] == "explain"
-
-
 def test_repl_non_interactive_step_alias_matches_bare_input_behavior() -> None:
     bare = _run_non_interactive_lines("set premise concise\nquit\n")
     aliased = _run_non_interactive_lines("step set premise concise\nquit\n")
@@ -304,14 +296,11 @@ def test_repl_non_interactive_step_alias_matches_bare_input_behavior() -> None:
 
 def test_repl_non_interactive_preview_and_step_require_payload() -> None:
     out = StringIO()
-    run_repl(StringIO("preview\nexplain\nstep\nquit\n"), out)
+    run_repl(StringIO("preview\nstep\nquit\n"), out)
     lines = [line for line in out.getvalue().splitlines() if line.strip()]
 
     assert _contains_subsequence(
         lines, ["error: preview requires input.", "Use 'preview <input>'."]
-    )
-    assert _contains_subsequence(
-        lines, ["error: explain requires input.", "Use 'explain <input>'."]
     )
     assert _contains_subsequence(lines, ["error: step requires input.", "Use 'step <input>'."])
 
@@ -341,7 +330,7 @@ def test_repl_step_command_rejects_non_confirmation_while_pending() -> None:
         lines,
         [
             "error: step command only accepts confirmation while clarification is pending.",
-            "Use yes/no (or variants), or use preview/explain/state.",
+            "Use yes/no (or variants), or use preview/state.",
         ],
     )
     assert _contains_subsequence(
@@ -360,19 +349,13 @@ def test_repl_step_command_accepts_confirmation_while_pending() -> None:
     )
 
 
-def test_repl_preview_and_explain_available_while_pending_clarification() -> None:
+def test_repl_preview_available_while_pending_clarification() -> None:
     out = StringIO()
-    run_repl(
-        StringIO("use kubectl instead of docker\npreview yes\nexplain no\nyes\nquit\n"),
-        out,
-    )
+    run_repl(StringIO("use kubectl instead of docker\npreview yes\nyes\nquit\n"), out)
     lines = [line for line in out.getvalue().splitlines() if line.strip()]
 
     assert _contains_subsequence(
         lines, ["preview", "updated", "premise: (none)", "policies:", "- use kubectl"]
-    )
-    assert _contains_subsequence(
-        lines, ["explain", "updated", "premise: (none)", "policies: (none)"]
     )
 
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -349,6 +349,15 @@ def test_repl_step_command_accepts_confirmation_while_pending() -> None:
     )
 
 
+def test_repl_step_command_accepts_negative_confirmation_while_pending() -> None:
+    out = StringIO()
+    run_repl(StringIO("use kubectl instead of docker\nstep no\nquit\n"), out)
+    lines = [line for line in out.getvalue().splitlines() if line.strip()]
+
+    assert _contains_subsequence(lines, ['confirm: Did you mean to use "kubectl" instead?'])
+    assert _contains_subsequence(lines, ["updated", "premise: (none)", "policies: (none)"])
+
+
 def test_repl_preview_available_while_pending_clarification() -> None:
     out = StringIO()
     run_repl(StringIO("use kubectl instead of docker\npreview yes\nyes\nquit\n"), out)
@@ -357,6 +366,41 @@ def test_repl_preview_available_while_pending_clarification() -> None:
     assert _contains_subsequence(
         lines, ["preview", "updated", "premise: (none)", "policies:", "- use kubectl"]
     )
+
+
+def test_repl_interactive_preview_available_while_pending_clarification() -> None:
+    lines = _run_interactive_lines("use kubectl instead of docker\npreview yes\nyes\nquit\n")
+
+    assert _contains_subsequence(lines, ['confirm: Did you mean to use "kubectl" instead?'])
+    assert _contains_subsequence(
+        lines, ["preview", "updated", "premise: (none)", "policies:", "- use kubectl"]
+    )
+    assert _contains_subsequence(lines, ["would_mutate: yes"])
+    assert _contains_subsequence(
+        lines, ["updated", "premise: (none)", "policies:", "- use kubectl"]
+    )
+
+
+def test_repl_interactive_help_available_while_pending_clarification() -> None:
+    lines = _run_interactive_lines("use kubectl instead of docker\nhelp\nyes\nquit\n")
+
+    assert _contains_subsequence(lines, ['confirm: Did you mean to use "kubectl" instead?'])
+    assert _contains_subsequence(lines, ["Commands: help/? exit/quit"])
+    assert _contains_subsequence(lines, ["REPL command layer (not engine directives):"])
+    assert _contains_subsequence(
+        lines, ["updated", "premise: (none)", "policies:", "- use kubectl"]
+    )
+
+
+def test_repl_preview_idempotent_admin_action_reports_no_mutation() -> None:
+    out = StringIO()
+    run_repl(StringIO("preview clear premise\nquit\n"), out)
+    lines = [line for line in out.getvalue().splitlines() if line.strip()]
+
+    assert _contains_subsequence(
+        lines, ["preview", "updated", "premise: (none)", "policies: (none)"]
+    )
+    assert _contains_subsequence(lines, ["would_mutate: no", "diff:", "- (none)"])
 
 
 def test_repl_with_preprocessor_parses_directive_before_engine_step() -> None:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -837,6 +837,11 @@ def test_repl_interactive_state_renders_empty_state() -> None:
     assert _contains_subsequence(lines, ["updated", "premise: (none)", "policies: (none)"])
 
 
+def test_repl_interactive_state_command_renders_current_state() -> None:
+    lines = _run_interactive_lines("state\nquit\n")
+    assert _contains_subsequence(lines, ["premise: (none)", "policies: (none)"])
+
+
 def test_repl_interactive_state_renders_premise_only() -> None:
     lines = _run_interactive_lines("set premise concise\nquit\n")
     assert _contains_subsequence(lines, ["updated", "premise: concise", "policies: (none)"])
@@ -862,3 +867,68 @@ def test_repl_interactive_state_renders_mixed_with_sorted_policies() -> None:
             "- prohibit poetry",
         ],
     )
+
+
+def test_repl_interactive_step_command_paths_while_pending() -> None:
+    lines = _run_interactive_lines("use kubectl instead of docker\nstep maybe\nstep yes!!!\nquit\n")
+
+    assert _contains_subsequence(lines, ['confirm: Did you mean to use "kubectl" instead?'])
+    assert _contains_subsequence(
+        lines,
+        [
+            "error: step command only accepts confirmation while clarification is pending.",
+            "Use yes/no (or variants), or use preview/state.",
+        ],
+    )
+    assert _contains_subsequence(
+        lines, ["updated", "premise: (none)", "policies:", "- use kubectl"]
+    )
+
+
+def test_repl_interactive_preview_requires_payload() -> None:
+    lines = _run_interactive_lines("preview\nquit\n")
+    assert _contains_subsequence(
+        lines, ["error: preview requires input.", "Use 'preview <input>'."]
+    )
+
+
+def test_repl_interactive_step_requires_payload() -> None:
+    lines = _run_interactive_lines("step\nquit\n")
+    assert _contains_subsequence(lines, ["error: step requires input.", "Use 'step <input>'."])
+
+
+def test_repl_interactive_preview_renders_structural_diff_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preview_result = {
+        "output_version": 1,
+        "mode": "preview",
+        "decision": {
+            "kind": "update",
+            "state": {"premise": "after", "policies": {"docker": "prohibit"}},
+            "prompt_to_user": None,
+        },
+        "state_before": {"premise": "before", "policies": {"docker": "use", "kubectl": "use"}},
+        "state_after": {"premise": "after", "policies": {"docker": "prohibit"}},
+        "diff": {
+            "changed": True,
+            "premise": {"before": "before", "after": "after", "changed": True},
+            "policies": {
+                "added": {},
+                "removed": {"kubectl": "use"},
+                "changed": {"docker": {"before": "use", "after": "prohibit"}},
+            },
+        },
+        "would_mutate": True,
+    }
+
+    def _fake_preview(_engine: object, _user_input: str) -> object:
+        return preview_result
+
+    monkeypatch.setattr(repl_module, "controller_preview", _fake_preview)
+
+    lines = _run_interactive_lines("preview test\nquit\n")
+    assert _contains_subsequence(lines, ["preview", "updated"])
+    assert _contains_subsequence(lines, ["- premise: before -> after"])
+    assert _contains_subsequence(lines, ["- - use kubectl"])
+    assert _contains_subsequence(lines, ["- ~ use docker -> prohibit docker"])

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -243,6 +243,139 @@ def test_repl_non_interactive_uses_human_readable_output() -> None:
     assert lines == ["passthrough"]
 
 
+def test_repl_non_interactive_state_command_renders_current_state() -> None:
+    out = StringIO()
+    run_repl(StringIO("set premise concise\nstate\nquit\n"), out)
+
+    lines = out.getvalue().splitlines()
+    assert _contains_subsequence(lines, ["updated", "premise: concise", "policies: (none)"])
+    assert _contains_subsequence(lines, ["premise: concise", "policies: (none)"])
+
+
+def test_repl_non_interactive_preview_reports_no_mutation_for_clarify_and_keeps_pending() -> None:
+    out = StringIO()
+    run_repl(
+        StringIO("use kubectl instead of docker\npreview yes\nyes\nquit\n"),
+        out,
+    )
+    lines = [line for line in out.getvalue().splitlines() if line.strip()]
+
+    assert _contains_subsequence(lines, ['confirm: Did you mean to use "kubectl" instead?'])
+    assert _contains_subsequence(
+        lines, ["preview", "updated", "premise: (none)", "policies:", "- use kubectl"]
+    )
+    assert _contains_subsequence(lines, ["would_mutate: yes"])
+    assert _contains_subsequence(
+        lines, ["updated", "premise: (none)", "policies:", "- use kubectl"]
+    )
+
+
+def test_repl_non_interactive_preview_decline_reports_no_mutation() -> None:
+    out = StringIO()
+    run_repl(StringIO("use kubectl instead of docker\npreview no\nquit\n"), out)
+    lines = [line for line in out.getvalue().splitlines() if line.strip()]
+
+    assert _contains_subsequence(
+        lines, ["preview", "updated", "premise: (none)", "policies: (none)"]
+    )
+    assert _contains_subsequence(lines, ["would_mutate: no", "diff:", "- (none)"])
+
+
+def test_repl_non_interactive_explain_alias_matches_preview() -> None:
+    preview_out = StringIO()
+    run_repl(StringIO("preview set premise concise\nquit\n"), preview_out)
+
+    explain_out = StringIO()
+    run_repl(StringIO("explain set premise concise\nquit\n"), explain_out)
+
+    preview_lines = [line for line in preview_out.getvalue().splitlines() if line.strip()]
+    explain_lines = [line for line in explain_out.getvalue().splitlines() if line.strip()]
+
+    assert preview_lines[1:] == explain_lines[1:]
+    assert preview_lines[0] == "preview"
+    assert explain_lines[0] == "explain"
+
+
+def test_repl_non_interactive_step_alias_matches_bare_input_behavior() -> None:
+    bare = _run_non_interactive_lines("set premise concise\nquit\n")
+    aliased = _run_non_interactive_lines("step set premise concise\nquit\n")
+    assert bare == aliased
+
+
+def test_repl_non_interactive_preview_and_step_require_payload() -> None:
+    out = StringIO()
+    run_repl(StringIO("preview\nexplain\nstep\nquit\n"), out)
+    lines = [line for line in out.getvalue().splitlines() if line.strip()]
+
+    assert _contains_subsequence(
+        lines, ["error: preview requires input.", "Use 'preview <input>'."]
+    )
+    assert _contains_subsequence(
+        lines, ["error: explain requires input.", "Use 'explain <input>'."]
+    )
+    assert _contains_subsequence(lines, ["error: step requires input.", "Use 'step <input>'."])
+
+
+def test_repl_state_command_available_while_pending_clarification() -> None:
+    out = StringIO()
+    run_repl(StringIO("use kubectl instead of docker\nstate\nyes\nquit\n"), out)
+    lines = [line for line in out.getvalue().splitlines() if line.strip()]
+
+    assert _contains_subsequence(lines, ['confirm: Did you mean to use "kubectl" instead?'])
+    assert _contains_subsequence(lines, ["premise: (none)", "policies: (none)"])
+    assert _contains_subsequence(
+        lines, ["updated", "premise: (none)", "policies:", "- use kubectl"]
+    )
+
+
+def test_repl_step_command_rejects_non_confirmation_while_pending() -> None:
+    out = StringIO()
+    run_repl(
+        StringIO("use kubectl instead of docker\nstep set premise concise\nyes\nquit\n"),
+        out,
+    )
+    lines = [line for line in out.getvalue().splitlines() if line.strip()]
+
+    assert _contains_subsequence(lines, ['confirm: Did you mean to use "kubectl" instead?'])
+    assert _contains_subsequence(
+        lines,
+        [
+            "error: step command only accepts confirmation while clarification is pending.",
+            "Use yes/no (or variants), or use preview/explain/state.",
+        ],
+    )
+    assert _contains_subsequence(
+        lines, ["updated", "premise: (none)", "policies:", "- use kubectl"]
+    )
+
+
+def test_repl_step_command_accepts_confirmation_while_pending() -> None:
+    out = StringIO()
+    run_repl(StringIO("use kubectl instead of docker\nstep yes\nquit\n"), out)
+    lines = [line for line in out.getvalue().splitlines() if line.strip()]
+
+    assert _contains_subsequence(lines, ['confirm: Did you mean to use "kubectl" instead?'])
+    assert _contains_subsequence(
+        lines, ["updated", "premise: (none)", "policies:", "- use kubectl"]
+    )
+
+
+def test_repl_preview_and_explain_available_while_pending_clarification() -> None:
+    out = StringIO()
+    run_repl(
+        StringIO("use kubectl instead of docker\npreview yes\nexplain no\nyes\nquit\n"),
+        out,
+    )
+    lines = [line for line in out.getvalue().splitlines() if line.strip()]
+
+    assert _contains_subsequence(
+        lines, ["preview", "updated", "premise: (none)", "policies:", "- use kubectl"]
+    )
+    assert _contains_subsequence(
+        lines, ["explain", "updated", "premise: (none)", "policies: (none)"]
+    )
+
+
 def test_repl_with_preprocessor_parses_directive_before_engine_step() -> None:
     out = StringIO()
     run_repl(

--- a/tests/test_repl_coverage.py
+++ b/tests/test_repl_coverage.py
@@ -1,0 +1,68 @@
+from io import StringIO
+
+from context_compiler.repl import (
+    _normalize_confirmation_token,
+    _print_command_error,
+    _render_diff_lines,
+    run_repl,
+)
+
+
+class _TTYStringIO(StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+def test_render_diff_lines_covers_premise_removed_and_changed_policy() -> None:
+    preview_result = {
+        "output_version": 1,
+        "mode": "preview",
+        "decision": {
+            "kind": "update",
+            "state": {"premise": "next", "policies": {}},
+            "prompt_to_user": None,
+        },
+        "state_before": {"premise": "before", "policies": {"docker": "use"}},
+        "state_after": {"premise": "next", "policies": {"docker": "prohibit"}},
+        "would_mutate": True,
+        "diff": {
+            "changed": True,
+            "premise": {"before": "before", "after": "next", "changed": True},
+            "policies": {
+                "added": {},
+                "removed": {"kubectl": "use"},
+                "changed": {"docker": {"before": "use", "after": "prohibit"}},
+            },
+        },
+    }
+
+    lines = _render_diff_lines(preview_result)  # type: ignore[arg-type]
+    assert "- premise: before -> next" in lines
+    assert "- - use kubectl" in lines
+    assert "- ~ use docker -> prohibit docker" in lines
+
+
+def test_print_command_error_leading_blank_line() -> None:
+    out = StringIO()
+    _print_command_error(out, leading_blank=True, message="boom")
+    assert out.getvalue().splitlines() == ["", "error: boom"]
+
+
+def test_normalize_confirmation_token_strips_trailing_punctuation() -> None:
+    assert _normalize_confirmation_token(" YES PLEASE!! ") == "yes please"
+
+
+def test_interactive_state_step_and_preview_command_error_paths() -> None:
+    out = _TTYStringIO()
+    run_repl(
+        _TTYStringIO("state\nstep\npreview\nquit\n"),
+        out,
+    )
+    lines = out.getvalue().splitlines()
+
+    assert "premise: (none)" in lines
+    assert "policies: (none)" in lines
+    assert "error: step requires input." in lines
+    assert "Use 'step <input>'." in lines
+    assert "error: preview requires input." in lines
+    assert "Use 'preview <input>'." in lines

--- a/tests/test_repl_properties.py
+++ b/tests/test_repl_properties.py
@@ -15,6 +15,13 @@ LINE_TEXT = st.text(
 )
 
 
+def _is_repl_command_line(line: str) -> bool:
+    token = line.strip().lower()
+    if token in {"state", "preview", "explain", "step"}:
+        return True
+    return line.startswith("preview ") or line.startswith("explain ") or line.startswith("step ")
+
+
 def _run_repl_lines(lines: list[str]) -> tuple[str, list[str]]:
     in_stream = StringIO("".join(f"{line}\n" for line in lines))
     out_stream = StringIO()
@@ -57,6 +64,7 @@ def _oracle_render_decision(decision: dict[str, object]) -> list[str]:
 @given(st.lists(LINE_TEXT, min_size=0, max_size=40))
 def test_repl_matches_engine_for_non_exit_sequences(lines: list[str]) -> None:
     assume(all(line.strip().lower() not in {"exit", "quit"} for line in lines))
+    assume(all(not _is_repl_command_line(line) for line in lines))
 
     _, repl_lines = _run_repl_lines(lines)
 
@@ -87,6 +95,7 @@ def test_repl_stops_processing_after_exit_or_quit(
     prefix: list[str], stop_token: str, suffix: list[str]
 ) -> None:
     assume(all(line.strip().lower() not in {"exit", "quit"} for line in prefix))
+    assume(all(not _is_repl_command_line(line) for line in prefix))
     lines = [*prefix, stop_token, *suffix]
     _, repl_lines = _run_repl_lines(lines)
 

--- a/tests/test_repl_properties.py
+++ b/tests/test_repl_properties.py
@@ -17,9 +17,9 @@ LINE_TEXT = st.text(
 
 def _is_repl_command_line(line: str) -> bool:
     token = line.strip().lower()
-    if token in {"state", "preview", "explain", "step"}:
+    if token in {"state", "preview", "step"}:
         return True
-    return line.startswith("preview ") or line.startswith("explain ") or line.startswith("step ")
+    return line.startswith("preview ") or line.startswith("step ")
 
 
 def _run_repl_lines(lines: list[str]) -> tuple[str, list[str]]:


### PR DESCRIPTION
## What changed
- Added REPL command-layer commands on top of controller APIs: state, preview <input>, and step <input>.
- Kept bare REPL input behavior unchanged.
- Routed REPL progression and preview through controller exports to preserve engine authority.
- Allowed read-only observational commands during pending clarification while still blocking non-confirmation mutating progression.
- Removed explain alias to keep the command surface small.
- Added and updated REPL tests for command parsing, pending behavior, and preview non-mutation behavior.
- Added concise README API coverage for public controller exports and decision-kind constants.

## Why this was needed
- Establishes the 0.7 REPL/controller command semantics before JSON-mode output.
- Hardens boundaries so hosts use stable controller/runtime queries instead of checkpoint internals.
- Keeps a minimal, explicit command surface for predictable scripting and future TS parity.

Closes #84