### PR TITLE
fix: harden fallback boundary validation

### DIFF
--- a/docs/llm-preprocessor.md
+++ b/docs/llm-preprocessor.md
@@ -50,6 +50,8 @@ Boundary policy (explicit):
 - Do not split sentences or mine multi-line batches for commands.
 - Do not extract from markdown/code blocks or quoted/reported text.
 - Do not perform broad semantic rewrites.
+- Preserve quoted payload tokens in canonical directives; do not silently strip
+  payload quotes (for example `use "docker"` remains quoted).
 - Prefer false negatives over false positive state mutation.
 
 Natural-language state proposal workflows should be handled by explicit host

--- a/experimental/preprocessor/README.md
+++ b/experimental/preprocessor/README.md
@@ -67,6 +67,8 @@ Conservative boundary policy:
 - No markdown/code-block extraction.
 - No broad natural-language semantic rewriting.
 - Prefer false negatives over false positives.
+- Quoted payload tokens inside an otherwise canonical directive (for example
+  `use "docker"`) are preserved as-is; they are not silently unquoted.
 
 If you need natural-language proposal/orchestration behavior, use an explicit
 host-side assist workflow with preview/diff/confirmation, not this preprocessor.

--- a/experimental/preprocessor/output_validation.py
+++ b/experimental/preprocessor/output_validation.py
@@ -35,6 +35,29 @@ _MULTI_CANDIDATE_DIRECTIVE_PATTERN = re.compile(
 )
 _SET_PREMISE_TO_NEAR_MISS_PATTERN = re.compile(r"^set premise to\s+(.+\S)\s*$")
 _CHANGE_PREMISE_MISSING_TO_NEAR_MISS_PATTERN = re.compile(r"^change premise\s+(?!to\b)(.+\S)\s*$")
+_DIRECTIVE_CUE_PATTERN = re.compile(
+    r"\b(set premise|change premise|use|prohibit|remove policy|clear premise|"
+    r"reset policies|clear state)\b"
+)
+_META_PREFIX_PATTERN = re.compile(
+    r"^\s*(?:example:|for example\b|the command is\b|(?:i|he|she|they|docs?|documentation)\s+"
+    r"(?:say|says|said)\b)"
+)
+_MULTI_SEGMENT_PATTERN = re.compile(
+    r"^\s*(?:use|prohibit|remove policy|set premise|change premise to|clear premise|"
+    r"reset policies|clear state)\b"
+    r".*\b(?:because|then continue|and)\b"
+)
+_SENTENCE_ADJACENT_DIRECTIVE_PATTERN = re.compile(
+    r"^[^!?]*\.\s*(?:set premise|change premise|use|prohibit|remove policy|clear premise|"
+    r"reset policies|clear state)\b"
+)
+_PUNCTUATION_TRIM_PATTERN = re.compile(r"[.!]+\s*$")
+_REPORTED_SPEECH_QUOTE_PATTERN = re.compile(r"\b(?:say|says|said|docs?|documentation)\b")
+_WRAPPER_PAIRS = {
+    ("(", ")"),
+    ("[", "]"),
+}
 
 
 def _unknown() -> PreprocessorValidationResult:
@@ -61,9 +84,12 @@ def _contains_multiple_candidate_directives(text: str) -> bool:
 
 
 def _is_safe_fallback_directive_rewrite(source_input: str, directive_output: str) -> bool:
-    """Reject fallback rewrites that bypass engine-owned premise clarify behavior."""
+    """Reject fallback rewrites that bypass strict whole-message boundaries."""
     source = re.sub(r"\s+", " ", source_input.strip().lower())
     directive = re.sub(r"\s+", " ", directive_output.strip().lower())
+
+    if _source_input_is_structured_contract_directive(source_input, directive_output):
+        return True
 
     set_premise_to_match = _SET_PREMISE_TO_NEAR_MISS_PATTERN.fullmatch(source)
     if set_premise_to_match is not None:
