### PR TITLE
feat: add repl preload state and checkpoint flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,24 @@ jobs:
 
       - name: Contract tests with strict engine/checkpoint coverage gate (100%)
         run: uv run pytest -m contract --cov=context_compiler.engine --cov-report=term-missing --cov-fail-under=100
+
+  contract-controller-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dev dependencies
+        run: uv sync --extra dev
+
+      - name: Contract tests with strict controller coverage gate (100%)
+        run: uv run pytest -m contract --cov=context_compiler.controller --cov-report=term-missing --cov-fail-under=100

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ those forms.
 `--json` enables machine-readable NDJSON output for non-interactive usage
 (one complete JSON object per processed input line).
 
+Preload options keep authoritative state and runtime continuation separate:
+- `--initial-state-json` / `--initial-state-file` load authoritative state
+  (via exported state JSON).
+- `--initial-checkpoint-json` / `--initial-checkpoint-file` restore full
+  checkpoint continuation (authoritative state + pending clarification state).
+
 REPL command-layer commands (host/controller layer, not engine directives):
 - `state` shows current authoritative state.
 - `preview <input>` runs deterministic dry-run without mutating live state.

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -22,12 +22,20 @@ _STEP_PENDING_CONFIRMATION_ERROR = (
 )
 _CLI_HELP_TEXT = """Usage:
   context-compiler [--help] [--version] [--with-preprocessor] [--json]
+                   [--initial-state-json <json> | --initial-state-file <path>]
+                   [--initial-checkpoint-json <json> | --initial-checkpoint-file <path>]
 
 Options:
   --help                Show this help message and exit.
   --version             Show the installed context-compiler version and exit.
   --with-preprocessor   Enable preprocessor before each REPL turn (heuristic + validation only)
   --json                Emit machine-readable NDJSON output (non-interactive only)
+  --initial-state-json  Initialize authoritative state from exported state JSON text
+  --initial-state-file  Initialize authoritative state from UTF-8 state JSON file
+  --initial-checkpoint-json
+                        Restore runtime continuation from checkpoint JSON text
+  --initial-checkpoint-file
+                        Restore runtime continuation from UTF-8 checkpoint JSON file
 """
 
 
@@ -194,6 +202,83 @@ def _json_error_payload(*, command: str, code: str, message: str) -> dict[str, o
     }
 
 
+def _read_utf8_file(path: str) -> str:
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _parse_cli_options(args: list[str]) -> tuple[dict[str, str | bool], str | None]:
+    options: dict[str, str | bool] = {
+        "use_preprocessor": False,
+        "json_mode": False,
+    }
+
+    value_flags = {
+        "--initial-state-json": "initial_state_json",
+        "--initial-state-file": "initial_state_file",
+        "--initial-checkpoint-json": "initial_checkpoint_json",
+        "--initial-checkpoint-file": "initial_checkpoint_file",
+    }
+
+    idx = 0
+    while idx < len(args):
+        arg = args[idx]
+        if arg == "--with-preprocessor":
+            options["use_preprocessor"] = True
+            idx += 1
+            continue
+        if arg == "--json":
+            options["json_mode"] = True
+            idx += 1
+            continue
+        if arg in value_flags:
+            key = value_flags[arg]
+            if idx + 1 >= len(args):
+                return {}, f"option '{arg}' requires a value"
+            if key in options:
+                return {}, f"option '{arg}' was provided more than once"
+            options[key] = args[idx + 1]
+            idx += 2
+            continue
+        return {}, f"unknown option '{arg}'"
+
+    has_state_json = "initial_state_json" in options
+    has_state_file = "initial_state_file" in options
+    has_checkpoint_json = "initial_checkpoint_json" in options
+    has_checkpoint_file = "initial_checkpoint_file" in options
+
+    if has_state_json and has_state_file:
+        return {}, "state preload options are mutually exclusive"
+    if has_checkpoint_json and has_checkpoint_file:
+        return {}, "checkpoint preload options are mutually exclusive"
+    if (has_state_json or has_state_file) and (has_checkpoint_json or has_checkpoint_file):
+        return {}, "state preload and checkpoint preload are mutually exclusive"
+
+    return options, None
+
+
+def _apply_preload_from_options(engine: Engine, options: dict[str, str | bool]) -> None:
+    if "initial_state_json" in options:
+        raw = options["initial_state_json"]
+        assert isinstance(raw, str)
+        engine.import_json(raw)
+        return
+    if "initial_state_file" in options:
+        path = options["initial_state_file"]
+        assert isinstance(path, str)
+        engine.import_json(_read_utf8_file(path))
+        return
+    if "initial_checkpoint_json" in options:
+        raw = options["initial_checkpoint_json"]
+        assert isinstance(raw, str)
+        engine.import_checkpoint_json(raw)
+        return
+    if "initial_checkpoint_file" in options:
+        path = options["initial_checkpoint_file"]
+        assert isinstance(path, str)
+        engine.import_checkpoint_json(_read_utf8_file(path))
+
+
 def _has_pending_clarification(engine: Engine) -> bool:
     return engine.has_pending_clarification()
 
