### PR TITLE
fix: return local ack for openwebui updates

### DIFF
--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -88,11 +88,9 @@ Validate clarify short-circuit, passthrough forwarding without state injection,
 update forwarding with compiler state (`[[cc_state]]`) added to the request, chat isolation
 with real chat ids, restart state loss, and non-text bypass behavior.
 
-Note: In the OpenWebUI example pipes, `update` decisions call the downstream
-LLM with authoritative compiler state injected as a compiler-owned system
-message (`[[cc_state]] ...`) for state-affecting updates. Administrative
-updates (`clear state`, `clear premise`, `reset policies`, `remove policy <item>`)
-return deterministic local acknowledgments and do not call the downstream LLM.
+Note: In the OpenWebUI example pipes, recognized directive-only `update`
+decisions return deterministic local acknowledgments and do not call the
+downstream LLM.
 When trace is enabled, responses include concise evidence of decision kind,
 active state, downstream LLM call/no-call, and whether state was injected.
 

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -353,7 +353,7 @@ class Pipe:
 
     - ``clarify`` returns plain text and skips model forwarding.
     - ``passthrough`` forwards with minimal mutation.
-    - ``update`` forwards with compiler-owned state injection.
+    - ``update`` returns deterministic local acknowledgement (no model call).
     """
 
     class Valves(BaseModel):
@@ -676,31 +676,14 @@ class Pipe:
             )
         if kind == DECISION_UPDATE:
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            if _is_administrative_update_input(latest_user_text):
-                return self._with_trace(
-                    _summarize_update_from_input(latest_user_text),
-                    original_input=latest_user_text,
-                    compiler_input=latest_user_text,
-                    decision=decision,
-                    state_before=state_before,
-                    state_after=state_after,
-                    llm_called=False,
-                )
-            response = await self._forward_update(
-                body,
-                __user__,
-                __request__,
-                state_after,
-            )
             return self._with_trace(
-                response,
+                _summarize_update_from_input(latest_user_text),
                 original_input=latest_user_text,
                 compiler_input=latest_user_text,
                 decision=decision,
                 state_before=state_before,
                 state_after=state_after,
-                llm_called=True,
-                state_injected=_active_state_summary(state_after),
+                llm_called=False,
             )
 
         response = await self._forward_passthrough(body, __user__, __request__)

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -404,7 +404,7 @@ class Pipe:
 
     This variant adds a preprocessor stage before ``engine.step(...)``:
     heuristic first, then Open WebUI-native LLM fallback.
-    Update decisions forward with compiler-owned state injection.
+    Update decisions return deterministic local acknowledgement (no model call).
     """
 
     class Valves(BaseModel):
@@ -967,34 +967,15 @@ class Pipe:
             )
         if kind == DECISION_UPDATE:
             _CHECKPOINTS_BY_CHAT_KEY[chat_key] = engine.export_checkpoint_json()