@@ -77,7 +103,103 @@ def _is_safe_fallback_directive_rewrite(source_input: str, directive_output: str
         if directive == f"change premise to {payload}":
             return False
 
-    return True
+    if _is_boundary_unsafe_source_input(source_input):
+        return False
+
+    normalized_source = _normalize_source_candidate(source_input)
+    if not _is_allowed_directive(normalized_source):
+        return False
+
+    return directive == normalized_source
+
+
+def _strip_terminal_punctuation(message: str) -> str:
+    return _PUNCTUATION_TRIM_PATTERN.sub("", message).strip()
+
+
+def _strip_exact_wrapper(message: str) -> str:
+    stripped = message.strip()
+    if len(stripped) < 2:
+        return stripped
+    opener = stripped[0]
+    closer = stripped[-1]
+    if (opener, closer) not in _WRAPPER_PAIRS:
+        return stripped
+    inner = stripped[1:-1].strip()
+    if not inner:
+        return stripped
+    return inner
+
+
+def _normalize_source_candidate(source_input: str) -> str:
+    stripped = source_input.strip()
+    no_punct = _strip_terminal_punctuation(stripped)
+    unwrapped = _strip_exact_wrapper(no_punct)
+    return re.sub(r"\s+", " ", unwrapped).strip().lower()
+
+
+def _is_boundary_unsafe_source_input(source_input: str) -> bool:
+    lower = source_input.lower()
+    normalized = re.sub(r"\s+", " ", source_input.strip().lower())
+
+    if "\n" in source_input or "\r" in source_input:
+        return True
+
+    if "```" in source_input or "~~~" in source_input:
+        return True
+
+    if "`" in source_input and _DIRECTIVE_CUE_PATTERN.search(normalized):
+        return True
+
+    if _META_PREFIX_PATTERN.match(normalized):
+        return True
+
+    if "?" in source_input and _DIRECTIVE_CUE_PATTERN.search(normalized):
+        return True
+
+    if _MULTI_SEGMENT_PATTERN.match(normalized):
+        return True
+
+    if _MULTI_CANDIDATE_DIRECTIVE_PATTERN.search(normalized):
+        return True
+
+    if _SENTENCE_ADJACENT_DIRECTIVE_PATTERN.match(normalized):
+        return True
+
+    if '"' in source_input and _REPORTED_SPEECH_QUOTE_PATTERN.search(lower):
+        return True
+
+    return bool(
+        _DIRECTIVE_CUE_PATTERN.search(normalized)
+        and not _is_allowed_directive(_normalize_source_candidate(source_input))
+    )
+
+
+def _source_input_is_structured_contract_directive(
+    source_input: str, directive_output: str
+) -> bool:
+    stripped = source_input.strip()
+    if not stripped or stripped[0] not in {"{", "["}:
+        return False
+
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return False
+
+    if not isinstance(parsed, dict):
+        return False
+
+    if set(parsed.keys()) != {"classification", "output"}:
+        return False
+
+    classification = parsed.get("classification")
+    output = parsed.get("output")
+    return (
+        classification == "directive"
+        and isinstance(output, str)
+        and output.strip().lower() == directive_output.strip().lower()
+    )
 
 
 def _validate_structured_output(raw_output: object) -> PreprocessorValidationResult:

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -103,15 +103,29 @@ They are exercised by [`tests/test_preprocessor_conformance.py`](../test_preproc
 
 Portable fixture scope:
 - deterministic heuristic and validator input/output contracts intended for cross-language parity
+- source-aware parse contract fixtures (`parse_preprocessor_output(raw_output, source_input=...)`) for fallback-boundary parity
 
 Python-local test scope:
 - property/fuzz invariants and filesystem/template behaviors (for example `render_prompt` file-loading behavior) remain in Python unit/property tests and are not portable fixture requirements.
+
+Supported `preprocessor/` fixture kinds:
+
+* `heuristic`
+  * fields: `input`, `expected`
+  * asserts normalized heuristic classification/output
+* `validator`
+  * fields: `raw_output`, optional `source_input`, `expected`
+  * asserts `validate_preprocessor_output(...)` classification/output
+* `parse`
+  * fields: `raw_output`, optional `source_input`, `expected_parsed`
+  * asserts `parse_preprocessor_output(...)` return (`string` or `null`)
 
 They validate:
 
 * heuristic classification determinism
 * directive extraction and normalization
 * output validation boundaries
+* source-aware fallback parse boundaries
 * reject/unknown safety handling for ambiguous and near-miss inputs
 
 ## Test runner

--- a/tests/fixtures/preprocessor/canonical-directive-quoted-payload-use-docker.json
+++ b/tests/fixtures/preprocessor/canonical-directive-quoted-payload-use-docker.json
@@ -1,0 +1,8 @@
+{
+  "name": "canonical-directive-quoted-payload-use-docker",
+  "input": "use \"docker\"",
+  "expected": {
+    "classification": "directive",
+    "output": "use \"docker\""
+  }
+}

--- a/tests/fixtures/preprocessor/parse-source-input-fenced-code-rejected.json
+++ b/tests/fixtures/preprocessor/parse-source-input-fenced-code-rejected.json
@@ -1,0 +1,7 @@
+{
+  "name": "parse-source-input-fenced-code-rejected",
+  "kind": "parse",
+  "source_input": "```\nuse docker\n```",
+  "raw_output": "use docker",
+  "expected_parsed": null
+}

--- a/tests/fixtures/preprocessor/parse-source-input-inline-prose-code-rejected.json
+++ b/tests/fixtures/preprocessor/parse-source-input-inline-prose-code-rejected.json
@@ -1,0 +1,7 @@
+{
+  "name": "parse-source-input-inline-prose-code-rejected",
+  "kind": "parse",
+  "source_input": "the command is `use docker`",
+  "raw_output": "use docker",
+  "expected_parsed": null
+}

--- a/tests/fixtures/preprocessor/parse-source-input-mixed-directive-task-rejected.json
+++ b/tests/fixtures/preprocessor/parse-source-input-mixed-directive-task-rejected.json
@@ -1,0 +1,7 @@
+{
+  "name": "parse-source-input-mixed-directive-task-rejected",
+  "kind": "parse",
+  "source_input": "use docker and explain why",
+  "raw_output": "use docker",
+  "expected_parsed": null
+}

--- a/tests/fixtures/preprocessor/parse-source-input-multiline-rejected.json
+++ b/tests/fixtures/preprocessor/parse-source-input-multiline-rejected.json
@@ -1,0 +1,7 @@
+{
+  "name": "parse-source-input-multiline-rejected",
+  "kind": "parse",
+  "source_input": "clear premise\nreset policies",
+  "raw_output": "clear state",
+  "expected_parsed": null
+}

--- a/tests/fixtures/preprocessor/parse-source-input-question-form-rejected.json
+++ b/tests/fixtures/preprocessor/parse-source-input-question-form-rejected.json
@@ -1,0 +1,7 @@
+{
+  "name": "parse-source-input-question-form-rejected",
+  "kind": "parse",
+  "source_input": "can you use docker?",
+  "raw_output": "use docker",
+  "expected_parsed": null
+}

--- a/tests/fixtures/preprocessor/parse-source-input-quoted-payload-locked.json
+++ b/tests/fixtures/preprocessor/parse-source-input-quoted-payload-locked.json
@@ -1,0 +1,7 @@
+{
+  "name": "parse-source-input-quoted-payload-locked",
+  "kind": "parse",
+  "source_input": "use \"docker\"",
+  "raw_output": "use \"docker\"",
+  "expected_parsed": "use \"docker\""
+}

--- a/tests/fixtures/preprocessor/parse-source-input-reported-speech-rejected.json
+++ b/tests/fixtures/preprocessor/parse-source-input-reported-speech-rejected.json
@@ -1,0 +1,7 @@
+{
+  "name": "parse-source-input-reported-speech-rejected",
+  "kind": "parse",
+  "source_input": "the docs say \"use docker\"",
+  "raw_output": "use docker",
+  "expected_parsed": null
+}

--- a/tests/fixtures/preprocessor/parse-source-input-safe-canonical-use-docker.json
+++ b/tests/fixtures/preprocessor/parse-source-input-safe-canonical-use-docker.json
@@ -1,0 +1,7 @@
+{
+  "name": "parse-source-input-safe-canonical-use-docker",
+  "kind": "parse",
+  "source_input": "use docker",
+  "raw_output": "use docker",
+  "expected_parsed": "use docker"
+}

--- a/tests/fixtures/preprocessor/parse-source-input-safe-canonicalization-use-docker.json
+++ b/tests/fixtures/preprocessor/parse-source-input-safe-canonicalization-use-docker.json
@@ -1,0 +1,7 @@
+{
+  "name": "parse-source-input-safe-canonicalization-use-docker",
+  "kind": "parse",
+  "source_input": "Use   Docker",
+  "raw_output": "use docker",
+  "expected_parsed": "use docker"
+}

--- a/tests/fixtures/preprocessor/validator-source-input-allow-safe-directive.json
+++ b/tests/fixtures/preprocessor/validator-source-input-allow-safe-directive.json
@@ -4,7 +4,7 @@
   "raw_output": "prohibit peanuts",
   "source_input": "what is a simple curry recipe?",
   "expected": {
-    "classification": "directive",
-    "output": "prohibit peanuts"
+    "classification": "unknown",
+    "output": null
   }
 }

--- a/tests/test_litellm_checkpoint_integration.py
+++ b/tests/test_litellm_checkpoint_integration.py
@@ -711,3 +711,57 @@ def test_litellm_with_preprocessor_trace_on_passthrough_includes_trace() -> None
     assert "Context Compiler trace" in result
     assert "decision kind: passthrough" in result
     assert "downstream LLM call: yes" in result
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    [
+        "ok. prohibit peanuts",
+        "```\nuse docker\n```",
+        "the command is `use docker`",
+        'the docs say "use docker"',
+        "can you use docker?",
+    ],
+)
+def test_litellm_with_preprocessor_fallback_boundary_unsafe_sources_do_not_mutate_state(
+    monkeypatch: pytest.MonkeyPatch, user_input: str
+) -> None:
+    module = _load_module(
+        "litellm_with_preprocessor_fallback_boundary_unsafe",
+        Path("examples/integrations/litellm/with_preprocessor.py"),
+    )
+
+    class _Config:
+        mode = "openai"
+        api_key = "test-key"
+        base_url = "http://example.invalid"
+        model = "base-model"
+        source = "test"
+
+    completion_calls: list[str] = []
+
+    def _completion(**kwargs: object) -> dict[str, object]:
+        model = str(kwargs.get("model", ""))
+        completion_calls.append(model)
+        if model == "prep-model":
+            return {"choices": [{"message": {"content": "use docker"}}]}
+        return {"choices": [{"message": {"content": "downstream-ok"}}]}
+
+    monkeypatch.setenv("PREPROCESSOR_MODEL", "prep-model")
+    monkeypatch.setattr(module, "resolve_provider_config", lambda **_kwargs: _Config())
+    monkeypatch.setattr(module, "_get_litellm_completion", lambda: _completion)
+    monkeypatch.setattr(module, "render_prompt", lambda *_args, **_kwargs: "prompt")
+    monkeypatch.setattr(
+        module,
+        "preprocess_heuristic",
+        lambda _text: {"outcome": "unknown", "directive": None, "rule_id": "test"},
+    )
+
+    engine = create_engine()
+    initial_state = dict(engine.state["policies"])
+
+    result = module.handle_turn(user_input, engine)
+
+    assert result == "downstream-ok"
+    assert engine.state["policies"] == initial_state
+    assert completion_calls == ["prep-model", "base-model"]

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -1085,6 +1085,60 @@ def test_preprocessor_pipe_near_miss_directives_return_deterministic_clarify_wit
     assert downstream_calls == 0
 
 