@@ -225,8 +310,9 @@ def run_repl(
     *,
     use_preprocessor: bool = False,
     json_mode: bool = False,
+    engine: Engine | None = None,
 ) -> None:
-    engine = create_engine()
+    active_engine = create_engine() if engine is None else engine
 
     if _is_interactive(in_stream, out_stream):
         print("Context Compiler REPL (0.5). Type help for commands.", file=out_stream)
@@ -251,7 +337,7 @@ def run_repl(
 
             if token == "state":
                 print("", file=out_stream)
-                for line in _render_state_lines(engine.state):
+                for line in _render_state_lines(active_engine.state):
                     print(line, file=out_stream)
                 continue
 
@@ -265,7 +351,9 @@ def run_repl(
                     )
                     continue
                 if payload != "" and (user_input == "step" or user_input.startswith("step ")):
-                    if _has_pending_clarification(engine) and not _is_confirmation_input(payload):
+                    if _has_pending_clarification(active_engine) and not _is_confirmation_input(
+                        payload
+                    ):
                         _print_command_error(
                             out_stream,
                             leading_blank=True,
@@ -273,9 +361,9 @@ def run_repl(
                         )
                         continue
                     compile_input = _compile_input(
-                        payload, engine, use_preprocessor=use_preprocessor
+                        payload, active_engine, use_preprocessor=use_preprocessor
                     )
-                    result: StepResult = controller_step(engine, compile_input)
+                    result: StepResult = controller_step(active_engine, compile_input)
                     _print_decision_lines(result["decision"], out_stream, leading_blank=True)
                     continue
 
@@ -295,8 +383,10 @@ def run_repl(
                         message="preview requires input.\nUse 'preview <input>'.",
                     )
                     continue
-                compile_input = _compile_input(payload, engine, use_preprocessor=use_preprocessor)
-                preview_result = controller_preview(engine, compile_input)
+                compile_input = _compile_input(
+                    payload, active_engine, use_preprocessor=use_preprocessor
+                )
+                preview_result = controller_preview(active_engine, compile_input)
                 _print_preview_lines(
                     preview_result,
                     out_stream,
@@ -305,8 +395,10 @@ def run_repl(
                 )
                 continue
 
-            compile_input = _compile_input(user_input, engine, use_preprocessor=use_preprocessor)
-            result = controller_step(engine, compile_input)
+            compile_input = _compile_input(
+                user_input, active_engine, use_preprocessor=use_preprocessor
+            )
+            result = controller_step(active_engine, compile_input)
             _print_decision_lines(result["decision"], out_stream, leading_blank=True)
         return
 
@@ -331,9 +423,9 @@ def run_repl(
         token = user_input.strip().lower()
         if token == "state":
             if json_mode:
-                _write_json_line(out_stream, _json_state_payload(engine.state))
+                _write_json_line(out_stream, _json_state_payload(active_engine.state))
             else:
-                for state_line in _render_state_lines(engine.state):
+                for state_line in _render_state_lines(active_engine.state):
                     print(state_line, file=out_stream)
             continue
 
@@ -357,7 +449,9 @@ def run_repl(
                     )
                 continue
             if payload != "" and (user_input == "step" or user_input.startswith("step ")):
-                if _has_pending_clarification(engine) and not _is_confirmation_input(payload):
+                if _has_pending_clarification(active_engine) and not _is_confirmation_input(
+                    payload
+                ):
                     if json_mode:
                         _write_json_line(
                             out_stream,
@@ -374,8 +468,10 @@ def run_repl(
                             message=_STEP_PENDING_CONFIRMATION_ERROR,
                         )
                     continue
-                compile_input = _compile_input(payload, engine, use_preprocessor=use_preprocessor)
-                result = controller_step(engine, compile_input)
+                compile_input = _compile_input(
+                    payload, active_engine, use_preprocessor=use_preprocessor
+                )
+                result = controller_step(active_engine, compile_input)
                 if json_mode:
                     _write_json_line(out_stream, _json_step_payload(result, command="step"))
                 else:
@@ -408,8 +504,10 @@ def run_repl(
                         message="preview requires input.\nUse 'preview <input>'.",
                     )
                 continue
-            compile_input = _compile_input(payload, engine, use_preprocessor=use_preprocessor)
-            preview_result = controller_preview(engine, compile_input)
+            compile_input = _compile_input(
+                payload, active_engine, use_preprocessor=use_preprocessor
+            )
+            preview_result = controller_preview(active_engine, compile_input)
             if json_mode:
                 _write_json_line(
                     out_stream, _json_preview_payload(preview_result, command="preview")
@@ -423,8 +521,8 @@ def run_repl(
                 )
             continue
 
-        compile_input = _compile_input(user_input, engine, use_preprocessor=use_preprocessor)
-        result = controller_step(engine, compile_input)
+        compile_input = _compile_input(user_input, active_engine, use_preprocessor=use_preprocessor)
+        result = controller_step(active_engine, compile_input)
         if json_mode:
             _write_json_line(out_stream, _json_step_payload(result, command="input"))
         else:
@@ -445,27 +543,32 @@ def main() -> int:  # pragma: no cover
         print(__version__, file=sys.stdout)
         return 0
 
-    if args and all(arg in {"--with-preprocessor", "--json"} for arg in args) and len(args) <= 2:
-        if len(args) != len(set(args)):
-            bad_arg = args[0]
-            print(f"error: unknown option '{bad_arg}'", file=sys.stderr)
-            print("Try 'context-compiler --help' for usage.", file=sys.stderr)
-            return 1
+    options, parse_error = _parse_cli_options(args)
+    if parse_error is not None:
+        print(f"error: {parse_error}", file=sys.stderr)
+        print("Try 'context-compiler --help' for usage.", file=sys.stderr)
+        return 1
 
-        use_preprocessor = "--with-preprocessor" in args
-        json_mode = "--json" in args
+    json_mode = bool(options["json_mode"])
+    if json_mode and _is_interactive(sys.stdin, sys.stdout):
+        print("error: --json requires non-interactive stdin/stdout.", file=sys.stderr)
+        return 1
 
-        if json_mode and _is_interactive(sys.stdin, sys.stdout):
-            print("error: --json requires non-interactive stdin/stdout.", file=sys.stderr)
-            return 1
+    engine = create_engine()
+    try:
+        _apply_preload_from_options(engine, options)
+    except (OSError, ValueError) as exc:
+        print(f"error: preload failed: {exc}", file=sys.stderr)
+        return 1
 
-        run_repl(sys.stdin, sys.stdout, use_preprocessor=use_preprocessor, json_mode=json_mode)
-        return 0
-
-    bad_arg = args[0]
-    print(f"error: unknown option '{bad_arg}'", file=sys.stderr)
-    print("Try 'context-compiler --help' for usage.", file=sys.stderr)
-    return 1
+    run_repl(
+        sys.stdin,
+        sys.stdout,
+        use_preprocessor=bool(options["use_preprocessor"]),
+        json_mode=json_mode,
+        engine=engine,
+    )
+    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -116,6 +116,27 @@ def test_state_diff_structural_changes() -> None:
     }
 
 
+@pytest.mark.contract
+def test_state_diff_policy_removed_and_value_changed() -> None:
+    before = {
+        "premise": None,
+        "policies": {"docker": "use", "pytest": "prohibit"},
+        "version": 2,
+    }
+    after = {
+        "premise": None,
+        "policies": {"docker": "prohibit"},
+        "version": 2,
+    }
+
+    diff = state_diff(before, after)
+    assert diff["changed"] is True
+    assert diff["premise"] == {"before": None, "after": None, "changed": False}
+    assert diff["policies"]["removed"] == {"pytest": "prohibit"}
+    assert diff["policies"]["changed"] == {"docker": {"before": "use", "after": "prohibit"}}
+    assert diff["policies"]["added"] == {}
+
+
 def test_preview_fails_when_checkpoint_restore_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,4 +1,5 @@
 import json
+import pathlib
 import subprocess
 import sys
 from io import StringIO
@@ -88,6 +89,8 @@ def test_main_help_flag_prints_usage_and_exits_zero(
     assert captured.out == (
         "Usage:\n"
         "  context-compiler [--help] [--version] [--with-preprocessor] [--json]\n"
+        "                   [--initial-state-json <json> | --initial-state-file <path>]\n"
+        "                   [--initial-checkpoint-json <json> | --initial-checkpoint-file <path>]\n"
         "\n"
         "Options:\n"
         "  --help                Show this help message and exit.\n"
@@ -95,6 +98,12 @@ def test_main_help_flag_prints_usage_and_exits_zero(
         "  --with-preprocessor   Enable preprocessor before each REPL turn "
         "(heuristic + validation only)\n"
         "  --json                Emit machine-readable NDJSON output (non-interactive only)\n"
+        "  --initial-state-json  Initialize authoritative state from exported state JSON text\n"
+        "  --initial-state-file  Initialize authoritative state from UTF-8 state JSON file\n"
+        "  --initial-checkpoint-json\n"
+        "                        Restore runtime continuation from checkpoint JSON text\n"
+        "  --initial-checkpoint-file\n"
+        "                        Restore runtime continuation from UTF-8 checkpoint JSON file\n"
     )
     assert captured.err == ""
 
@@ -116,11 +125,18 @@ def test_main_without_args_runs_repl_as_before(monkeypatch: pytest.MonkeyPatch) 
     called: dict[str, object] = {}
 
     def _fake_run_repl(
-        in_stream: TextIO, out_stream: TextIO, *, use_preprocessor: bool = False
+        in_stream: TextIO,
+        out_stream: TextIO,
+        *,
+        use_preprocessor: bool = False,
+        json_mode: bool = False,
+        engine: object | None = None,
     ) -> None:
         called["in_stream"] = in_stream
         called["out_stream"] = out_stream
         called["use_preprocessor"] = use_preprocessor
+        called["json_mode"] = json_mode
+        called["engine"] = engine
 
     monkeypatch.setattr(repl_module, "run_repl", _fake_run_repl)
     monkeypatch.setattr(sys, "argv", ["context-compiler"])
@@ -131,6 +147,8 @@ def test_main_without_args_runs_repl_as_before(monkeypatch: pytest.MonkeyPatch) 
     assert called["in_stream"] is sys.stdin
     assert called["out_stream"] is sys.stdout
     assert called["use_preprocessor"] is False
+    assert called["json_mode"] is False
+    assert called["engine"] is None
 
 
 def test_main_with_preprocessor_flag_runs_repl_with_flag(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -142,6 +160,7 @@ def test_main_with_preprocessor_flag_runs_repl_with_flag(monkeypatch: pytest.Mon
         *,
         use_preprocessor: bool = False,
         json_mode: bool = False,
+        engine: object | None = None,
     ) -> None:
         called["in_stream"] = in_stream
         called["out_stream"] = out_stream
@@ -169,6 +188,7 @@ def test_main_with_json_flag_runs_repl_with_json_mode(monkeypatch: pytest.Monkey
         *,
         use_preprocessor: bool = False,
         json_mode: bool = False,
+        engine: object | None = None,
     ) -> None:
         called["in_stream"] = in_stream
         called["out_stream"] = out_stream
@@ -199,6 +219,7 @@ def test_main_with_json_and_preprocessor_runs_repl_with_both(
         *,
         use_preprocessor: bool = False,
         json_mode: bool = False,
+        engine: object | None = None,
     ) -> None:
         called["in_stream"] = in_stream
         called["out_stream"] = out_stream
@@ -247,22 +268,246 @@ def test_main_unknown_flag_prints_error_hint_and_exits_nonzero(
     )
 
 
-@pytest.mark.parametrize(
-    "args, expected_bad_arg",
-    [
-        (["--with-preprocessor", "foo"], "--with-preprocessor"),
-        (["--help", "--version"], "--help"),
-        (["--version", "--with-preprocessor"], "--version"),
-    ],
-)
-def test_cli_rejects_non_single_flag_argument_forms(args: list[str], expected_bad_arg: str) -> None:
+@pytest.mark.parametrize("args", [["--help", "--version"], ["--version", "--with-preprocessor"]])
+def test_cli_rejects_non_single_flag_argument_forms(args: list[str]) -> None:
     result = _run_repl_cli(*args)
 
     assert result.returncode != 0
     assert result.stdout == ""
-    assert result.stderr == (
-        f"error: unknown option '{expected_bad_arg}'\nTry 'context-compiler --help' for usage.\n"
+    assert "error: unknown option" in result.stderr
+    assert "Try 'context-compiler --help' for usage." in result.stderr
+
+
+def test_cli_rejects_unknown_positional_after_flag() -> None:
+    result = _run_repl_cli("--with-preprocessor", "foo")
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert (
+        result.stderr == "error: unknown option 'foo'\nTry 'context-compiler --help' for usage.\n"
     )
+
+
+def test_cli_initial_state_json_preload_works() -> None:
+    engine = create_engine()
+    engine.step("set premise concise")
+    payload = engine.export_json()
+
+    result = _run_repl_cli("--initial-state-json", payload, input_text="state\nquit\n")
+    assert result.returncode == 0
+    assert "premise: concise" in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_initial_state_file_preload_works(tmp_path: pathlib.Path) -> None:
+    engine = create_engine()
+    engine.step("use docker")
+    path = tmp_path / "state.json"
+    path.write_text(engine.export_json(), encoding="utf-8")
+
+    result = _run_repl_cli("--initial-state-file", str(path), input_text="state\nquit\n")
+    assert result.returncode == 0
+    assert "policies:" in result.stdout
+    assert "- use docker" in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_initial_checkpoint_json_preload_works_with_pending_confirmation() -> None:
+    engine = create_engine()
+    engine.step("use kubectl instead of docker")
+    payload = engine.export_checkpoint_json()
+
+    result = _run_repl_cli("--initial-checkpoint-json", payload, input_text="yes\nquit\n")
+    assert result.returncode == 0
+    assert "updated" in result.stdout
+    assert "- use kubectl" in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_initial_checkpoint_file_preload_works(tmp_path: pathlib.Path) -> None:
+    engine = create_engine()
+    engine.step("set premise concise")
+    checkpoint = engine.export_checkpoint_json()
+    path = tmp_path / "checkpoint.json"
+    path.write_text(checkpoint, encoding="utf-8")
+
+    result = _run_repl_cli("--initial-checkpoint-file", str(path), input_text="state\nquit\n")
+    assert result.returncode == 0
+    assert "premise: concise" in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_invalid_initial_state_preload_fails_fast() -> None:
+    result = _run_repl_cli("--initial-state-json", '{"bad":true}', input_text="state\nquit\n")
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr == "error: preload failed: Invalid state payload.\n"
+
+
+def test_cli_invalid_initial_checkpoint_preload_fails_fast() -> None:
+    result = _run_repl_cli("--initial-checkpoint-json", '{"bad":true}', input_text="state\nquit\n")
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr == "error: preload failed: Invalid checkpoint payload.\n"
+
+
+def test_cli_preload_mutual_exclusion_state_json_vs_file() -> None:
+    result = _run_repl_cli("--initial-state-json", "{}", "--initial-state-file", "/tmp/ignored")
+    assert result.returncode == 1
+    assert result.stdout == ""
+    expected = (
+        "error: state preload options are mutually exclusive\n"
+        "Try 'context-compiler --help' for usage.\n"
+    )
+    assert result.stderr == expected
+
+
+def test_cli_preload_mutual_exclusion_checkpoint_json_vs_file() -> None:
+    result = _run_repl_cli(
+        "--initial-checkpoint-json", "{}", "--initial-checkpoint-file", "/tmp/ignored"
+    )
+    assert result.returncode == 1
+    assert result.stdout == ""
+    expected = (
+        "error: checkpoint preload options are mutually exclusive\n"
+        "Try 'context-compiler --help' for usage.\n"
+    )
+    assert result.stderr == expected
+
+
+def test_cli_preload_mutual_exclusion_state_vs_checkpoint() -> None:
+    result = _run_repl_cli("--initial-state-json", "{}", "--initial-checkpoint-json", "{}")
+    assert result.returncode == 1
+    assert result.stdout == ""
+    expected = (
+        "error: state preload and checkpoint preload are mutually exclusive\n"
+        "Try 'context-compiler --help' for usage.\n"
+    )
+    assert result.stderr == expected
+
+
+def test_cli_preload_works_with_json_mode() -> None:
+    engine = create_engine()
+    engine.step("set premise concise")
+    payload = engine.export_json()
+
+    result = _run_repl_cli("--json", "--initial-state-json", payload, input_text="state\nquit\n")
+    assert result.returncode == 0
+    lines = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    assert lines[0]["mode"] == "state"
+    assert lines[0]["state"]["premise"] == "concise"
+    assert result.stderr == ""
+
+
+def test_cli_preload_missing_value_errors() -> None:
+    result = _run_repl_cli("--initial-state-json")
+    assert result.returncode == 1
+    assert result.stdout == ""
+    expected = (
+        "error: option '--initial-state-json' requires a value\n"
+        "Try 'context-compiler --help' for usage.\n"
+    )
+    assert result.stderr == expected
+
+
+def test_parse_cli_options_duplicate_value_flag_rejected() -> None:
+    options, error = repl_module._parse_cli_options(
+        ["--initial-state-json", "{}", "--initial-state-json", "{}"]
+    )
+    assert options == {}
+    assert error == "option '--initial-state-json' was provided more than once"
+
+
+def test_parse_cli_options_missing_value_rejected() -> None:
+    options, error = repl_module._parse_cli_options(["--initial-state-json"])
+    assert options == {}
+    assert error == "option '--initial-state-json' requires a value"
+
+
+def test_parse_cli_options_mutual_exclusion_errors() -> None:
+    options_state, error_state = repl_module._parse_cli_options(
+        ["--initial-state-json", "{}", "--initial-state-file", "/tmp/x"]
+    )
+    assert options_state == {}
+    assert error_state == "state preload options are mutually exclusive"
+
+    options_ckpt, error_ckpt = repl_module._parse_cli_options(
+        ["--initial-checkpoint-json", "{}", "--initial-checkpoint-file", "/tmp/x"]
+    )
+    assert options_ckpt == {}
+    assert error_ckpt == "checkpoint preload options are mutually exclusive"
+
+    options_cross, error_cross = repl_module._parse_cli_options(
+        ["--initial-state-json", "{}", "--initial-checkpoint-json", "{}"]
+    )
+    assert options_cross == {}
+    assert error_cross == "state preload and checkpoint preload are mutually exclusive"
+
+
+def test_apply_preload_from_options_state_and_checkpoint_file_paths(
+    tmp_path: pathlib.Path,
+) -> None:
+    baseline = create_engine()
+    baseline.step("set premise concise")
+    baseline_checkpoint_engine = create_engine()
+    baseline_checkpoint_engine.step("use kubectl instead of docker")
+
+    state_path = tmp_path / "initial_state.json"
+    checkpoint_path = tmp_path / "initial_checkpoint.json"
+    state_path.write_text(baseline.export_json(), encoding="utf-8")
+    checkpoint_path.write_text(
+        baseline_checkpoint_engine.export_checkpoint_json(), encoding="utf-8"
+    )
+
+    state_engine = create_engine()
+    repl_module._apply_preload_from_options(
+        state_engine,
+        {"use_preprocessor": False, "json_mode": False, "initial_state_file": str(state_path)},
+    )
+    assert state_engine.state["premise"] == "concise"
+
+    checkpoint_engine = create_engine()
+    repl_module._apply_preload_from_options(
+        checkpoint_engine,
+        {
+            "use_preprocessor": False,
+            "json_mode": False,
+            "initial_checkpoint_file": str(checkpoint_path),
+        },
+    )
+    decision = checkpoint_engine.step("yes")
+    assert decision["kind"] == "update"
+    assert checkpoint_engine.state["policies"] == {"kubectl": "use"}
+
+
+def test_apply_preload_from_options_state_and_checkpoint_json() -> None:
+    source_state = create_engine()
+    source_state.step("set premise concise")
+    source_checkpoint = create_engine()
+    source_checkpoint.step("use kubectl instead of docker")
+
+    state_engine = create_engine()
+    repl_module._apply_preload_from_options(
+        state_engine,
+        {
+            "use_preprocessor": False,
+            "json_mode": False,
+            "initial_state_json": source_state.export_json(),
+        },
+    )
+    assert state_engine.state["premise"] == "concise"
+
+    checkpoint_engine = create_engine()
+    repl_module._apply_preload_from_options(
+        checkpoint_engine,
+        {
+            "use_preprocessor": False,
+            "json_mode": False,
+            "initial_checkpoint_json": source_checkpoint.export_checkpoint_json(),
+        },
+    )
+    decision = checkpoint_engine.step("yes")
+    assert decision["kind"] == "update"
+    assert checkpoint_engine.state["policies"] == {"kubectl": "use"}
 
 
 def test_repl_update_flow() -> None:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -409,6 +409,69 @@ def test_cli_preload_missing_value_errors() -> None:
     assert result.stderr == expected
 
 
+def test_cli_initial_state_file_preload_unreadable_file_error_is_deterministic(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _boom(_path: str) -> str:
+        raise OSError("cannot read preload file")
+
+    monkeypatch.setattr(repl_module, "_read_utf8_file", _boom)
+    monkeypatch.setattr(
+        sys, "argv", ["context-compiler", "--initial-state-file", "/tmp/state.json"]
+    )
+
+    result = repl_module.main()
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert captured.out == ""
+    assert captured.err == "error: preload failed: cannot read preload file\n"
+
+
+def test_cli_initial_checkpoint_file_preload_permission_failure_is_deterministic(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _boom(_path: str) -> str:
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(repl_module, "_read_utf8_file", _boom)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["context-compiler", "--initial-checkpoint-file", "/tmp/checkpoint.json"],
+    )
+
+    result = repl_module.main()
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert captured.out == ""
+    assert captured.err == "error: preload failed: permission denied\n"
+
+
+def test_cli_initial_state_file_preload_utf8_decode_failure_is_deterministic(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _boom(_path: str) -> str:
+        raise UnicodeDecodeError("utf-8", b"\x80", 0, 1, "invalid start byte")
+
+    monkeypatch.setattr(repl_module, "_read_utf8_file", _boom)
+    monkeypatch.setattr(
+        sys, "argv", ["context-compiler", "--initial-state-file", "/tmp/state.json"]
+    )
+
+    result = repl_module.main()
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert captured.out == ""
+    expected = (
+        "error: preload failed: 'utf-8' codec can't decode byte 0x80 in position 0: "
+        "invalid start byte\n"
+    )
+    assert captured.err == expected
+
+
 def test_parse_cli_options_duplicate_value_flag_rejected() -> None:
     options, error = repl_module._parse_cli_options(
         ["--initial-state-json", "{}", "--initial-state-json", "{}"]


### PR DESCRIPTION
## What changed
- Added explicit preload flags for REPL/CLI:
  - --initial-state-json <json>
  - --initial-state-file <path>
  - --initial-checkpoint-json <json>
  - --initial-checkpoint-file <path>
- Implemented strict mutual exclusion between state preload and checkpoint preload options.
- State preload uses engine.import_json(...); checkpoint preload uses engine.import_checkpoint_json(...).
- Added UTF-8 file loading for preload file flags.
- Added fail-fast preload validation before processing stdin.
- Kept default REPL behavior unchanged when no preload flags are provided.
- Added/updated tests for preload success paths, mutual exclusion, invalid payloads, JSON-mode compatibility, and preload file I/O failures.
- Added brief README and CLI help coverage clarifying authoritative state preload vs checkpoint continuation preload.
- Added CI contract coverage job for controller module (100% gate), aligned with existing REPL and engine coverage jobs.

## Why this was needed
- Supports explicit host-controlled startup state for scripting and REPL workflows.
- Keeps authoritative state transport and runtime continuation restoration as separate concepts.
- Preserves deterministic behavior and clear boundary semantics for 0.7.

Closes #138