-            if _is_administrative_update_input(compile_input):
-                return self._with_trace(
-                    _summarize_update_from_input(compile_input),
-                    original_input=latest_user_text,
-                    compiler_input=compile_input,
-                    decision=decision,
-                    state_before=state_before,
-                    state_after=state_after,
-                    preprocessor_output=preprocessd,
-                    llm_called=False,
-                )
-            response = await self._forward_update(
-                body,
-                __user__,
-                __request__,
-                state_after,
-                base_model_id=base_model_id,
-            )
             return self._with_trace(
-                response,
+                _summarize_update_from_input(compile_input),
                 original_input=latest_user_text,
                 compiler_input=compile_input,
                 decision=decision,
                 state_before=state_before,
                 state_after=state_after,
                 preprocessor_output=preprocessd,
-                llm_called=base_model_id is not None,
-                state_injected=_active_state_summary(state_after),
+                llm_called=False,
             )
 
         response = await self._forward_passthrough(

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -265,7 +265,7 @@ def test_pipe_supports_async_user_lookup(monkeypatch) -> None:
     assert isinstance(result, dict)
 
 
-def test_pipe_normal_update_forwards_with_state_and_persists_checkpoint(monkeypatch) -> None:
+def test_pipe_normal_update_returns_local_ack_and_persists_checkpoint(monkeypatch) -> None:
     module = _load_module_with_openwebui_stubs("owui_pipe_update_forward", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
@@ -296,11 +296,8 @@ def test_pipe_normal_update_forwards_with_state_and_persists_checkpoint(monkeypa
         )
     )
 
-    assert result == {"ok": True}
-    assert len(forwarded_payloads) == 1
-    first_messages = forwarded_payloads[0]["messages"]
-    assert isinstance(first_messages, list)
-    assert first_messages[0] == {"role": "system", "content": "[[cc_state]]\nProhibit: peanuts"}
+    assert result == "State updated: Prohibit peanuts."
+    assert len(forwarded_payloads) == 0
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
@@ -319,14 +316,14 @@ def test_pipe_normal_update_forwards_with_state_and_persists_checkpoint(monkeypa
     )
 
     assert result == "State updated: Removed policy peanuts."
-    assert len(forwarded_payloads) == 1
+    assert len(forwarded_payloads) == 0
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
     assert checkpoint["authoritative_state"]["policies"] == {}
 
 
-def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatch) -> None:
+def test_pipe_update_directives_return_local_ack_across_shapes(monkeypatch) -> None:
     module = _load_module_with_openwebui_stubs("owui_pipe_update_shapes", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
@@ -352,7 +349,7 @@ def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatc
             __chat_id__="chat-use",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Use docker."
 
     result = asyncio.run(
         pipe.pipe(
@@ -365,7 +362,7 @@ def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatc
             __chat_id__="chat-prohibit",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Prohibit docker."
 
     result = asyncio.run(
         pipe.pipe(
@@ -375,7 +372,7 @@ def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatc
             __chat_id__="chat-idempotent",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Use docker."
 
     result = asyncio.run(
         pipe.pipe(
@@ -388,7 +385,7 @@ def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatc
             __chat_id__="chat-replace",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Use docker."
 
     result = asyncio.run(
         pipe.pipe(
@@ -401,7 +398,7 @@ def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatc
             __chat_id__="chat-replace",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Use kubectl."
 
     result = asyncio.run(
         pipe.pipe(
@@ -414,7 +411,7 @@ def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatc
             __chat_id__="chat-premise",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated."
 
     result = asyncio.run(
         pipe.pipe(
@@ -437,16 +434,8 @@ def test_pipe_update_forwarding_injects_state_across_directive_shapes(monkeypatc
             __chat_id__="chat-replace-noop",
         )
     )
-    assert result == {"ok": True}
-    assert len(forwarded_payloads) == 7
-    assert all(
-        isinstance(payload.get("messages"), list)
-        and isinstance(payload["messages"][0], dict)
-        and payload["messages"][0].get("role") == "system"
-        and isinstance(payload["messages"][0].get("content"), str)
-        and payload["messages"][0]["content"].startswith("[[cc_state]]")
-        for payload in forwarded_payloads
-    )
+    assert result == "State updated: Use docker."
+    assert len(forwarded_payloads) == 0
 
 
 def test_pipe_near_miss_directives_return_deterministic_clarify_without_downstream(
@@ -504,7 +493,7 @@ def test_pipe_near_miss_directives_return_deterministic_clarify_without_downstre
         ("no thanks.", {}),
     ],
 )
-def test_pipe_confirmation_update_forwards_with_state(
+def test_pipe_confirmation_update_returns_local_ack(
     monkeypatch,
     confirmation: str,
     expected_policies: dict[str, str],
@@ -553,14 +542,8 @@ def test_pipe_confirmation_update_forwards_with_state(
             __chat_id__=chat_key,
         )
     )
-    assert resumed == {"ok": True}
-    assert len(forwarded_payloads) == 1
-    resumed_messages = forwarded_payloads[0]["messages"]
-    assert isinstance(resumed_messages, list)
-    assert isinstance(resumed_messages[0], dict)
-    assert resumed_messages[0].get("role") == "system"
-    assert isinstance(resumed_messages[0].get("content"), str)
-    assert resumed_messages[0]["content"].startswith("[[cc_state]]")
+    assert resumed == "State updated."
+    assert len(forwarded_payloads) == 0
 
     resumed_engine = module._ENGINES_BY_CHAT_KEY[chat_key]
     assert resumed_engine.state == {
@@ -675,7 +658,7 @@ def test_pipe_trace_on_passthrough_stream_appends_trace_after_chunks(monkeypatch
     assert "state injected: no" in content
 
 
-def test_pipe_trace_on_update_shows_state_payload_and_downstream_call(monkeypatch) -> None:
+def test_pipe_trace_on_update_shows_local_ack_and_no_downstream_call(monkeypatch) -> None:
     module = _load_module_with_openwebui_stubs("owui_pipe_trace_update", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()
     module._CHECKPOINTS_BY_CHAT_KEY.clear()
@@ -704,18 +687,18 @@ def test_pipe_trace_on_update_shows_state_payload_and_downstream_call(monkeypatc
             __chat_id__="chat-trace-update",
         )
     )
-    assert isinstance(result, dict)
-    content = result["choices"][0]["message"]["content"]
-    assert "downstream" in content
+    assert isinstance(result, str)
+    content = result
+    assert content.startswith("State updated: Prohibit peanuts.")
     assert "Context Compiler trace" in content
     assert "decision kind: update" in content
-    assert "downstream LLM call: yes" in content
+    assert "downstream LLM call: no" in content
     assert "state change:" in content
     assert "active state:" in content
-    assert "state injected: prohibit peanuts" in content
+    assert "state injected: no" in content
     assert "\n\ndecision kind: update" in content
-    assert "\n\nstate injected: prohibit peanuts" in content
-    assert downstream_calls == 1
+    assert "\n\nstate injected: no" in content
+    assert downstream_calls == 0
 
 
 def test_pipe_trace_on_clarify_shows_prompt_and_no_downstream_call(monkeypatch) -> None:
@@ -809,19 +792,13 @@ def test_pipe_trace_appends_on_object_response_for_passthrough_and_update(monkey
             __chat_id__="chat-object-update",
         )
     )
-    assert hasattr(update, "choices")
-    update_content = update.choices[0].message.content
+    assert isinstance(update, str)
+    update_content = update
     assert "Context Compiler trace" in update_content
     assert "decision kind: update" in update_content
-    assert "downstream LLM call: yes" in update_content
-    assert "state injected:" in update_content
-    assert any(
-        isinstance(payload.get("messages"), list)
-        and isinstance(payload["messages"][0], dict)
-        and isinstance(payload["messages"][0].get("content"), str)
-        and payload["messages"][0]["content"].startswith("[[cc_state]]")
-        for payload in forwarded_payloads
-    )
+    assert "downstream LLM call: no" in update_content
+    assert "state injected: no" in update_content
+    assert len(forwarded_payloads) == 1
 
 
 def test_pipe_trace_appends_on_streaming_response_wrapper_passthrough_and_update(
@@ -879,18 +856,11 @@ def test_pipe_trace_appends_on_streaming_response_wrapper_passthrough_and_update
             __chat_id__="chat-stream-wrapper-update",
         )
     )
-    update_stream = asyncio.run(_collect_stream(update))
-    assert "data: [DONE]" in update_stream
-    assert "Context Compiler trace" in update_stream
-    assert "decision kind: update" in update_stream
-    assert "state injected:" in update_stream
-    assert any(
-        isinstance(payload.get("messages"), list)
-        and isinstance(payload["messages"][0], dict)
-        and isinstance(payload["messages"][0].get("content"), str)
-        and payload["messages"][0]["content"].startswith("[[cc_state]]")
-        for payload in forwarded_payloads
-    )
+    assert isinstance(update, str)
+    assert "Context Compiler trace" in update
+    assert "decision kind: update" in update
+    assert "state injected: no" in update
+    assert len(forwarded_payloads) == 1
 
 
 @pytest.mark.parametrize(
@@ -960,7 +930,7 @@ def test_pipe_trace_update_clear_reset_paths_single_and_consistent(
     assert "downstream LLM call: yes" not in content
     assert "active state: none" in content
     assert "state injected: no" in content
-    assert downstream_calls == len(steps) - 1
+    assert downstream_calls == 0
 
 
 def test_pipe_clear_state_trace_not_duplicated_when_model_echoes_history(monkeypatch) -> None:
@@ -999,8 +969,8 @@ def test_pipe_clear_state_trace_not_duplicated_when_model_echoes_history(monkeyp
             __chat_id__=chat_id,
         )
     )
-    assert isinstance(first, dict)
-    first_content = first["choices"][0]["message"]["content"]
+    assert isinstance(first, str)
+    first_content = first
     assert first_content.count("Context Compiler trace") == 1
 
     second = asyncio.run(

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -195,9 +195,7 @@ def test_pipe_debug_true_missing_base_skips_update_forwarding_call(monkeypatch) 
         )
     )
 
-    assert result == (
-        "Context Compiler debug mode: BASE_MODEL_ID is empty; skipping model passthrough."
-    )
+    assert result == "State updated: Use docker."
     assert llm_calls == 0
 
 
@@ -570,7 +568,7 @@ def test_preprocessor_pipe_restore_and_persist_checkpoint_points(monkeypatch) ->
     assert module._CHECKPOINTS_BY_CHAT_KEY["chat-2"] == "ckpt-keep"
 
 
-def test_preprocessor_pipe_normal_update_forwards_with_state_and_persists_checkpoint(
+def test_preprocessor_pipe_normal_update_returns_local_ack_and_persists_checkpoint(
     monkeypatch,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_update_forward", monkeypatch)
@@ -621,11 +619,8 @@ def test_preprocessor_pipe_normal_update_forwards_with_state_and_persists_checkp
         )
     )
 
-    assert result == {"ok": True}
-    assert len(forwarded_payloads) == 1
-    first_messages = forwarded_payloads[0]["messages"]
-    assert isinstance(first_messages, list)
-    assert first_messages[0] == {"role": "system", "content": "[[cc_state]]\nProhibit: peanuts"}
+    assert result == "State updated: Prohibit peanuts."
+    assert len(forwarded_payloads) == 0
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
@@ -644,14 +639,14 @@ def test_preprocessor_pipe_normal_update_forwards_with_state_and_persists_checkp
     )
 
     assert result == "State updated: Removed policy peanuts."
-    assert len(forwarded_payloads) == 1
+    assert len(forwarded_payloads) == 0
 
     checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert checkpoint["pending"] is None
     assert checkpoint["authoritative_state"]["policies"] == {}
 
 
-def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shapes(
+def test_preprocessor_pipe_update_directives_return_local_ack_across_shapes(
     monkeypatch,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_update_shapes", monkeypatch)
@@ -680,7 +675,7 @@ def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shap
             __chat_id__="chat-use",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Use docker."
 
     result = asyncio.run(
         pipe.pipe(
@@ -693,7 +688,7 @@ def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shap
             __chat_id__="chat-prohibit",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Prohibit docker."
 
     result = asyncio.run(
         pipe.pipe(
@@ -703,7 +698,7 @@ def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shap
             __chat_id__="chat-idempotent",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Use docker."
 
     result = asyncio.run(
         pipe.pipe(
@@ -716,7 +711,7 @@ def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shap
             __chat_id__="chat-replace",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Use docker."
 
     result = asyncio.run(
         pipe.pipe(
@@ -729,7 +724,7 @@ def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shap
             __chat_id__="chat-replace",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Use kubectl."
 
     result = asyncio.run(
         pipe.pipe(
@@ -742,7 +737,7 @@ def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shap
             __chat_id__="chat-premise",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated."
 
     result = asyncio.run(
         pipe.pipe(
@@ -752,7 +747,7 @@ def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shap
             __chat_id__="chat-idempotent",
         )
     )
-    assert result == {"ok": True}
+    assert result == "State updated: Use docker."
 
     result = asyncio.run(
         pipe.pipe(
@@ -765,16 +760,8 @@ def test_preprocessor_pipe_update_forwarding_injects_state_across_directive_shap
             __chat_id__="chat-replace-noop",
         )
     )
-    assert result == {"ok": True}
-    assert len(forwarded_payloads) == 8
-    assert all(
-        isinstance(payload.get("messages"), list)
-        and isinstance(payload["messages"][0], dict)
-        and payload["messages"][0].get("role") == "system"
-        and isinstance(payload["messages"][0].get("content"), str)
-        and payload["messages"][0]["content"].startswith("[[cc_state]]")
-        for payload in forwarded_payloads
-    )
+    assert result == "State updated: Use docker."
+    assert len(forwarded_payloads) == 0
 
 
 @pytest.mark.parametrize(
@@ -854,16 +841,10 @@ def test_preprocessor_pipe_bypasses_preprocess_while_pending(
         )
     )
 
-    assert result == {"ok": True}
+    assert result == "State updated."
     assert engine.step_inputs == [confirmation]
     assert module._CHECKPOINTS_BY_CHAT_KEY["chat-pending"] == "ckpt-out"
-    assert len(forwarded_payloads) == 1
-    first_messages = forwarded_payloads[0]["messages"]
-    assert isinstance(first_messages, list)
-    assert isinstance(first_messages[0], dict)
-    assert first_messages[0].get("role") == "system"
-    assert isinstance(first_messages[0].get("content"), str)
-    assert first_messages[0]["content"].startswith("[[cc_state]]")
+    assert len(forwarded_payloads) == 0
 
 
 @pytest.mark.parametrize(
@@ -935,7 +916,7 @@ def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
             __chat_id__=chat_key,
         )
     )
-    assert resumed == {"ok": True}
+    assert resumed == "State updated."
     resumed_engine = cast(Any, module._ENGINES_BY_CHAT_KEY[chat_key])
     assert resumed_engine.state == {
         "premise": None,
@@ -944,13 +925,7 @@ def test_preprocessor_pipe_checkpoint_resume_yes_no_end_to_end(
     }
     resumed_checkpoint = json.loads(module._CHECKPOINTS_BY_CHAT_KEY[chat_key])
     assert resumed_checkpoint["pending"] is None
-    assert len(forwarded_payloads) == 1
-    resumed_messages = forwarded_payloads[0]["messages"]
-    assert isinstance(resumed_messages, list)
-    assert isinstance(resumed_messages[0], dict)
-    assert resumed_messages[0].get("role") == "system"
-    assert isinstance(resumed_messages[0].get("content"), str)
-    assert resumed_messages[0]["content"].startswith("[[cc_state]]")
+    assert len(forwarded_payloads) == 0
 
 
 @pytest.mark.parametrize(
@@ -1173,17 +1148,17 @@ def test_preprocessor_pipe_trace_on_appends_trace_to_user_visible_output(monkeyp
             __chat_id__="chat-preproc-trace-on",
         )
     )
-    assert isinstance(result, dict)
-    content = result["choices"][0]["message"]["content"]
-    assert "downstream" in content
+    assert isinstance(result, str)
+    content = result
+    assert content.startswith("State updated: Prohibit peanuts.")
     assert "Context Compiler trace" in content
     assert "decision kind: update" in content
     assert "preprocessor output:" not in content
-    assert "downstream LLM call: yes" in content
+    assert "downstream LLM call: no" in content
     assert "state change:" in content
     assert "active state:" in content
-    assert "state injected: prohibit peanuts" in content
-    assert "\n\nstate injected: prohibit peanuts" in content
+    assert "state injected: no" in content
+    assert "\n\nstate injected: no" in content
 
 
 def test_preprocessor_pipe_trace_on_passthrough_appends_trace_to_llm_content(monkeypatch) -> None:
@@ -1381,18 +1356,13 @@ def test_preprocessor_pipe_trace_appends_on_object_response_for_passthrough_and_
             __chat_id__="chat-preproc-object-update",
         )
     )
-    update_content = update.choices[0].message.content
+    assert isinstance(update, str)
+    update_content = update
     assert "Context Compiler trace" in update_content
     assert "decision kind: update" in update_content
-    assert "downstream LLM call: yes" in update_content
-    assert "state injected:" in update_content
-    assert any(
-        isinstance(payload.get("messages"), list)
-        and isinstance(payload["messages"][0], dict)
-        and isinstance(payload["messages"][0].get("content"), str)
-        and payload["messages"][0]["content"].startswith("[[cc_state]]")
-        for payload in forwarded_payloads
-    )
+    assert "downstream LLM call: no" in update_content
+    assert "state injected: no" in update_content
+    assert len(forwarded_payloads) == 2
 
 
 def test_preprocessor_pipe_trace_appends_on_streaming_response_wrapper_passthrough_and_update(
@@ -1460,18 +1430,11 @@ def test_preprocessor_pipe_trace_appends_on_streaming_response_wrapper_passthrou
             __chat_id__="chat-preproc-stream-wrapper-update",
         )
     )
-    update_stream = asyncio.run(_collect_stream(update))
-    assert "data: [DONE]" in update_stream
-    assert "Context Compiler trace" in update_stream
-    assert "decision kind: update" in update_stream
-    assert "state injected:" in update_stream
-    assert any(
-        isinstance(payload.get("messages"), list)
-        and isinstance(payload["messages"][0], dict)
-        and isinstance(payload["messages"][0].get("content"), str)
-        and payload["messages"][0]["content"].startswith("[[cc_state]]")
-        for payload in forwarded_payloads
-    )
+    assert isinstance(update, str)
+    assert "Context Compiler trace" in update
+    assert "decision kind: update" in update
+    assert "state injected: no" in update
+    assert len(forwarded_payloads) == 2
 
 
 @pytest.mark.parametrize(
@@ -1551,7 +1514,7 @@ def test_preprocessor_pipe_trace_update_clear_reset_paths_single_and_consistent(
     assert "downstream LLM call: yes" not in content
     assert "active state: none" in content
     assert "state injected: no" in content
-    assert downstream_calls == len(steps) - 1
+    assert downstream_calls == 0
 
 
 def test_preprocessor_pipe_clear_state_trace_not_duplicated_when_model_echoes_history(
@@ -1601,8 +1564,8 @@ def test_preprocessor_pipe_clear_state_trace_not_duplicated_when_model_echoes_hi
             __chat_id__=chat_id,
         )
     )
-    assert isinstance(first, dict)
-    first_content = first["choices"][0]["message"]["content"]
+    assert isinstance(first, str)
+    first_content = first
     assert first_content.count("Context Compiler trace") == 1
 
     second = asyncio.run(
@@ -1700,7 +1663,7 @@ def test_preprocessor_pipe_clear_state_strips_preexisting_contradictory_trace_fr
     assert "downstream LLM call: yes" not in second_content
 
 
-def test_preprocessor_pipe_update_trace_and_injection_when_heuristic_emits_directive(
+def test_preprocessor_pipe_update_trace_local_ack_when_heuristic_emits_directive(
     monkeypatch,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_nl_use_docker", monkeypatch)
@@ -1746,23 +1709,18 @@ def test_preprocessor_pipe_update_trace_and_injection_when_heuristic_emits_direc
             __chat_id__="chat-preproc-nl-use-docker",
         )
     )
-    assert isinstance(result, dict)
-    content = result["choices"][0]["message"]["content"]
+    assert isinstance(result, str)
+    content = result
     assert content.count("Context Compiler trace") == 1
     assert "decision kind: update" in content
-    assert "downstream LLM call: yes" in content
-    assert "downstream LLM call: no" not in content
+    assert "downstream LLM call: no" in content
+    assert "downstream LLM call: yes" not in content
     assert "active state: use docker" in content
-    assert "state injected: use docker" in content
-    assert any(
-        isinstance(payload.get("messages"), list)
-        and isinstance(payload["messages"][0], dict)
-        and payload["messages"][0].get("content") == "[[cc_state]]\nUse: docker"
-        for payload in forwarded_payloads
-    )
+    assert "state injected: no" in content
+    assert len(forwarded_payloads) == 0
 
 
-def test_preprocessor_pipe_replacement_update_trace_and_injection_when_heuristic_emits_directive(
+def test_preprocessor_pipe_replacement_update_trace_local_ack_when_heuristic_emits_directive(
     monkeypatch,
 ) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_nl_replace", monkeypatch)
@@ -1823,14 +1781,14 @@ def test_preprocessor_pipe_replacement_update_trace_and_injection_when_heuristic
             __chat_id__=chat_id,
         )
     )
-    assert isinstance(result, dict)
-    content = result["choices"][0]["message"]["content"]
+    assert isinstance(result, str)
+    content = result
     assert content.count("Context Compiler trace") == 1
     assert "decision kind: update" in content
-    assert "downstream LLM call: yes" in content
-    assert "downstream LLM call: no" not in content
+    assert "downstream LLM call: no" in content
+    assert "downstream LLM call: yes" not in content
     assert "active state: use podman" in content
-    assert "state injected: use podman" in content
+    assert "state injected: no" in content
 
 
 def test_preprocessor_pipe_ambiguous_text_passthrough_trace_streaming(monkeypatch) -> None:


### PR DESCRIPTION
## What changed
- Updated both OpenWebUI example pipes to return deterministic local acknowledgements for directive-only `update` decisions.
- Stopped downstream LLM calls on those `update` paths.
- Kept `passthrough` behavior unchanged (still forwards).
- Kept `clarify` behavior unchanged (still deterministic and no downstream call).
- Preserved useful trace output, now showing `downstream LLM call: no` for update acknowledgements.
- Updated OpenWebUI integration tests to match the new update behavior.
- Updated the OpenWebUI integration README note to match the new behavior.

## Why this was needed
- Reduces directive-update response spam from downstream model calls.
- Keeps directive updates deterministic and user-facing in the host layer.
- Preserves engine authority and avoids changing engine semantics.