### PR TITLE
test: lock preprocessor boundary fixtures

### DIFF
--- a/docs/llm-preprocessor.md
+++ b/docs/llm-preprocessor.md
@@ -42,6 +42,19 @@ The preprocessor is best-effort and intentionally conservative. Ambiguous,
 reported, quoted, or mixed-intent inputs may still require abstention or host
 clarification behavior.
 
+Boundary policy (explicit):
+
+- Whole-message canonicalization only.
+- At most one canonical directive may be emitted; otherwise abstain.
+- Do not extract directives from surrounding prose, questions, or reporting.
+- Do not split sentences or mine multi-line batches for commands.
+- Do not extract from markdown/code blocks or quoted/reported text.
+- Do not perform broad semantic rewrites.
+- Prefer false negatives over false positive state mutation.
+
+Natural-language state proposal workflows should be handled by explicit host
+assist/proposal flows, not implicit preprocessing.
+
 ## Status
 
 This preprocessor surface is experimental and may evolve independently of the

--- a/experimental/preprocessor/README.md
+++ b/experimental/preprocessor/README.md
@@ -58,6 +58,19 @@ Raw preprocessor/LLM outputs must not be passed directly to the compiler.
 The preprocessor does not expand directive grammar. It may emit only validated
 canonical directives accepted by the compiler.
 
+Conservative boundary policy:
+
+- Whole-message canonicalization only (no directive mining from prose).
+- Emit at most one canonical directive; otherwise abstain.
+- No sentence splitting or hidden multi-line extraction.
+- No mixed directive + task extraction.
+- No markdown/code-block extraction.
+- No broad natural-language semantic rewriting.
+- Prefer false negatives over false positives.
+
+If you need natural-language proposal/orchestration behavior, use an explicit
+host-side assist workflow with preview/diff/confirmation, not this preprocessor.
+
 ## Safe usage pattern
 
 1. Run `preprocess_heuristic(message)`.

--- a/tests/fixtures/preprocessor/canonical-directive-case-normalized-use-docker.json
+++ b/tests/fixtures/preprocessor/canonical-directive-case-normalized-use-docker.json
@@ -1,0 +1,8 @@
+{
+  "name": "canonical-directive-case-normalized-use-docker",
+  "input": "Use Docker",
+  "expected": {
+    "classification": "directive",
+    "output": "use docker"
+  }
+}

--- a/tests/fixtures/preprocessor/canonical-directive-whitespace-collapsed-use-docker.json
+++ b/tests/fixtures/preprocessor/canonical-directive-whitespace-collapsed-use-docker.json
@@ -1,0 +1,8 @@
+{
+  "name": "canonical-directive-whitespace-collapsed-use-docker",
+  "input": "  use    docker  ",
+  "expected": {
+    "classification": "directive",
+    "output": "use docker"
+  }
+}

--- a/tests/fixtures/preprocessor/fenced-code-block-directive-unknown.json
+++ b/tests/fixtures/preprocessor/fenced-code-block-directive-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "fenced-code-block-directive-unknown",
+  "input": "```\nuse docker\n```",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/inline-prose-code-directive-unknown.json
+++ b/tests/fixtures/preprocessor/inline-prose-code-directive-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "inline-prose-code-directive-unknown",
+  "input": "the command is `use docker`",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/mixed-directive-task-unknown.json
+++ b/tests/fixtures/preprocessor/mixed-directive-task-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "mixed-directive-task-unknown",
+  "input": "use docker and explain why",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/multiline-multi-directive-unknown.json
+++ b/tests/fixtures/preprocessor/multiline-multi-directive-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "multiline-multi-directive-unknown",
+  "input": "clear premise\nreset policies",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/nested-wrapper-clear-state-unknown.json
+++ b/tests/fixtures/preprocessor/nested-wrapper-clear-state-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "nested-wrapper-clear-state-unknown",
+  "input": "([clear state])",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/question-can-you-use-docker-unknown.json
+++ b/tests/fixtures/preprocessor/question-can-you-use-docker-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "question-can-you-use-docker-unknown",
+  "input": "can you use docker?",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/reported-speech-docs-say-unknown.json
+++ b/tests/fixtures/preprocessor/reported-speech-docs-say-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "reported-speech-docs-say-unknown",
+  "input": "the docs say \"use docker\"",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/sentence-adjacent-directive-unknown.json
+++ b/tests/fixtures/preprocessor/sentence-adjacent-directive-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "sentence-adjacent-directive-unknown",
+  "input": "ok. prohibit peanuts",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}


### PR DESCRIPTION
## What changed

- Added conservative preprocessor guard fixtures for abstain-only boundary cases (multiline, sentence-adjacent, fenced code block, inline prose/code, reported speech, mixed directive+task, conversational question, nested wrappers).
- Added positive fixtures for existing safe canonicalizations (case normalization, whitespace collapse).
- Updated preprocessor docs to explicitly define whole-message canonicalization boundaries and abstain-first policy.

## Why

- Lock expected 0.7 conservative preprocessor behavior with explicit fixture coverage.
- Prevent boundary drift by documenting and testing abstain behavior for directive-like text embedded in prose/mixed-intent formats.
- Keep preprocessor scope narrow (format canonicalization only) without expanding natural-language parsing semantics.
- This resolves the heuristic boundary portion of #77 by fixture-locking conservative abstain behavior; fallback-boundary hardening remains follow-up work.

Refs #77

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
