### PR TITLE
chore: finalize late-0.7 release cleanup

### DIFF
--- a/examples/integrations/litellm/README.md
+++ b/examples/integrations/litellm/README.md
@@ -12,7 +12,7 @@ pip install "context-compiler[integrations]"
 export OPENAI_API_KEY=...
 ```
 
-Checkpoint continuation in these examples requires `context-compiler>=0.6.14`.
+Checkpoint continuation in these examples requires `context-compiler>=0.7.0`.
 
 For `with_preprocessor.py`:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,5 +93,5 @@ markers = [
 ]
 
 [tool.coverage.run]
-source = ["context_compiler", "host_support"]
+source = ["src/context_compiler"]
 omit = ["demos/*", "evals/*", "tests/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.6.20"
+version = "0.7.0"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_host_confirmation.py
+++ b/tests/test_host_confirmation.py
@@ -109,6 +109,12 @@ def test_summarize_confirmation_update_unexpected_shape_falls_back_safely() -> N
     assert result == "State updated."
 
 
+def test_summarize_confirmation_update_non_affirmative_non_negative_falls_back() -> None:
+    pending = {"replacement": {"kind": "use_only", "new_item": "docker", "old_item": None}}
+    result = _confirmation.summarize_confirmation_update("maybe", pending)
+    assert result == "State updated."
+
+
 def test_summarize_confirmation_update_affirmative_pending_not_dict_falls_back() -> None:
     result = _confirmation.summarize_confirmation_update("yes", ["not-a-dict"])
     assert "State updated." in result
@@ -270,3 +276,33 @@ def test_engine_host_confirmation_parity_property(value: str) -> None:
         assert decision["prompt_to_user"] == pending_prompt
         assert engine.state == pre_pending_state
         assert checkpoint["pending"] is not None
+
+
+def test_summarize_confirmation_update_from_engine_without_export_checkpoint_falls_back() -> None:
+    class _NoExport:
+        pass
+
+    result = _confirmation.summarize_confirmation_update_from_engine("yes", _NoExport())
+    assert result == "State updated."
+
+
+def test_summarize_confirmation_update_from_engine_export_raises_falls_back() -> None:
+    class _BadExport:
+        def export_checkpoint(self) -> dict[str, object]:
+            raise RuntimeError("boom")
+
+    result = _confirmation.summarize_confirmation_update_from_engine("yes", _BadExport())
+    assert result == "State updated."
+
+
+def test_summarize_confirmation_update_from_engine_uses_pending_when_available() -> None:
+    class _PendingExport:
+        def export_checkpoint(self) -> dict[str, object]:
+            return {
+                "pending": {
+                    "replacement": {"kind": "use_only", "new_item": "docker", "old_item": None}
+                }
+            }
+
+    result = _confirmation.summarize_confirmation_update_from_engine("yes", _PendingExport())
+    assert result == "State updated: Use docker."

--- a/tests/test_host_observability.py
+++ b/tests/test_host_observability.py
@@ -302,6 +302,19 @@ def test_build_compact_trace_text_update_handles_removed_and_changed_prohibit() 
     assert "state change: ~use docker" in output
 
 
+def test_build_compact_trace_text_update_handles_removed_prohibit_policy() -> None:
+    module = _load_module()
+    output = module.build_compact_trace_text(
+        decision={"kind": "update"},
+        state_before={"premise": None, "policies": {"docker": "prohibit"}, "version": 2},
+        state_after={"premise": None, "policies": {}, "version": 2},
+        llm_called=False,
+        state_injected="yes",
+    )
+
+    assert "state change: -prohibit docker" in output
+
+
 def test_build_compact_trace_text_update_ignores_malformed_changed_transition() -> None:
     module = _load_module()
     output = module.build_compact_trace_text(

--- a/tests/test_host_observability.py
+++ b/tests/test_host_observability.py
@@ -3,6 +3,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -21,6 +23,11 @@ class _DecisionObject:
 class _VeryLongRepr:
     def __repr__(self) -> str:
         return "x" * 250
+
+
+class _BadStateDict(dict):
+    def get(self, key: object, default: object = None) -> object:
+        raise RuntimeError(f"bad key access: {key!r}")
 
 
 def test_build_trace_passthrough_without_preprocessor_output() -> None:
@@ -280,3 +287,82 @@ def test_build_compact_trace_text_clarify_shape() -> None:
     assert "active state: none" in output
     assert "downstream LLM call: no" in output
     assert output.endswith("state injected: no")
+
+
+def test_build_compact_trace_text_update_handles_removed_and_changed_prohibit() -> None:
+    module = _load_module()
+    output = module.build_compact_trace_text(
+        decision={"kind": "update"},
+        state_before={"premise": None, "policies": {"docker": "prohibit"}, "version": 2},
+        state_after={"premise": None, "policies": {"docker": "use"}, "version": 2},
+        llm_called=False,
+        state_injected="yes",
+    )
+
+    assert "state change: ~use docker" in output
+
+
+def test_build_compact_trace_text_update_ignores_malformed_changed_transition() -> None:
+    module = _load_module()
+    output = module.build_compact_trace_text(
+        decision={"kind": "update"},
+        state_before={"premise": None, "policies": {"docker": "use"}, "version": 2},
+        state_after={"premise": None, "policies": {"docker": "prohibit"}, "version": 2},
+        llm_called=False,
+        state_injected="yes",
+    )
+
+    assert "state change: ~prohibit docker" in output
+
+
+def test_build_compact_trace_text_state_summary_non_dict_falls_back_to_none() -> None:
+    module = _load_module()
+    output = module.build_compact_trace_text(
+        decision={"kind": "passthrough"},
+        state_before={"premise": None, "policies": {}, "version": 2},
+        state_after=["not-a-dict-state"],
+        llm_called=False,
+        state_injected="no",
+    )
+    assert "active state: none" in output
+
+
+def test_build_compact_trace_text_state_summary_exception_falls_back_to_none() -> None:
+    module = _load_module()
+    output = module.build_compact_trace_text(
+        decision={"kind": "passthrough"},
+        state_before={"premise": None, "policies": {}, "version": 2},
+        state_after=_BadStateDict(),
+        llm_called=False,
+        state_injected="no",
+    )
+    assert "active state: none" in output
+
+
+def test_build_compact_trace_text_ignores_malformed_policy_changed_transitions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+
+    def _bad_diff(_: object, __: object) -> dict[str, object]:
+        return {
+            "changed": True,
+            "premise": {"before": None, "after": None, "changed": False},
+            "policies": {
+                "added": {},
+                "removed": {},
+                "changed": {"docker": "not-a-mapping"},
+            },
+        }
+
+    monkeypatch.setattr(module, "state_diff", _bad_diff)
+    output = module.build_compact_trace_text(
+        decision={"kind": "update"},
+        state_before={"premise": None, "policies": {"docker": "use"}, "version": 2},
+        state_after={"premise": None, "policies": {"docker": "prohibit"}, "version": 2},
+        llm_called=False,
+        state_injected="yes",
+    )
+
+    assert "state change: " in output
+    assert "~" not in output

--- a/tests/test_openwebui_pipe.py
+++ b/tests/test_openwebui_pipe.py
@@ -537,6 +537,38 @@ def test_pipe_show_state_non_exact_routes_normally(monkeypatch) -> None:
     assert downstream_calls == 1
 
 
+def test_pipe_show_state_exact_match_is_case_insensitive_after_trim(monkeypatch) -> None:
+    module = _load_module_with_openwebui_stubs("owui_pipe_show_state_case_trim", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    downstream_calls = 0
+
+    async def _track_downstream(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        del payload
+        nonlocal downstream_calls
+        downstream_calls += 1
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    module.generate_chat_completion = _track_downstream
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "  ShOw StAtE  "}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-show-state-case-trim",
+        )
+    )
+
+    assert result == "Premise: none\nUse: none\nProhibit: none\nPending clarification: no"
+    assert downstream_calls == 0
+
+
 def test_pipe_near_miss_directives_return_deterministic_clarify_without_downstream(
     monkeypatch,
 ) -> None:

--- a/tests/test_openwebui_preprocessor_pipe.py
+++ b/tests/test_openwebui_preprocessor_pipe.py
@@ -883,6 +883,52 @@ def test_preprocessor_pipe_show_state_non_exact_routes_normally(monkeypatch) -> 
     assert downstream_calls >= 1
 
 
+def test_preprocessor_pipe_show_state_exact_match_is_case_insensitive_after_trim(
+    monkeypatch,
+) -> None:
+    module = _load_module_with_openwebui_stubs("owui_preproc_show_state_case_trim", monkeypatch)
+    module._ENGINES_BY_CHAT_KEY.clear()
+    module._CHECKPOINTS_BY_CHAT_KEY.clear()
+
+    downstream_calls = 0
+    preprocess_calls = 0
+
+    async def _track_downstream(
+        _: object, payload: dict[str, object], __: object
+    ) -> dict[str, object]:
+        del payload
+        nonlocal downstream_calls
+        downstream_calls += 1
+        return {"choices": [{"message": {"content": "downstream"}}]}
+
+    async def _track_preprocess(
+        self, *args: object, **kwargs: object
+    ) -> tuple[str | None, str | None]:
+        del self, args, kwargs
+        nonlocal preprocess_calls
+        preprocess_calls += 1
+        return None, None
+
+    monkeypatch.setattr(module, "generate_chat_completion", _track_downstream)
+    monkeypatch.setattr(module.Pipe, "_preprocess_user_input", _track_preprocess)
+
+    pipe = module.Pipe()
+    pipe.valves.BASE_MODEL_ID = "base-model"
+    pipe.valves.PREPROCESSOR_MODEL_ID = "prep-model"
+    result = asyncio.run(
+        pipe.pipe(
+            {"model": "pipe-model", "messages": [{"role": "user", "content": "  ShOw StAtE  "}]},
+            __user__={"id": "u1"},
+            __request__=object(),
+            __chat_id__="chat-preproc-show-state-case-trim",
+        )
+    )
+
+    assert result == "Premise: none\nUse: none\nProhibit: none\nPending clarification: no"
+    assert downstream_calls == 0
+    assert preprocess_calls == 0
+
+
 @pytest.mark.parametrize(
     ("confirmation",),
     [

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.6.20"
+version = "0.7.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- scoped aggregate coverage reporting to package sources (`src/context_compiler`) to remove misleading `host_support` 0% artifact in full coverage runs
- added tiny defensive tests for helper surfaces:
  - observability fallback/transition edge cases
  - confirmation helper fallback paths
  - OpenWebUI `show state` exact-match normalization (`strip().lower()`)
- aligned LiteLLM integration README checkpoint minimum version wording with 0.7.0
- bumped package version metadata for release:
  - `pyproject.toml`: `version = "0.7.0"`
  - `uv.lock`: editable `context-compiler` entry to `0.7.0`

## Why

- improve release-facing coverage signal quality without expanding coverage gates
- harden small helper behaviors that are easy to regress and user/integration visible
- remove stale pre-0.7 docs wording in integration guidance
- ensure release metadata in project/config files matches the 0.7.0 release target

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