+@pytest.mark.parametrize(
+    "user_input",
+    [
+        "ok. prohibit peanuts",
+        "```\nuse docker\n```",
+        "the command is `use docker`",
+        'the docs say "use docker"',
+        "can you use docker?",
+    ],
+)
+def test_preprocessor_pipe_fallback_boundary_unsafe_sources_do_not_mutate_state(
+    monkeypatch, user_input: str
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_fallback_boundary_unsafe", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    calls: list[str] = []
+
+    async def _chat_completion(_: object, payload: dict[str, Any], __: object) -> dict[str, object]:
+        model = str(payload.get("model", ""))
+        calls.append(model)
+        if model == "prep-model":
+            return {"choices": [{"message": {"content": "use docker"}}]}
+        return {"ok": True}
+
+    monkeypatch.setattr(module, "generate_chat_completion", _chat_completion)
+    monkeypatch.setattr(module, "render_prompt", lambda *_args, **_kwargs: "prompt")
+    monkeypatch.setattr(
+        module,
+        "preprocess_heuristic",
+        lambda _text: {"outcome": "unknown", "directive": None, "rule_id": "test"},
+    )
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+
+    chat_id = "chat-fallback-boundary-unsafe"
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": user_input}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__=chat_id,
+        )
+    )
+
+    assert result == {"ok": True}
+    assert calls == ["prep-model", "base-model"]
+    assert chat_id in module._ENGINES_BY_CHAT_KEY
+    assert module._ENGINES_BY_CHAT_KEY[chat_id].state["policies"] == {}
+
+
 def test_preprocessor_pipe_trace_off_keeps_existing_response_shape(monkeypatch) -> None:
     module = _load_module_with_openwebui_stubs("owui_preproc_trace_off_shape", monkeypatch)
     module._ENGINES_BY_CHAT_KEY.clear()

