### PR TITLE
docs: require context-compiler 0.7.0 in openwebui examples

### DIFF
--- a/examples/integrations/openwebui/README.md
+++ b/examples/integrations/openwebui/README.md
@@ -18,7 +18,7 @@ These examples support both sync (`0.8.x`) and async (`0.9.x`) user lookup.
 The minimal pipe path below is the easiest first-run flow and was runtime-validated in Docker via API flow with a real backend model.
 
 1. Import `open_webui_pipe.py` (recommended/default) as a Function by URL.
-2. Open WebUI installs `context-compiler>=0.6.14` from the function frontmatter requirements.
+2. Open WebUI installs `context-compiler>=0.7.0` from the function frontmatter requirements.
 3. Enable the function.
 4. Set `BASE_MODEL_ID` to a valid Open WebUI model id (required).
 5. Select the pipe model in chat.
@@ -27,7 +27,7 @@ Open WebUI is host-provided runtime infrastructure and must already be installed
 Open WebUI also needs at least one real backend model/provider configured (for example Ollama or OpenAI) so `BASE_MODEL_ID` resolves to an actual model.
 Note: The `PROVIDER` environment contract used in LiteLLM examples/demos does not apply to OpenWebUI. OpenWebUI manages providers via its own connection settings and model IDs.
 
-Checkpoint continuation in these examples requires `context-compiler>=0.6.14`.
+Checkpoint continuation in these examples requires `context-compiler>=0.7.0`.
 
 ### Model configuration
 
@@ -64,8 +64,8 @@ If frontmatter dependency installs are disabled, offline, or unavailable:
 1. Open a shell in the Open WebUI container:
    - `docker exec -it <openwebui-container> sh`
 2. Install the package manually:
-   - Minimal pipe: `pip install "context-compiler>=0.6.14"`
-   - Preprocessor pipe: `pip install "context-compiler[experimental]>=0.6.14"`
+  - Minimal pipe: `pip install "context-compiler>=0.7.0"`
+  - Preprocessor pipe: `pip install "context-compiler[experimental]>=0.7.0"`
 3. Import and enable the function in Open WebUI, then configure valves.
 
 ### Finding valid model ids

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -4,7 +4,7 @@ author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
 version: 0.9.0
-requirements: context-compiler>=0.6.20
+requirements: context-compiler>=0.7.0
 
 Minimal Open WebUI Pipe integration for Context Compiler.
 

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -4,7 +4,7 @@ author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
 version: 0.9.0
-requirements: context-compiler[experimental]>=0.6.20
+requirements: context-compiler[experimental]>=0.7.0
 
 Open WebUI integration with Context Compiler preprocessor.
 


### PR DESCRIPTION
## What changed

- updated OpenWebUI pipe frontmatter requirements to the stabilized 0.7 package surface:
  - `context-compiler>=0.7.0`
  - `context-compiler[experimental]>=0.7.0`
- kept both OpenWebUI pipe frontmatter versions at `0.9.0`
- updated OpenWebUI integration README requirement references from `0.6.14` to `0.7.0`
- retained package-scoped compact trace import usage (`context_compiler.observability.build_compact_trace_text`) with no local compact-trace fallback logic

## Why

- align OpenWebUI examples with the intended 0.7+ package boundary and avoid stale install guidance
- make requirement metadata consistent across frontmatter and README setup instructions

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
