### PR TITLE
feat: add repl json output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Canonical matrix: [docs/demos-results.md](docs/demos-results.md)
 pip install context-compiler
 context-compiler
 context-compiler --with-preprocessor
+context-compiler --json < input.txt
 ```
 
 `context-compiler` launches the interactive REPL.
@@ -40,6 +41,9 @@ context-compiler --with-preprocessor
 (heuristic + validation only). Near-miss inputs are not rewritten and are
 passed through to the engine, which continues to return clarify behavior for
 those forms.
+
+`--json` enables machine-readable NDJSON output for non-interactive usage
+(one complete JSON object per processed input line).
 
 REPL command-layer commands (host/controller layer, not engine directives):
 - `state` shows current authoritative state.

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -1,10 +1,11 @@
+import json
 import sys
 from typing import TextIO
 
 from experimental.preprocessor.output_validation import parse_preprocessor_output
 
 from . import __version__, create_engine, get_policy_items, get_premise_value
-from .controller import PreviewResult, StepResult
+from .controller import OUTPUT_VERSION, PreviewResult, StepResult
 from .controller import preview as controller_preview
 from .controller import step as controller_step
 from .decision_constants import DECISION_CLARIFY, DECISION_PASSTHROUGH
@@ -20,12 +21,13 @@ _STEP_PENDING_CONFIRMATION_ERROR = (
     "Use yes/no (or variants), or use preview/state."
 )
 _CLI_HELP_TEXT = """Usage:
-  context-compiler [--help] [--version] [--with-preprocessor]
+  context-compiler [--help] [--version] [--with-preprocessor] [--json]
 
 Options:
   --help                Show this help message and exit.
   --version             Show the installed context-compiler version and exit.
   --with-preprocessor   Enable preprocessor before each REPL turn (heuristic + validation only)
+  --json                Emit machine-readable NDJSON output (non-interactive only)
 """
 
 
@@ -158,6 +160,40 @@ def _print_command_error(out_stream: TextIO, *, leading_blank: bool, message: st
     print(f"error: {message}", file=out_stream)
 
 
+def _write_json_line(out_stream: TextIO, payload: dict[str, object]) -> None:
+    print(json.dumps(payload, separators=(",", ":"), sort_keys=True), file=out_stream)
+
+
+def _json_step_payload(result: StepResult, *, command: str) -> dict[str, object]:
+    payload: dict[str, object] = dict(result)
+    payload["command"] = command
+    return payload
+
+
+def _json_preview_payload(result: PreviewResult, *, command: str) -> dict[str, object]:
+    payload: dict[str, object] = dict(result)
+    payload["command"] = command
+    return payload
+
+
+def _json_state_payload(state: State) -> dict[str, object]:
+    return {
+        "output_version": OUTPUT_VERSION,
+        "mode": "state",
+        "command": "state",
+        "state": state,
+    }
+
+
+def _json_error_payload(*, command: str, code: str, message: str) -> dict[str, object]:
+    return {
+        "output_version": OUTPUT_VERSION,
+        "mode": "error",
+        "command": command,
+        "error": {"code": code, "message": message},
+    }
+
+
 def _has_pending_clarification(engine: Engine) -> bool:
     return engine.has_pending_clarification()
 
@@ -183,7 +219,13 @@ def _compile_input(raw_input: str, engine: Engine, *, use_preprocessor: bool) ->
     return parsed if parsed is not None else raw_input
 
 
-def run_repl(in_stream: TextIO, out_stream: TextIO, *, use_preprocessor: bool = False) -> None:
+def run_repl(
+    in_stream: TextIO,
+    out_stream: TextIO,
+    *,
+    use_preprocessor: bool = False,
+    json_mode: bool = False,
+) -> None:
     engine = create_engine()
 
     if _is_interactive(in_stream, out_stream):
@@ -270,7 +312,17 @@ def run_repl(in_stream: TextIO, out_stream: TextIO, *, use_preprocessor: bool = 
 
     for line in in_stream:
         if _has_embedded_newline(line):
-            _print_decision_lines(_multi_command_decision(), out_stream, leading_blank=False)
+            if json_mode:
+                _write_json_line(
+                    out_stream,
+                    _json_error_payload(
+                        command="input",
+                        code="multi_command_input",
+                        message=_MULTI_COMMAND_PROMPT,
+                    ),
+                )
+            else:
+                _print_decision_lines(_multi_command_decision(), out_stream, leading_blank=False)
             continue
         user_input = line.rstrip("\n")
         if user_input.strip().lower() in _EXIT_TOKENS:
@@ -278,30 +330,56 @@ def run_repl(in_stream: TextIO, out_stream: TextIO, *, use_preprocessor: bool = 
 
         token = user_input.strip().lower()
         if token == "state":
-            for state_line in _render_state_lines(engine.state):
-                print(state_line, file=out_stream)
+            if json_mode:
+                _write_json_line(out_stream, _json_state_payload(engine.state))
+            else:
+                for state_line in _render_state_lines(engine.state):
+                    print(state_line, file=out_stream)
             continue
 
         if user_input.startswith("step"):
             payload = user_input[4:].lstrip() if user_input != "step" else ""
             if token == "step" and payload == "":
-                _print_command_error(
-                    out_stream,
-                    leading_blank=False,
-                    message="step requires input.\nUse 'step <input>'.",
-                )
-                continue
-            if payload != "" and (user_input == "step" or user_input.startswith("step ")):
-                if _has_pending_clarification(engine) and not _is_confirmation_input(payload):
+                if json_mode:
+                    _write_json_line(
+                        out_stream,
+                        _json_error_payload(
+                            command="step",
+                            code="missing_step_input",
+                            message="step requires input.\nUse 'step <input>'.",
+                        ),
+                    )
+                else:
                     _print_command_error(
                         out_stream,
                         leading_blank=False,
-                        message=_STEP_PENDING_CONFIRMATION_ERROR,
+                        message="step requires input.\nUse 'step <input>'.",
                     )
+                continue
+            if payload != "" and (user_input == "step" or user_input.startswith("step ")):
+                if _has_pending_clarification(engine) and not _is_confirmation_input(payload):
+                    if json_mode:
+                        _write_json_line(
+                            out_stream,
+                            _json_error_payload(
+                                command="step",
+                                code="pending_confirmation_required",
+                                message=_STEP_PENDING_CONFIRMATION_ERROR,
+                            ),
+                        )
+                    else:
+                        _print_command_error(
+                            out_stream,
+                            leading_blank=False,
+                            message=_STEP_PENDING_CONFIRMATION_ERROR,
+                        )
                     continue
                 compile_input = _compile_input(payload, engine, use_preprocessor=use_preprocessor)
                 result = controller_step(engine, compile_input)
-                _print_decision_lines(result["decision"], out_stream, leading_blank=False)
+                if json_mode:
+                    _write_json_line(out_stream, _json_step_payload(result, command="step"))
+                else:
+                    _print_decision_lines(result["decision"], out_stream, leading_blank=False)
                 continue
 
         preview_command = None
@@ -314,25 +392,43 @@ def run_repl(in_stream: TextIO, out_stream: TextIO, *, use_preprocessor: bool = 
 
         if preview_command == "preview":
             if payload.strip() == "":
-                _print_command_error(
-                    out_stream,
-                    leading_blank=False,
-                    message="preview requires input.\nUse 'preview <input>'.",
-                )
+                if json_mode:
+                    _write_json_line(
+                        out_stream,
+                        _json_error_payload(
+                            command="preview",
+                            code="missing_preview_input",
+                            message="preview requires input.\nUse 'preview <input>'.",
+                        ),
+                    )
+                else:
+                    _print_command_error(
+                        out_stream,
+                        leading_blank=False,
+                        message="preview requires input.\nUse 'preview <input>'.",
+                    )
                 continue
             compile_input = _compile_input(payload, engine, use_preprocessor=use_preprocessor)
             preview_result = controller_preview(engine, compile_input)
-            _print_preview_lines(
-                preview_result,
-                out_stream,
-                leading_blank=False,
-                command_name=preview_command,
-            )
+            if json_mode:
+                _write_json_line(
+                    out_stream, _json_preview_payload(preview_result, command="preview")
+                )
+            else:
+                _print_preview_lines(
+                    preview_result,
+                    out_stream,
+                    leading_blank=False,
+                    command_name=preview_command,
+                )
             continue
 
         compile_input = _compile_input(user_input, engine, use_preprocessor=use_preprocessor)
         result = controller_step(engine, compile_input)
-        _print_decision_lines(result["decision"], out_stream, leading_blank=False)
+        if json_mode:
+            _write_json_line(out_stream, _json_step_payload(result, command="input"))
+        else:
+            _print_decision_lines(result["decision"], out_stream, leading_blank=False)
 
 
 def main() -> int:  # pragma: no cover
@@ -349,8 +445,21 @@ def main() -> int:  # pragma: no cover
         print(__version__, file=sys.stdout)
         return 0
 
-    if args == ["--with-preprocessor"]:
-        run_repl(sys.stdin, sys.stdout, use_preprocessor=True)
+    if args and all(arg in {"--with-preprocessor", "--json"} for arg in args) and len(args) <= 2:
+        if len(args) != len(set(args)):
+            bad_arg = args[0]
+            print(f"error: unknown option '{bad_arg}'", file=sys.stderr)
+            print("Try 'context-compiler --help' for usage.", file=sys.stderr)
+            return 1
+
+        use_preprocessor = "--with-preprocessor" in args
+        json_mode = "--json" in args
+
+        if json_mode and _is_interactive(sys.stdin, sys.stdout):
+            print("error: --json requires non-interactive stdin/stdout.", file=sys.stderr)
+            return 1
+
+        run_repl(sys.stdin, sys.stdout, use_preprocessor=use_preprocessor, json_mode=json_mode)
         return 0
 
     bad_arg = args[0]

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -405,6 +405,45 @@ def test_repl_non_interactive_json_machine_readable_errors() -> None:
     ]
 
 
+def test_repl_non_interactive_json_multi_command_chunk_error() -> None:
+    out = StringIO()
+    run_repl(
+        _ChunkedInput(["set premise concise\nprohibit peanuts\n", "quit\n"]),  # type: ignore[arg-type]
+        out,
+        json_mode=True,
+    )
+    rows = [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+    assert rows == [
+        {
+            "command": "input",
+            "error": {
+                "code": "multi_command_input",
+                "message": "Multiple commands detected.\nEnter one command per line.",
+            },
+            "mode": "error",
+            "output_version": 1,
+        }
+    ]
+
+
+def test_repl_non_interactive_json_step_pending_confirmation_error() -> None:
+    rows = _run_non_interactive_json_lines(
+        "use kubectl instead of docker\nstep set premise concise\nyes\nquit\n"
+    )
+    assert rows[1] == {
+        "command": "step",
+        "error": {
+            "code": "pending_confirmation_required",
+            "message": (
+                "step command only accepts confirmation while clarification is pending.\n"
+                "Use yes/no (or variants), or use preview/state."
+            ),
+        },
+        "mode": "error",
+        "output_version": 1,
+    }
+
+
 def test_repl_non_interactive_json_has_no_human_output_leakage() -> None:
     out = StringIO()
     run_repl(

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import sys
 from io import StringIO
@@ -86,13 +87,14 @@ def test_main_help_flag_prints_usage_and_exits_zero(
     assert result == 0
     assert captured.out == (
         "Usage:\n"
-        "  context-compiler [--help] [--version] [--with-preprocessor]\n"
+        "  context-compiler [--help] [--version] [--with-preprocessor] [--json]\n"
         "\n"
         "Options:\n"
         "  --help                Show this help message and exit.\n"
         "  --version             Show the installed context-compiler version and exit.\n"
         "  --with-preprocessor   Enable preprocessor before each REPL turn "
         "(heuristic + validation only)\n"
+        "  --json                Emit machine-readable NDJSON output (non-interactive only)\n"
     )
     assert captured.err == ""
 
@@ -135,11 +137,16 @@ def test_main_with_preprocessor_flag_runs_repl_with_flag(monkeypatch: pytest.Mon
     called: dict[str, object] = {}
 
     def _fake_run_repl(
-        in_stream: TextIO, out_stream: TextIO, *, use_preprocessor: bool = False
+        in_stream: TextIO,
+        out_stream: TextIO,
+        *,
+        use_preprocessor: bool = False,
+        json_mode: bool = False,
     ) -> None:
         called["in_stream"] = in_stream
         called["out_stream"] = out_stream
         called["use_preprocessor"] = use_preprocessor
+        called["json_mode"] = json_mode
 
     monkeypatch.setattr(repl_module, "run_repl", _fake_run_repl)
     monkeypatch.setattr(sys, "argv", ["context-compiler", "--with-preprocessor"])
@@ -150,6 +157,79 @@ def test_main_with_preprocessor_flag_runs_repl_with_flag(monkeypatch: pytest.Mon
     assert called["in_stream"] is sys.stdin
     assert called["out_stream"] is sys.stdout
     assert called["use_preprocessor"] is True
+    assert called["json_mode"] is False
+
+
+def test_main_with_json_flag_runs_repl_with_json_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, object] = {}
+
+    def _fake_run_repl(
+        in_stream: TextIO,
+        out_stream: TextIO,
+        *,
+        use_preprocessor: bool = False,
+        json_mode: bool = False,
+    ) -> None:
+        called["in_stream"] = in_stream
+        called["out_stream"] = out_stream
+        called["use_preprocessor"] = use_preprocessor
+        called["json_mode"] = json_mode
+
+    monkeypatch.setattr(repl_module, "run_repl", _fake_run_repl)
+    monkeypatch.setattr(repl_module, "_is_interactive", lambda _in, _out: False)
+    monkeypatch.setattr(sys, "argv", ["context-compiler", "--json"])
+
+    result = repl_module.main()
+
+    assert result == 0
+    assert called["in_stream"] is sys.stdin
+    assert called["out_stream"] is sys.stdout
+    assert called["use_preprocessor"] is False
+    assert called["json_mode"] is True
+
+
+def test_main_with_json_and_preprocessor_runs_repl_with_both(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: dict[str, object] = {}
+
+    def _fake_run_repl(
+        in_stream: TextIO,
+        out_stream: TextIO,
+        *,
+        use_preprocessor: bool = False,
+        json_mode: bool = False,
+    ) -> None:
+        called["in_stream"] = in_stream
+        called["out_stream"] = out_stream
+        called["use_preprocessor"] = use_preprocessor
+        called["json_mode"] = json_mode
+
+    monkeypatch.setattr(repl_module, "run_repl", _fake_run_repl)
+    monkeypatch.setattr(repl_module, "_is_interactive", lambda _in, _out: False)
+    monkeypatch.setattr(sys, "argv", ["context-compiler", "--with-preprocessor", "--json"])
+
+    result = repl_module.main()
+
+    assert result == 0
+    assert called["in_stream"] is sys.stdin
+    assert called["out_stream"] is sys.stdout
+    assert called["use_preprocessor"] is True
+    assert called["json_mode"] is True
+
+
+def test_main_json_requires_non_interactive_stdio(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(repl_module, "_is_interactive", lambda _in, _out: True)
+    monkeypatch.setattr(sys, "argv", ["context-compiler", "--json"])
+
+    result = repl_module.main()
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert captured.out == ""
+    assert captured.err == "error: --json requires non-interactive stdin/stdout.\n"
 
 
 def test_main_unknown_flag_prints_error_hint_and_exits_nonzero(
@@ -248,6 +328,91 @@ def test_repl_non_interactive_uses_human_readable_output() -> None:
 
     lines = out.getvalue().splitlines()
     assert lines == ["passthrough"]
+
+
+def _run_non_interactive_json_lines(text: str) -> list[dict[str, object]]:
+    out = StringIO()
+    run_repl(StringIO(text), out, json_mode=True)
+    return [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+
+
+def test_repl_non_interactive_json_bare_input_step_result() -> None:
+    rows = _run_non_interactive_json_lines("set premise concise\nquit\n")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["output_version"] == 1
+    assert row["mode"] == "step"
+    assert row["command"] == "input"
+    decision = row["decision"]
+    assert isinstance(decision, dict)
+    assert decision["kind"] == "update"
+
+
+def test_repl_non_interactive_json_step_and_preview_results() -> None:
+    rows = _run_non_interactive_json_lines(
+        "step set premise concise\npreview clear premise\nquit\n"
+    )
+    assert [row["mode"] for row in rows] == ["step", "preview"]
+    assert [row["command"] for row in rows] == ["step", "preview"]
+    assert rows[0]["output_version"] == 1
+    assert rows[1]["output_version"] == 1
+    assert "would_mutate" in rows[1]
+    assert "diff" in rows[1]
+
+
+def test_repl_non_interactive_json_state_command() -> None:
+    rows = _run_non_interactive_json_lines("set premise concise\nstate\nquit\n")
+    assert rows[1]["command"] == "state"
+    assert rows[1]["mode"] == "state"
+    assert rows[1]["output_version"] == 1
+    state = rows[1]["state"]
+    assert isinstance(state, dict)
+    assert state["premise"] == "concise"
+    assert state["policies"] == {}
+
+
+def test_repl_non_interactive_json_clarify_and_passthrough() -> None:
+    rows = _run_non_interactive_json_lines(
+        "prohibit docker\nuse kubectl instead of docker\nyes\nhello\nquit\n"
+    )
+    assert rows[1]["mode"] == "step"
+    assert rows[1]["decision"]["kind"] == "clarify"
+    assert rows[3]["mode"] == "step"
+    assert rows[3]["decision"]["kind"] == "passthrough"
+
+
+def test_repl_non_interactive_json_machine_readable_errors() -> None:
+    rows = _run_non_interactive_json_lines("preview\nstep\nquit\n")
+    assert rows == [
+        {
+            "command": "preview",
+            "error": {
+                "code": "missing_preview_input",
+                "message": "preview requires input.\nUse 'preview <input>'.",
+            },
+            "mode": "error",
+            "output_version": 1,
+        },
+        {
+            "command": "step",
+            "error": {
+                "code": "missing_step_input",
+                "message": "step requires input.\nUse 'step <input>'.",
+            },
+            "mode": "error",
+            "output_version": 1,
+        },
+    ]
+
+
+def test_repl_non_interactive_json_has_no_human_output_leakage() -> None:
+    out = StringIO()
+    run_repl(
+        StringIO("state\nset premise concise\npreview clear premise\nquit\n"), out, json_mode=True
+    )
+    for line in out.getvalue().splitlines():
+        parsed = json.loads(line)
+        assert isinstance(parsed, dict)
 
 
 def test_repl_non_interactive_state_command_renders_current_state() -> None:


### PR DESCRIPTION
## What changed
- Added --json CLI flag for machine-readable REPL output in non-interactive usage.
- Implemented NDJSON-style output: one complete JSON object per processed input line.
- Reused existing controller result shapes for JSON step and preview outputs.
- Added JSON envelopes for state command output and command-layer errors.
- Kept default human-readable REPL behavior unchanged.
- Added targeted REPL tests for JSON command paths, error paths, and contract coverage.
- Added a minimal README Quickstart note for --json NDJSON behavior.

## Why this was needed
- Provides stable script-friendly REPL output for automation workflows.
- Preserves existing interactive UX while adding machine-readable non-interactive output.
- Establishes a versioned, deterministic output surface for future parity work.

Closes #56