--- a/tests/test_preprocessor_conformance.py
+++ b/tests/test_preprocessor_conformance.py
@@ -3,7 +3,10 @@ import re
 from pathlib import Path
 
 from experimental.preprocessor.heuristic_preprocessor import preprocess_heuristic
-from experimental.preprocessor.output_validation import validate_preprocessor_output
+from experimental.preprocessor.output_validation import (
+    parse_preprocessor_output,
+    validate_preprocessor_output,
+)
 
 _PREPROCESSOR_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "preprocessor"
 
@@ -46,6 +49,10 @@ def _normalize_validator_result(
     }
 
 
+def _normalize_parse_result(raw_output: object, source_input: str | None = None) -> str | None:
+    return parse_preprocessor_output(raw_output, source_input=source_input)
+
+
 def _derived_risky_rewrite_candidates(source_input: str) -> list[str]:
     normalized = re.sub(r"\s+", " ", source_input.strip().lower())
     candidates: list[str] = []
@@ -69,13 +76,12 @@ def test_preprocessor_conformance_fixtures() -> None:
         if path.name.startswith("public-api-"):
             continue
 
-        expected = fixture.get("expected")
         fixture_name = fixture.get("name", path.name)
         kind = fixture.get("kind", "heuristic")
 
-        assert isinstance(expected, dict), fixture_name
-
         if kind == "heuristic":
+            expected = fixture.get("expected")
+            assert isinstance(expected, dict), fixture_name
             input_text = fixture.get("input")
             assert isinstance(input_text, str), fixture_name
 
@@ -86,17 +92,31 @@ def test_preprocessor_conformance_fixtures() -> None:
             assert first == expected, fixture_name
             continue
 
-        assert kind == "validator", fixture_name
         assert "raw_output" in fixture, fixture_name
         raw_output = fixture["raw_output"]
         source_input_obj = fixture.get("source_input")
         source_input = source_input_obj if isinstance(source_input_obj, str) else None
 
+        if kind == "validator":
+            expected = fixture.get("expected")
+            assert isinstance(expected, dict), fixture_name
+            # Deterministic replay check.
+            first = _normalize_validator_result(raw_output, source_input=source_input)
+            second = _normalize_validator_result(raw_output, source_input=source_input)
+            assert first == second, fixture_name
+            assert first == expected, fixture_name
+            continue
+
+        assert kind == "parse", fixture_name
+        assert "expected_parsed" in fixture, fixture_name
+        expected_parsed = fixture["expected_parsed"]
+        assert isinstance(expected_parsed, str) or expected_parsed is None, fixture_name
+
         # Deterministic replay check.
-        first = _normalize_validator_result(raw_output, source_input=source_input)
-        second = _normalize_validator_result(raw_output, source_input=source_input)
-        assert first == second, fixture_name
-        assert first == expected, fixture_name
+        first_parsed = _normalize_parse_result(raw_output, source_input=source_input)
+        second_parsed = _normalize_parse_result(raw_output, source_input=source_input)
+        assert first_parsed == second_parsed, fixture_name
+        assert first_parsed == expected_parsed, fixture_name
 
 
 def test_engine_owned_near_misses_are_reject_only_for_fallback_rewrites() -> None:

--- a/tests/test_preprocessor_output_validation.py
+++ b/tests/test_preprocessor_output_validation.py
@@ -159,6 +159,56 @@ def test_validation_with_source_input_allows_other_directives() -> None:
         "use coconut milk",
         source_input="what is a simple curry recipe?",
     ) == {
+        "classification": "unknown",
+        "output": None,
+    }
+
+
+def test_validation_with_source_input_rejects_boundary_unsafe_fallback_rewrites() -> None:
+    cases = [
+        ("ok. prohibit peanuts", "prohibit peanuts"),
+        ("clear premise\nreset policies", "clear premise"),
+        ("```\nuse docker\n```", "use docker"),
+        ("the command is `use docker`", "use docker"),
+        ('the docs say "use docker"', "use docker"),
+        ("use docker and explain why", "use docker"),
+        ("can you use docker?", "use docker"),
+    ]
+    for source_input, fallback_output in cases:
+        assert validate_preprocessor_output(
+            fallback_output,
+            source_input=source_input,
+        ) == {
+            "classification": "unknown",
+            "output": None,
+        }
+
+
+def test_validation_with_source_input_preserves_safe_whole_message_canonicalization() -> None:
+    cases = [
+        ("Use Docker", "use docker"),
+        ("  use    docker  ", "use docker"),
+        ("clear state.", "clear state"),
+        ("reset policies!", "reset policies"),
+        ("(clear state)", "clear state"),
+        ("[clear state]", "clear state"),
+        ('use "docker"', 'use "docker"'),
+    ]
+    for source_input, fallback_output in cases:
+        assert validate_preprocessor_output(
+            fallback_output,
+            source_input=source_input,
+        ) == {
+            "classification": "directive",
+            "output": fallback_output,
+        }
+
+
+def test_validation_with_source_input_allows_strict_structured_contract_self_input() -> None:
+    assert validate_preprocessor_output(
+        '{"classification":"directive","output":"prohibit peanuts"}',
+        source_input='{"classification":"directive","output":"prohibit peanuts"}',
+    ) == {
         "classification": "directive",
-        "output": "use coconut milk",
+        "output": "prohibit peanuts",
     }

--- a/tests/test_preprocessor_validator_properties.py
+++ b/tests/test_preprocessor_validator_properties.py
@@ -1,6 +1,9 @@
+from copy import deepcopy
+
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
+from context_compiler import create_engine
 from experimental.preprocessor.output_validation import (
     _is_allowed_directive,
     parse_preprocessor_output,
@@ -30,6 +33,15 @@ NOISY_TEXT = st.one_of(
     st.builds(lambda t: f"[{t}]", st.text(max_size=60)),
     st.builds(lambda a, b: f"{a}; {b}", st.text(max_size=30), st.text(max_size=30)),
     st.builds(lambda a, b: f"{a}: {b}", st.text(max_size=30), st.text(max_size=30)),
+)
+UNSAFE_SOURCE_TEMPLATES = st.sampled_from(
+    [
+        "ok. {}",
+        "```\n{}\n```",
+        "the command is `{}`",
+        'the docs say "{}"',
+        "can you {}?",
+    ]
 )
 
 
@@ -140,3 +152,34 @@ def test_validate_output_always_has_null_for_non_directive(raw_output: object) -
         assert isinstance(validated["output"], str)
     else:
         assert validated["output"] is None
+
+
+@given(
+    st.sampled_from(CANONICAL_DIRECTIVES),
+    st.sampled_from(CANONICAL_DIRECTIVES),
+    UNSAFE_SOURCE_TEMPLATES,
+)
+def test_source_aware_validation_rejects_unsafe_wrapped_sources(
+    directive_in_source: str, fallback_directive: str, template: str
+) -> None:
+    source_input = template.format(directive_in_source)
+    validated = validate_preprocessor_output(fallback_directive, source_input=source_input)
+    assert validated == {"classification": "unknown", "output": None}
+
+
+@given(st.sampled_from(CANONICAL_DIRECTIVES), UNSAFE_SOURCE_TEMPLATES)
+def test_source_aware_rejection_prevents_engine_state_mutation(
+    directive_in_source: str, template: str
+) -> None:
+    source_input = template.format(directive_in_source)
+    fallback_directive = "use docker"
+    parsed = parse_preprocessor_output(fallback_directive, source_input=source_input)
+    compile_input = parsed if parsed is not None else source_input
+
+    engine = create_engine()
+    before = deepcopy(engine.state)
+    decision = engine.step(compile_input)
+    after = engine.state
+
+    assume(decision["kind"] != "update")
+    assert before == after


### PR DESCRIPTION
## What changed

- Hardened source-aware fallback validation in `experimental/preprocessor/output_validation.py` so boundary-unsafe `source_input` values cannot be converted into state-mutating directives by fallback output.
- Added validator-level regression tests for unsafe-source rejection and safe-source acceptance behavior.
- Added integration regressions (LiteLLM and Open WebUI preprocessor paths) to ensure fallback canonical outputs do not mutate state for unsafe source categories.
- Added focused Hypothesis coverage for unsafe wrapper/source patterns plus no-mutation assertions.
- Added portable preprocessor `kind: "parse"` conformance fixtures for `parse_preprocessor_output(raw_output, source_input=...)` behavior, and extended fixture conformance runner support.
- Documented parse fixture kind and source-aware fallback boundary contract in fixture docs.
- Locked quote-payload behavior (`use "docker"`) via fixture/tests/docs without broadening semantics.

## Why

- The prior heuristic-boundary hardening still allowed fallback-generated canonical directives to mutate state for boundary-unsafe source inputs.
- This patch closes that fallback loophole while preserving conservative preprocessor architecture: no heuristic expansion, no engine grammar/schema changes, and deterministic validator enforcement.
- Source-aware fallback behavior is now fixture-defined for future TS parity work.

Closes #77

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
