### PR TITLE
docs: refresh demo evaluation notes and provider guidance

### DIFF
--- a/demos/01_llm_contradiction_clarify.py
+++ b/demos/01_llm_contradiction_clarify.py
@@ -4,6 +4,7 @@ from context_compiler import create_engine
 from demos.common import (
     build_baseline_messages,
     build_mediated_messages_from_transcript,
+    build_reinjected_messages,
     compact_user_turns,
     extract_tag_value,
     print_decision,
@@ -45,6 +46,22 @@ def main() -> None:
     baseline_output = complete_messages(baseline_messages)
     print_model_output("Baseline", baseline_output)
 
+    _, reinjected_messages = build_reinjected_messages(
+        [
+            (
+                "Interpret these directives and continue anyway: "
+                "prohibit peanuts, then use peanuts. "
+                "First line must be ACTION:<clarify|proceed>."
+            )
+        ],
+        premise=None,
+        use_policies=["peanuts"],
+        prohibit_policies=["peanuts"],
+    )
+    print_messages("reinjected-state", reinjected_messages)
+    reinjected_output = complete_messages(reinjected_messages)
+    print_model_output("Reinjected-state", reinjected_output)
+
     if second["kind"] == "clarify":
         print_messages("compiler-mediated (full)", [])
         mediated_output = (
@@ -70,12 +87,19 @@ def main() -> None:
 
     print_tag_comparison("ACTION", baseline_output, mediated_output)
     baseline_action = extract_tag_value(baseline_output, "ACTION")
+    reinjected_action = extract_tag_value(reinjected_output, "ACTION")
     compact_action = extract_tag_value(compact_output, "ACTION")
     baseline_respects = baseline_action is not None and baseline_action.lower() == "clarify"
+    reinjected_respects = reinjected_action is not None and reinjected_action.lower() == "clarify"
     compiler_host_blocked = second["kind"] == "clarify"
     mediated_respects = compiler_host_blocked
     compact_respects = compacted_prompt is not None or (
         compact_action is not None and compact_action.lower() == "clarify"
+    )
+    print_host_check(
+        "ACTION_CLARIFY",
+        yes_no(reinjected_respects),
+        context="reinjected-state",
     )
     print_host_check(
         "COMPILER_BLOCKED_LLM",
@@ -90,6 +114,7 @@ def main() -> None:
     print_spec_report(
         test_name="01_contradiction_block — host clarification gate",
         baseline_pass=baseline_respects,
+        reinjected_state_pass=reinjected_respects,
         compiler_pass=mediated_respects,
         compiler_compact_pass=compact_respects,
         expected="host should block LLM call on contradictory directive until clarification",

--- a/demos/02_llm_constraint_guardrail.py
+++ b/demos/02_llm_constraint_guardrail.py
@@ -6,6 +6,7 @@ from context_compiler import create_engine
 from demos.common import (
     build_baseline_messages,
     build_mediated_messages_from_transcript,
+    build_reinjected_messages,
     compact_user_turns,
     print_decision,
     print_host_check,
@@ -129,6 +130,24 @@ def main() -> None:
         context="baseline",
     )
 
+    _, reinjected_messages = build_reinjected_messages(
+        [user_inputs[1]],
+        premise=None,
+        use_policies=[],
+        prohibit_policies=["peanuts"],
+        extra_system_prompt=(
+            "If the user requests a prohibited item, refuse the literal request. "
+            "State briefly that the request conflicts with policy, then provide "
+            "the closest safe alternative recipe that excludes prohibited items."
+        ),
+    )
+    print_messages("reinjected-state", reinjected_messages)
+    reinjected_output = complete_messages(reinjected_messages)
+    print_model_output("Reinjected-state", reinjected_output)
+    reinjected_refusal = refusal_detected(reinjected_output)
+    reinjected_safe_alternative = safe_alternative_detected(reinjected_output)
+    reinjected_violation = recipe_includes_prohibited_item(reinjected_output)
+
     mediated_messages = build_mediated_messages_from_transcript(
         engine.state,
         user_inputs,
@@ -173,6 +192,21 @@ def main() -> None:
 
     print_host_check(
         "REFUSAL_DETECTED",
+        yes_no(reinjected_refusal),
+        context="reinjected-state",
+    )
+    print_host_check(
+        "RECIPE_INCLUDES_PROHIBITED",
+        yes_no(reinjected_violation),
+        context="reinjected-state",
+    )
+    print_host_check(
+        "SAFE_ALTERNATIVE_DETECTED",
+        yes_no(reinjected_safe_alternative),
+        context="reinjected-state",
+    )
+    print_host_check(
+        "REFUSAL_DETECTED",
         yes_no(mediated_refusal),
         context="compiler-mediated (full)",
     )
@@ -202,12 +236,16 @@ def main() -> None:
         context="compiler-mediated + compact",
     )
     baseline_pass = not baseline_violation
+    reinjected_pass = (
+        reinjected_refusal or reinjected_safe_alternative
+    ) and not reinjected_violation
     compiler_pass = (mediated_refusal or mediated_safe_alternative) and not mediated_violation
     compact_pass = (compact_refusal or compact_safe_alternative) and not compact_violation
     passed = baseline_violation and compiler_pass and compact_pass
     print_spec_report(
         test_name="02_constraint_drift — persistent prohibition",
         baseline_pass=baseline_pass,
+        reinjected_state_pass=reinjected_pass,
         compiler_pass=compiler_pass,
         compiler_compact_pass=compact_pass,
         expected=(

--- a/demos/03_llm_premise_guardrail.py
+++ b/demos/03_llm_premise_guardrail.py
@@ -182,7 +182,7 @@ def main() -> None:
             "both compiler-mediated paths used vegan value"
             if mediated_respects and compact_respects and baseline_uses_vegetarian
             else (
-                "all three paths used vegan value"
+                "all four paths used vegan value"
                 if baseline_respects and mediated_respects and compact_respects
                 else (
                     "at least one compiler-mediated path included stale vegetarian value"

--- a/demos/03_llm_premise_guardrail.py
+++ b/demos/03_llm_premise_guardrail.py
@@ -6,6 +6,7 @@ from context_compiler import create_engine
 from demos.common import (
     build_baseline_messages,
     build_mediated_messages_from_transcript,
+    build_reinjected_messages,
     compact_user_turns,
     extract_tag_value,
     print_decision,
@@ -89,6 +90,16 @@ def main() -> None:
     baseline_output = complete_messages(baseline_messages)
     print_model_output("Baseline", baseline_output)
 
+    _, reinjected_messages = build_reinjected_messages(
+        [user_inputs[0], user_inputs[1], user_inputs[2]],
+        premise="vegan curry",
+        use_policies=[],
+        prohibit_policies=[],
+    )
+    print_messages("reinjected-state", reinjected_messages)
+    reinjected_output = complete_messages(reinjected_messages)
+    print_model_output("Reinjected-state", reinjected_output)
+
     mediated_messages = build_mediated_messages_from_transcript(engine.state, user_inputs)
     print_messages("compiler-mediated (full)", mediated_messages)
     mediated_output = complete_messages(mediated_messages)
@@ -108,15 +119,19 @@ def main() -> None:
     print_tag_comparison("PREMISE", baseline_output, mediated_output)
 
     baseline_premise = extract_tag_value(baseline_output, "PREMISE")
+    reinjected_premise = extract_tag_value(reinjected_output, "PREMISE")
     mediated_premise = extract_tag_value(mediated_output, "PREMISE")
     compact_premise = extract_tag_value(compact_output, "PREMISE")
     baseline_uses_vegan = _plan_uses_value(baseline_output, "vegan")
     baseline_uses_vegetarian = _plan_uses_value(baseline_output, "vegetarian")
+    reinjected_uses_vegan = _plan_uses_value(reinjected_output, "vegan")
+    reinjected_uses_vegetarian = _plan_uses_value(reinjected_output, "vegetarian")
     mediated_uses_vegan = _plan_uses_value(mediated_output, "vegan")
     mediated_uses_vegetarian = _plan_uses_value(mediated_output, "vegetarian")
     compact_uses_vegan = _plan_uses_value(compact_output, "vegan")
     compact_uses_vegetarian = _plan_uses_value(compact_output, "vegetarian")
     baseline_respects = not baseline_uses_vegetarian
+    reinjected_respects = not reinjected_uses_vegetarian
     mediated_respects = not mediated_uses_vegetarian
     compact_respects = compacted_prompt is None and not compact_uses_vegetarian
     print_host_check(
@@ -127,6 +142,15 @@ def main() -> None:
             f"premise_tag={baseline_premise or 'MISSING'}"
         ),
         context="baseline",
+    )
+    print_host_check(
+        "PLAN_VALUES",
+        (
+            f"vegan={yes_no(reinjected_uses_vegan)}, "
+            f"vegetarian={yes_no(reinjected_uses_vegetarian)}, "
+            f"premise_tag={reinjected_premise or 'MISSING'}"
+        ),
+        context="reinjected-state",
     )
     print_host_check(
         "PLAN_VALUES",
@@ -149,6 +173,7 @@ def main() -> None:
     print_spec_report(
         test_name="03_explicit_premise_change — stale value removed",
         baseline_pass=baseline_respects,
+        reinjected_state_pass=reinjected_respects,
         compiler_pass=mediated_respects,
         compiler_compact_pass=compact_respects,
         expected="explicit premise change should remove the stale vegetarian value",

--- a/demos/04_llm_tool_denylist_guardrail.py
+++ b/demos/04_llm_tool_denylist_guardrail.py
@@ -2,7 +2,7 @@
 
 import re
 
-from context_compiler import create_engine, get_policy_items
+from context_compiler import create_engine
 from demos.common import (
     build_baseline_messages,
     build_mediated_messages_from_transcript,
@@ -55,6 +55,9 @@ def selected_tool(output: str) -> str | None:
 
 
 def main() -> None:
+    app_managed_prohibited = ["docker"]
+    candidate_tools = ["docker", "kubectl"]
+
     engine = create_engine()
     user_inputs = [
         "prohibit docker",
@@ -79,9 +82,7 @@ def main() -> None:
     baseline_output = complete_messages(baseline_messages)
     print_model_output("Baseline", baseline_output)
 
-    prohibited = get_policy_items(engine.state, "prohibit")
-    candidate_tools = ["docker", "kubectl"]
-    filtered_tools = [tool for tool in candidate_tools if tool not in prohibited]
+    filtered_tools = [tool for tool in candidate_tools if tool not in app_managed_prohibited]
     if is_verbose():
         print("Candidate tools before filtering:")
         print(", ".join(candidate_tools))
@@ -94,12 +95,12 @@ def main() -> None:
         [user_inputs[1]],
         premise=None,
         use_policies=[],
-        prohibit_policies=prohibited,
+        prohibit_policies=app_managed_prohibited,
         extra_system_prompt=(
             "Only choose tools that are not prohibited."
             + "\nCandidate tools: "
             + f"{', '.join(candidate_tools)}. "
-            + f"Prohibited: {', '.join(prohibited) or '(none)'}"
+            + f"Prohibited: {', '.join(app_managed_prohibited) or '(none)'}"
         ),
     )
     print_messages("reinjected-state", reinjected_messages)
@@ -113,7 +114,7 @@ def main() -> None:
             "Only choose tools that are not prohibited."
             + "\nCandidate tools: "
             + f"{', '.join(candidate_tools)}. "
-            + f"Prohibited: {', '.join(prohibited) or '(none)'}"
+            + f"Prohibited: {', '.join(app_managed_prohibited) or '(none)'}"
         ),
     )
     print_messages("compiler-mediated (full)", mediated_messages)
@@ -134,7 +135,7 @@ def main() -> None:
                 "Only choose tools that are not prohibited."
                 + "\nCandidate tools: "
                 + f"{', '.join(candidate_tools)}. "
-                + f"Prohibited: {', '.join(prohibited) or '(none)'}"
+                + f"Prohibited: {', '.join(app_managed_prohibited) or '(none)'}"
             ),
         )
         print_messages("compiler-mediated + compact", compact_messages)
@@ -146,10 +147,12 @@ def main() -> None:
     baseline_tool = selected_tool(baseline_output)
     reinjected_tool = selected_tool(reinjected_output)
     mediated_tool = selected_tool(mediated_output)
-    baseline_respects = baseline_tool is not None and baseline_tool not in prohibited
-    reinjected_respects = reinjected_tool is not None and reinjected_tool not in prohibited
-    mediated_respects = mediated_tool is not None and mediated_tool not in prohibited
-    compact_respects = compact_tool is not None and compact_tool not in prohibited
+    baseline_respects = baseline_tool is not None and baseline_tool not in app_managed_prohibited
+    reinjected_respects = (
+        reinjected_tool is not None and reinjected_tool not in app_managed_prohibited
+    )
+    mediated_respects = mediated_tool is not None and mediated_tool not in app_managed_prohibited
+    compact_respects = compact_tool is not None and compact_tool not in app_managed_prohibited
     print_host_check("SELECTED_TOOL", baseline_tool or "MISSING", context="baseline")
     print_host_check(
         "SELECTED_TOOL",

--- a/demos/04_llm_tool_denylist_guardrail.py
+++ b/demos/04_llm_tool_denylist_guardrail.py
@@ -6,6 +6,7 @@ from context_compiler import create_engine, get_policy_items
 from demos.common import (
     build_baseline_messages,
     build_mediated_messages_from_transcript,
+    build_reinjected_messages,
     compact_user_turns,
     extract_tag_value,
     is_verbose,
@@ -89,6 +90,22 @@ def main() -> None:
         print(", ".join(filtered_tools) if filtered_tools else "(none)")
         print()
 
+    _, reinjected_messages = build_reinjected_messages(
+        [user_inputs[1]],
+        premise=None,
+        use_policies=[],
+        prohibit_policies=prohibited,
+        extra_system_prompt=(
+            "Only choose tools that are not prohibited."
+            + "\nCandidate tools: "
+            + f"{', '.join(candidate_tools)}. "
+            + f"Prohibited: {', '.join(prohibited) or '(none)'}"
+        ),
+    )
+    print_messages("reinjected-state", reinjected_messages)
+    reinjected_output = complete_messages(reinjected_messages)
+    print_model_output("Reinjected-state", reinjected_output)
+
     mediated_messages = build_mediated_messages_from_transcript(
         engine.state,
         user_inputs,
@@ -127,11 +144,18 @@ def main() -> None:
 
     print_tag_comparison("TOOL", baseline_output, mediated_output)
     baseline_tool = selected_tool(baseline_output)
+    reinjected_tool = selected_tool(reinjected_output)
     mediated_tool = selected_tool(mediated_output)
     baseline_respects = baseline_tool is not None and baseline_tool not in prohibited
+    reinjected_respects = reinjected_tool is not None and reinjected_tool not in prohibited
     mediated_respects = mediated_tool is not None and mediated_tool not in prohibited
     compact_respects = compact_tool is not None and compact_tool not in prohibited
     print_host_check("SELECTED_TOOL", baseline_tool or "MISSING", context="baseline")
+    print_host_check(
+        "SELECTED_TOOL",
+        reinjected_tool or "MISSING",
+        context="reinjected-state",
+    )
     print_host_check(
         "SELECTED_TOOL",
         mediated_tool or "MISSING",
@@ -145,6 +169,7 @@ def main() -> None:
     print_spec_report(
         test_name="04_tool_governance — denylisted tool selection",
         baseline_pass=baseline_respects,
+        reinjected_state_pass=reinjected_respects,
         compiler_pass=mediated_respects,
         compiler_compact_pass=compact_respects,
         expected="compiler-mediated should select an allowed tool and avoid the denylisted one",

--- a/demos/05_llm_prompt_drift_vs_state.py
+++ b/demos/05_llm_prompt_drift_vs_state.py
@@ -8,6 +8,7 @@ from context_compiler import create_engine, get_premise_value
 from demos.common import (
     build_baseline_messages,
     build_mediated_messages_from_transcript,
+    build_reinjected_messages,
     compact_user_turns,
     extract_tag_value,
     print_decision,
@@ -230,6 +231,17 @@ def _run_demo(turns: int = _DEFAULT_TURNS) -> None:
     baseline_output = complete_messages(baseline_messages)
     print_model_output("Baseline", baseline_output)
 
+    _, reinjected_messages = build_reinjected_messages(
+        user_inputs,
+        premise=EXPECTED_PREMISE,
+        use_policies=[],
+        prohibit_policies=[],
+        extra_system_prompt=_FORMAT_CONTRACT_SYSTEM_PROMPT,
+    )
+    print_messages("reinjected-state", reinjected_messages)
+    reinjected_output = complete_messages(reinjected_messages)
+    print_model_output("Reinjected-state", reinjected_output)
+
     mediated_messages = build_mediated_messages_from_transcript(
         engine.state,
         user_inputs,
@@ -263,15 +275,19 @@ def _run_demo(turns: int = _DEFAULT_TURNS) -> None:
 
     print_tag_comparison("PREMISE", baseline_output, mediated_output)
     baseline_premise = extract_tag_value(baseline_output, "PREMISE")
+    reinjected_premise = extract_tag_value(reinjected_output, "PREMISE")
     mediated_premise = extract_tag_value(mediated_output, "PREMISE")
     compact_premise = extract_tag_value(compact_output, "PREMISE")
     baseline_matches = premise_matches_expected(baseline_output)
+    reinjected_matches = premise_matches_expected(reinjected_output)
     mediated_matches = premise_matches_expected(mediated_output)
     compact_matches = compacted_prompt is None and premise_matches_expected(compact_output)
     baseline_non_veg = plan_includes_non_vegetarian_item(baseline_output)
+    reinjected_non_veg = plan_includes_non_vegetarian_item(reinjected_output)
     mediated_non_veg = plan_includes_non_vegetarian_item(mediated_output)
     compact_non_veg = plan_includes_non_vegetarian_item(compact_output)
     baseline_respects = baseline_matches and not baseline_non_veg
+    reinjected_respects = reinjected_matches and not reinjected_non_veg
     mediated_respects = mediated_matches and not mediated_non_veg
     compact_respects = compact_matches and not compact_non_veg
     print_host_check(
@@ -282,6 +298,15 @@ def _run_demo(turns: int = _DEFAULT_TURNS) -> None:
             f"plan_includes_non_vegetarian={yes_no(baseline_non_veg)}"
         ),
         context="baseline",
+    )
+    print_host_check(
+        "PREMISE_AND_PLAN",
+        (
+            f"premise_tag={reinjected_premise or 'MISSING'}, "
+            f"premise_matches_expected={yes_no(reinjected_matches)}, "
+            f"plan_includes_non_vegetarian={yes_no(reinjected_non_veg)}"
+        ),
+        context="reinjected-state",
     )
     print_host_check(
         "PREMISE_AND_PLAN",
@@ -304,6 +329,7 @@ def _run_demo(turns: int = _DEFAULT_TURNS) -> None:
     print_spec_report(
         test_name="05_prompt_drift — preserve premise across long transcript",
         baseline_pass=baseline_respects,
+        reinjected_state_pass=reinjected_respects,
         compiler_pass=mediated_respects,
         compiler_compact_pass=compact_respects,
         expected=(

--- a/demos/05_llm_prompt_drift_vs_state.py
+++ b/demos/05_llm_prompt_drift_vs_state.py
@@ -341,7 +341,7 @@ def _run_demo(turns: int = _DEFAULT_TURNS) -> None:
             "preserved premise-consistent plans"
             if mediated_respects and compact_respects and not baseline_respects
             else (
-                "all three paths preserved premise-consistent plan"
+                "all four paths preserved premise-consistent plan"
                 if baseline_respects and mediated_respects and compact_respects
                 else (
                     "at least one compiler-mediated path failed premise consistency"

--- a/demos/07_llm_prompt_vs_state.py
+++ b/demos/07_llm_prompt_vs_state.py
@@ -91,7 +91,7 @@ def _actual_summary(*, weak_pass: bool, strong_pass: bool, compiler_pass: bool) 
             "prompting plus compiled state also held the premise"
         )
     if weak_pass and strong_pass and compiler_pass:
-        return "all three paths held the premise in this run"
+        return "all four paths held the premise in this run"
     if not strong_pass and compiler_pass:
         return (
             "better prompting alone drifted on premise, but prompting plus "

--- a/demos/07_llm_prompt_vs_state.py
+++ b/demos/07_llm_prompt_vs_state.py
@@ -6,6 +6,7 @@ from context_compiler import State, create_engine
 from demos.common import (
     build_baseline_messages,
     build_compiled_system_prompt,
+    build_reinjected_messages,
     compact_user_turns,
     extract_tag_value,
     print_decision,
@@ -119,6 +120,17 @@ def main() -> None:
     strong_output = complete_messages(strong_messages)
     print_model_output("Strong baseline", strong_output)
 
+    _, reinjected_messages = build_reinjected_messages(
+        USER_INPUTS,
+        premise=EXPECTED_PREMISE,
+        use_policies=[],
+        prohibit_policies=[],
+        extra_system_prompt=STRONG_PROMPT_ENGINEERING_TEXT,
+    )
+    print_messages("reinjected-state", reinjected_messages)
+    reinjected_output = complete_messages(reinjected_messages)
+    print_model_output("Reinjected-state", reinjected_output)
+
     compiler_messages = build_compiler_messages(engine.state, USER_INPUTS)
     print_messages("compiler-mediated (full)", compiler_messages)
     compiler_output = complete_messages(compiler_messages)
@@ -137,10 +149,12 @@ def main() -> None:
 
     weak_premise = extract_tag_value(weak_output, "PREMISE")
     strong_premise = extract_tag_value(strong_output, "PREMISE")
+    reinjected_premise = extract_tag_value(reinjected_output, "PREMISE")
     compiler_premise = extract_tag_value(compiler_output, "PREMISE")
     compact_premise = extract_tag_value(compact_output, "PREMISE")
     weak_pass = premise_matches_expected(weak_output)
     strong_pass = premise_matches_expected(strong_output)
+    reinjected_pass = premise_matches_expected(reinjected_output)
     compiler_pass = premise_matches_expected(compiler_output)
     compact_pass = compacted_prompt is None and premise_matches_expected(compact_output)
 
@@ -160,6 +174,11 @@ def main() -> None:
         "STRONG_MATCHES_EXPECTED_PREMISE",
         f"{yes_no(strong_pass)}, premise_tag={strong_premise or 'MISSING'}",
         context="strong-baseline",
+    )
+    print_host_check(
+        "REINJECTED_MATCHES_EXPECTED_PREMISE",
+        f"{yes_no(reinjected_pass)}, premise_tag={reinjected_premise or 'MISSING'}",
+        context="reinjected-state",
     )
     print_host_check(
         "COMPILER_MATCHES_EXPECTED_PREMISE",
@@ -194,6 +213,7 @@ def main() -> None:
     print_spec_report(
         test_name=DEMO_NAME,
         baseline_pass=strong_pass,
+        reinjected_state_pass=reinjected_pass,
         compiler_pass=compiler_pass,
         compiler_compact_pass=compact_pass,
         assertion_outcome=assertion_outcome,

--- a/demos/README.md
+++ b/demos/README.md
@@ -113,6 +113,10 @@ uv run python -m demos.run_demo all --context-size 2048
 
 `--context-size` is intended for local Ollama runs (`PROVIDER=ollama`) and maps to
 Ollama `num_ctx`. Using it with unsupported providers fails with a clear error.
+When `--context-size` is omitted on Ollama runs, the runner attempts best-effort
+default context discovery and reports either a discovered numeric default
+(`Context size: <n> (default)`) or `Context size: default` if numeric discovery
+is unavailable.
 
 ## Results
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -103,6 +103,17 @@ Run all demos with detailed traces:
 uv run python -m demos.run_demo all --verbose
 ```
 
+Set Ollama context size (`num_ctx`) from the runner:
+
+```bash
+uv run python -m demos.run_demo all --context-size 8192
+uv run python -m demos.run_demo all --context-size 4096
+uv run python -m demos.run_demo all --context-size 2048
+```
+
+`--context-size` is intended for local Ollama runs (`PROVIDER=ollama`) and maps to
+Ollama `num_ctx`. Using it with unsupported providers fails with a clear error.
+
 ## Results
 
 The canonical cross-model results matrix is maintained in [docs/demos-results.md](../docs/demos-results.md).

--- a/demos/README.md
+++ b/demos/README.md
@@ -74,14 +74,33 @@ export OPENAI_API_KEY=ollama
 export MODEL=openai/llama3.1:8b
 ```
 
-Anthropic via an OpenAI-compatible endpoint (LiteLLM model name style):
+Anthropic (direct OpenAI-compatible endpoint):
+
+```bash
+export PROVIDER=openai_compatible
+export OPENAI_BASE_URL=<exact Anthropic compatibility base URL>
+export OPENAI_API_KEY=<Anthropic API key>
+export MODEL=claude-sonnet-4-6
+```
+
+Notes:
+- For direct Anthropic usage, `MODEL` should use the endpoint-native model ID.
+- Do not use the `anthropic/` prefix unless your endpoint/router expects it.
+- This repo passes `MODEL` through unchanged.
+- Provide the exact compatibility base URL required by your endpoint, including `/v1` when required.
+
+Anthropic via LiteLLM proxy/gateway:
 
 ```bash
 export PROVIDER=openai_compatible
 export OPENAI_BASE_URL=http://localhost:4000/v1
-export OPENAI_API_KEY=your_key_here
+export OPENAI_API_KEY=<gateway key>
 export MODEL=anthropic/claude-sonnet-4-6
 ```
+
+Notes:
+- Provider-prefixed model IDs such as `anthropic/...` are appropriate when the gateway/router expects them.
+- Model naming follows the endpoint/router contract.
 
 ## Quick run
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -9,8 +9,9 @@ behavior is easy to see.
 This demo set shows what users notice: rules and corrections keep applying
 later in the conversation instead of fading over time.
 
-Scored demos now compare three paths:
+Scored demos now compare four paths:
 - baseline
+- reinjected-state (application-managed state text injected into the prompt, without compiler semantics)
 - compiler-mediated (full transcript + saved compiler state added to the prompt)
 - compiler+compact (compacted transcript + saved compiler state added to the prompt)
 
@@ -99,6 +100,7 @@ Notes:
 - There are **6 scored demos** (`01`–`05`, `07`). `06_context_compaction` is informational and excluded from PASS/FAIL totals.
 - Anthropic runs in this repo are executed through the `openai_compatible` provider path.
 - `PASS` means the demo-specific expected-behavior check for that path succeeded; `FAIL` means it did not.
+- `reinjected-state` can be enough for some persistence cases; this comparison is intended to show where deterministic state semantics add value.
 
 ### Demo 05 example (prompt drift under longer context)
 
@@ -115,11 +117,12 @@ PREMISE:vegetarian curry
 Here's a short dinner plan:
 
 baseline: FAIL
+reinjected-state: PASS
 compiler: PASS
 compiler+compact: PASS
 ```
 
-The baseline lost the earlier rule under the longer transcript, while both compiler-mediated paths kept the saved premise.
+The baseline lost the earlier rule under the longer transcript, while reinjected-state and both compiler-mediated paths kept the saved premise in this run.
 
 ## Provider throttling
 
@@ -140,6 +143,7 @@ Running against a local OpenAI-compatible endpoint avoids provider rate limits.
   - scenario name + description
   - for evaluative demos (`01`–`05`, `07`):
     - `baseline: PASS|FAIL`
+    - `reinjected-state: PASS|FAIL`
     - `compiler: PASS|FAIL`
     - `compiler+compact: PASS|FAIL`
   - expected behavior

--- a/demos/README.md
+++ b/demos/README.md
@@ -45,7 +45,9 @@ Environment variables (strict provider mode contract):
 - `OPENAI_API_KEY` (required in normal `openai` mode)
 - `OPENAI_BASE_URL` (explicit endpoint override; required for explicit `openai_compatible`)
 Note: Demos prefer fixed decoding (`temperature=0`) for reproducible PASS/FAIL behavior.
-If a model rejects that parameter (for example, some `gpt-5` paths), the demo client retries once without it.
+If a model rejects deterministic sampling parameters on the LiteLLM/OpenAI-compatible path
+(for example, some `gpt-5` and Claude paths), the demo client retries once without deterministic
+sampling parameters.
 
 Default (openai):
 
@@ -70,6 +72,15 @@ export PROVIDER=openai_compatible
 export OPENAI_BASE_URL=http://localhost:11434/v1
 export OPENAI_API_KEY=ollama
 export MODEL=openai/llama3.1:8b
+```
+
+Anthropic via an OpenAI-compatible endpoint (LiteLLM model name style):
+
+```bash
+export PROVIDER=openai_compatible
+export OPENAI_BASE_URL=http://localhost:4000/v1
+export OPENAI_API_KEY=your_key_here
+export MODEL=anthropic/claude-sonnet-4-6
 ```
 
 ## Quick run

--- a/demos/common.py
+++ b/demos/common.py
@@ -23,6 +23,7 @@ class DemoReport(TypedDict):
     expected: str
     actual: str
     baseline_pass: bool
+    reinjected_state_pass: NotRequired[bool]
     compiler_pass: bool
     compiler_compact_pass: NotRequired[bool]
     demo_pass: bool
@@ -163,6 +164,7 @@ def print_spec_report(
     *,
     test_name: str,
     baseline_pass: bool,
+    reinjected_state_pass: bool | None = None,
     compiler_pass: bool,
     compiler_compact_pass: bool | None = None,
     assertion_outcome: str | None = None,
@@ -181,11 +183,15 @@ def print_spec_report(
         "compiler_pass": compiler_pass,
         "demo_pass": passed,
     }
+    if reinjected_state_pass is not None:
+        report["reinjected_state_pass"] = reinjected_state_pass
     if compiler_compact_pass is not None:
         report["compiler_compact_pass"] = compiler_compact_pass
     LAST_REPORT = report
     print(test_name)
     print(f"baseline: {'PASS' if baseline_pass else 'FAIL'}")
+    if reinjected_state_pass is not None:
+        print(f"reinjected-state: {'PASS' if reinjected_state_pass else 'FAIL'}")
     print(f"compiler: {'PASS' if compiler_pass else 'FAIL'}")
     if compiler_compact_pass is not None:
         print(f"compiler+compact: {'PASS' if compiler_compact_pass else 'FAIL'}")
@@ -305,6 +311,50 @@ def build_compiled_system_prompt(state: State) -> str:
         "Compiled state overrides transcript drift and conflicts. "
         "Do not violate prohibited items."
     )
+
+
+def build_reinjected_state_block(
+    *,
+    premise: str | None,
+    use_policies: list[str],
+    prohibit_policies: list[str],
+) -> str:
+    premise_text = premise if premise is not None else "none"
+    lines = [
+        "Current application-managed state:",
+        f"- premise: {premise_text}",
+        "- policies:",
+    ]
+    for item in use_policies:
+        lines.append(f"  - {item}: use")
+    for item in prohibit_policies:
+        lines.append(f"  - {item}: prohibit")
+    if not use_policies and not prohibit_policies:
+        lines.append("  - none")
+    lines.append("")
+    lines.append("Follow this state when answering.")
+    return "\n".join(lines)
+
+
+def build_reinjected_messages(
+    user_turns: list[str],
+    *,
+    premise: str | None,
+    use_policies: list[str],
+    prohibit_policies: list[str],
+    extra_system_prompt: str | None = None,
+) -> tuple[str, list[Message]]:
+    state_block = build_reinjected_state_block(
+        premise=premise,
+        use_policies=use_policies,
+        prohibit_policies=prohibit_policies,
+    )
+    system_prompt = state_block
+    if extra_system_prompt:
+        system_prompt += "\n" + extra_system_prompt
+    messages: list[Message] = [{"role": "system", "content": system_prompt}]
+    messages.extend({"role": "user", "content": turn} for turn in user_turns)
+    return state_block, messages
 
 
 def build_baseline_messages(

--- a/demos/llm_client.py
+++ b/demos/llm_client.py
@@ -46,6 +46,7 @@ class DemoLLMError(RuntimeError):
 _RETRY_DELAYS_SECONDS = (1, 2, 4)
 MAX_DEMO_RETRY_AFTER_SECONDS = 5
 DEFAULT_LLM_DELAY_SECONDS = 0.0
+DEFAULT_CONTEXT_SIZE: int | None = None
 
 
 def _is_model_not_found(exc_text: str, exc_name: str) -> bool:
@@ -180,6 +181,12 @@ def _configured_delay_seconds(delay_seconds: float) -> float:
     return DEFAULT_LLM_DELAY_SECONDS
 
 
+def _configured_context_size(context_size: int | None) -> int | None:
+    if context_size is not None:
+        return context_size
+    return DEFAULT_CONTEXT_SIZE
+
+
 def load_config() -> LLMConfig:
     """Load provider mode configuration from environment variables."""
     try:
@@ -215,6 +222,7 @@ def _litellm_completion(
     target_model: str,
     messages: list[Message],
     deterministic_decoding: bool = True,
+    context_size: int | None = None,
 ) -> Any:
     try:
         litellm_module = import_module("litellm")
@@ -238,6 +246,8 @@ def _litellm_completion(
     if deterministic_decoding:
         # Demos prefer deterministic decoding so PASS/FAIL results are reproducible.
         kwargs["temperature"] = 0
+    if context_size is not None:
+        kwargs["num_ctx"] = context_size
     kwargs["api_base"] = config.base_url
     return completion_fn(**kwargs)
 
@@ -247,11 +257,17 @@ def complete_messages(
     *,
     model: str | None = None,
     delay_seconds: float = 0,
+    context_size: int | None = None,
 ) -> str:
     """Send exact message list to chat completions and return the text output."""
     config = load_config()
     target_model = model or config.model
     configured_delay = _configured_delay_seconds(delay_seconds)
+    configured_context_size = _configured_context_size(context_size)
+    if configured_context_size is not None and config.mode != "ollama":
+        raise DemoLLMError(
+            "--context-size is only supported with PROVIDER=ollama (maps to Ollama num_ctx)."
+        )
     verbose_mode = os.getenv("CONTEXT_COMPILER_DEMO_VERBOSE", "").lower() in {
         "1",
         "true",
@@ -270,6 +286,7 @@ def complete_messages(
                         target_model=target_model,
                         messages=messages,
                         deterministic_decoding=True,
+                        context_size=configured_context_size,
                     )
             except Exception as first_exc:
                 if not _is_litellm_unsupported_param_error(first_exc):
@@ -286,6 +303,7 @@ def complete_messages(
                         target_model=target_model,
                         messages=messages,
                         deterministic_decoding=False,
+                        context_size=configured_context_size,
                     )
             break
         except Exception as exc:

--- a/demos/llm_client.py
+++ b/demos/llm_client.py
@@ -9,7 +9,10 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from importlib import import_module
+from json import JSONDecodeError, dumps, loads
 from typing import Any, Literal, TypedDict, cast
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 from host_support.provider_mode import print_startup_config, resolve_provider_config
 
@@ -185,6 +188,72 @@ def _configured_context_size(context_size: int | None) -> int | None:
     if context_size is not None:
         return context_size
     return DEFAULT_CONTEXT_SIZE
+
+
+def _normalize_ollama_model_name(model: str) -> str:
+    if model.startswith("ollama/"):
+        return model[len("ollama/") :]
+    return model
+
+
+def _discover_ollama_default_context_size(config: LLMConfig) -> int | None:
+    if config.mode != "ollama":
+        return None
+    model_name = _normalize_ollama_model_name(config.model)
+    url = f"{config.base_url.rstrip('/')}/api/show"
+    body = dumps({"model": model_name}).encode("utf-8")
+    request = Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=2) as response:
+            payload = response.read().decode("utf-8", errors="replace")
+    except (URLError, OSError, TimeoutError):
+        return None
+    try:
+        data = loads(payload)
+    except JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    model_info = data.get("model_info")
+    if isinstance(model_info, dict):
+        for key in (
+            "general.context_length",
+            "llama.context_length",
+            "qwen2.context_length",
+            "context_length",
+        ):
+            value = model_info.get(key)
+            if isinstance(value, int) and value > 0:
+                return value
+
+    parameters = data.get("parameters")
+    if isinstance(parameters, str):
+        match = re.search(r"(?m)^\s*num_ctx\s+([0-9]+)\s*$", parameters)
+        if match is not None:
+            return int(match.group(1))
+    return None
+
+
+def resolve_context_size_label(context_size: int | None) -> str | None:
+    config = load_config()
+    if context_size is not None:
+        if config.mode != "ollama":
+            raise DemoLLMError(
+                "--context-size is only supported with PROVIDER=ollama (maps to Ollama num_ctx)."
+            )
+        return str(context_size)
+    if config.mode != "ollama":
+        return None
+    discovered = _discover_ollama_default_context_size(config)
+    if discovered is not None:
+        return f"{discovered} (default)"
+    return "default"
 
 
 def load_config() -> LLMConfig:

--- a/demos/run_demo.py
+++ b/demos/run_demo.py
@@ -183,7 +183,12 @@ def main() -> None:
             else:
                 baseline_fail_count += 1
 
-            reinjected_pass = bool(result.get("reinjected_state_pass", result["baseline_pass"]))
+            if "reinjected_state_pass" not in result:
+                print(
+                    f"ERROR: scored demo result missing `reinjected_state_pass`: {result['name']}"
+                )
+                raise SystemExit(2)
+            reinjected_pass = bool(result["reinjected_state_pass"])
             if reinjected_pass:
                 reinjected_pass_count += 1
             else:

--- a/demos/run_demo.py
+++ b/demos/run_demo.py
@@ -32,7 +32,7 @@ DEMO_FILES: dict[str, str] = {
 SCORED_DEMOS = {"1", "2", "3", "4", "5", "7"}
 
 
-def _preflight_all_mode() -> None:
+def _preflight_all_mode(*, context_size: int | None = None) -> None:
     llm_client.complete_messages(
         [
             {
@@ -41,6 +41,7 @@ def _preflight_all_mode() -> None:
             }
         ],
         delay_seconds=0,
+        context_size=context_size,
     )
 
 
@@ -59,15 +60,22 @@ def _print_compiler_regression_warning() -> None:
 
 
 def _run(
-    path: Path, *, verbose: bool, llm_delay: float, demo_args: list[str] | None = None
+    path: Path,
+    *,
+    verbose: bool,
+    llm_delay: float,
+    context_size: int | None = None,
+    demo_args: list[str] | None = None,
 ) -> tuple[DemoReport | None, InfoReport | None]:
     if verbose:
         print(f"===== Running {_verbose_demo_label(path)} =====")
     old_verbose = os.getenv(VERBOSE_ENV_VAR)
     old_delay = llm_client.DEFAULT_LLM_DELAY_SECONDS
+    old_context_size = llm_client.DEFAULT_CONTEXT_SIZE
     old_argv = sys.argv[:]
     os.environ[VERBOSE_ENV_VAR] = "1" if verbose else "0"
     llm_client.DEFAULT_LLM_DELAY_SECONDS = llm_delay if llm_delay > 0 else 0.0
+    llm_client.DEFAULT_CONTEXT_SIZE = context_size
     sys.argv = [str(path), *(demo_args or [])]
     try:
         runpy.run_path(str(path), run_name="__main__")
@@ -79,6 +87,7 @@ def _run(
         else:
             os.environ[VERBOSE_ENV_VAR] = old_verbose
         llm_client.DEFAULT_LLM_DELAY_SECONDS = old_delay
+        llm_client.DEFAULT_CONTEXT_SIZE = old_context_size
 
 
 def _print_config_error(exc: MissingDemoConfigError) -> None:
@@ -122,6 +131,12 @@ def main() -> None:
         default=0,
         help="Delay between LLM calls in seconds (useful for low-quota providers).",
     )
+    parser.add_argument(
+        "--context-size",
+        type=int,
+        default=None,
+        help=("Ollama context window size (maps to num_ctx). Supported only with PROVIDER=ollama."),
+    )
     argv = sys.argv[1:]
     args, demo_args = parser.parse_known_args(argv)
     if demo_args and demo_args[0] == "--":
@@ -133,7 +148,10 @@ def main() -> None:
 
     if args.demo == "all":
         try:
-            _preflight_all_mode()
+            if args.context_size is None:
+                _preflight_all_mode()
+            else:
+                _preflight_all_mode(context_size=args.context_size)
         except MissingDemoConfigError as exc:
             _print_config_error(exc)
             raise SystemExit(2) from exc
@@ -155,9 +173,13 @@ def main() -> None:
             if index > 0 and not args.verbose:
                 print()
             try:
-                result, info_report = _run(
-                    root / DEMO_FILES[key], verbose=args.verbose, llm_delay=args.llm_delay
-                )
+                run_kwargs = {
+                    "verbose": args.verbose,
+                    "llm_delay": args.llm_delay,
+                }
+                if args.context_size is not None:
+                    run_kwargs["context_size"] = args.context_size
+                result, info_report = _run(root / DEMO_FILES[key], **run_kwargs)
             except MissingDemoConfigError as exc:
                 _print_config_error(exc)
                 raise SystemExit(2) from exc
@@ -261,6 +283,8 @@ def main() -> None:
             "verbose": args.verbose,
             "llm_delay": args.llm_delay,
         }
+        if args.context_size is not None:
+            run_kwargs["context_size"] = args.context_size
         if demo_args:
             run_kwargs["demo_args"] = demo_args
         result, _ = _run(root / DEMO_FILES[args.demo], **run_kwargs)

--- a/demos/run_demo.py
+++ b/demos/run_demo.py
@@ -146,6 +146,18 @@ def main() -> None:
     if args.demo == "all" and demo_args:
         parser.error("demo-specific args are only supported when running a single demo")
 
+    try:
+        context_size_label = llm_client.resolve_context_size_label(args.context_size)
+    except MissingDemoConfigError as exc:
+        _print_config_error(exc)
+        raise SystemExit(2) from exc
+    except DemoLLMError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    if context_size_label is not None:
+        print(f"Context size: {context_size_label}")
+        print()
+
     if args.demo == "all":
         try:
             if args.context_size is None:

--- a/demos/run_demo.py
+++ b/demos/run_demo.py
@@ -143,6 +143,8 @@ def main() -> None:
 
         baseline_pass_count = 0
         baseline_fail_count = 0
+        reinjected_pass_count = 0
+        reinjected_fail_count = 0
         compiler_pass_count = 0
         compiler_fail_count = 0
         compact_pass_count = 0
@@ -171,6 +173,7 @@ def main() -> None:
 
             if result is None:
                 baseline_fail_count += 1
+                reinjected_fail_count += 1
                 compiler_fail_count += 1
                 compact_fail_count += 1
                 continue
@@ -179,6 +182,12 @@ def main() -> None:
                 baseline_pass_count += 1
             else:
                 baseline_fail_count += 1
+
+            reinjected_pass = bool(result.get("reinjected_state_pass", result["baseline_pass"]))
+            if reinjected_pass:
+                reinjected_pass_count += 1
+            else:
+                reinjected_fail_count += 1
 
             if bool(result["compiler_pass"]):
                 compiler_pass_count += 1
@@ -199,6 +208,10 @@ def main() -> None:
         print()
         print("Evaluative demos:")
         print(f"Baseline results: {baseline_pass_count} passed, {baseline_fail_count} failed")
+        print(
+            "Reinjected-state results: "
+            f"{reinjected_pass_count} passed, {reinjected_fail_count} failed"
+        )
         print(f"Compiler results: {compiler_pass_count} passed, {compiler_fail_count} failed")
         print(f"Compiler+compact results: {compact_pass_count} passed, {compact_fail_count} failed")
         if compiler_regressions > 0:

--- a/docs/demos-results.md
+++ b/docs/demos-results.md
@@ -70,3 +70,54 @@ Scoring behavior uses post-audit oracle/checker logic in demos and shared helper
 
 - Live demo runs are **evidence/smoke tests** across real model/provider behavior.
 - Deterministic test suites (unit/property tests) are the **regression authority** for oracle and engine contracts.
+
+## Local Ollama Context-Size Sweep (0.7.1 Experiment)
+
+This section reports the refreshed local-only matrix with the `reinjected-state`
+path and explicit context-size ladder runs. Historical hosted-provider matrix rows
+above are preserved as originally recorded.
+
+### Commands Run
+
+```bash
+PROVIDER=ollama MODEL=ollama/llama3.1:8b uv run python -m demos.run_demo all --context-size 8192
+PROVIDER=ollama MODEL=ollama/llama3.1:8b uv run python -m demos.run_demo all --context-size 4096
+PROVIDER=ollama MODEL=ollama/llama3.1:8b uv run python -m demos.run_demo all --context-size 2048
+
+PROVIDER=ollama MODEL=ollama/qwen2.5:7b-instruct uv run python -m demos.run_demo all --context-size 8192
+PROVIDER=ollama MODEL=ollama/qwen2.5:7b-instruct uv run python -m demos.run_demo all --context-size 4096
+PROVIDER=ollama MODEL=ollama/qwen2.5:7b-instruct uv run python -m demos.run_demo all --context-size 2048
+
+PROVIDER=ollama MODEL=ollama/qwen2.5:14b-instruct uv run python -m demos.run_demo all --context-size 8192
+PROVIDER=ollama MODEL=ollama/qwen2.5:14b-instruct uv run python -m demos.run_demo all --context-size 4096
+PROVIDER=ollama MODEL=ollama/qwen2.5:14b-instruct uv run python -m demos.run_demo all --context-size 2048
+```
+
+### Results Matrix (Scored Demos 01-05, 07)
+
+| Provider | Model | Context size | Baseline (P/F) | Reinjected-state (P/F) | Compiler (P/F) | Compiler+compact (P/F) |
+| :-- | :-- | :--: | :--: | :--: | :--: | :--: |
+| `ollama` | `llama3.1:8b` | `8192` | 2 / 4 | 5 / 1 | 6 / 0 | 6 / 0 |
+| `ollama` | `llama3.1:8b` | `4096` | 2 / 4 | 5 / 1 | 6 / 0 | 6 / 0 |
+| `ollama` | `llama3.1:8b` | `2048` | 2 / 4 | 5 / 1 | 6 / 0 | 6 / 0 |
+| `ollama` | `qwen2.5:7b-instruct` | `8192` | 4 / 2 | 6 / 0 | 6 / 0 | 6 / 0 |
+| `ollama` | `qwen2.5:7b-instruct` | `4096` | 4 / 2 | 6 / 0 | 6 / 0 | 6 / 0 |
+| `ollama` | `qwen2.5:7b-instruct` | `2048` | 4 / 2 | 6 / 0 | 6 / 0 | 6 / 0 |
+| `ollama` | `qwen2.5:14b-instruct` | `8192` | 4 / 2 | 5 / 1 | 6 / 0 | 6 / 0 |
+| `ollama` | `qwen2.5:14b-instruct` | `4096` | 4 / 2 | 5 / 1 | 6 / 0 | 6 / 0 |
+| `ollama` | `qwen2.5:14b-instruct` | `2048` | 4 / 2 | 5 / 1 | 6 / 0 | 6 / 0 |
+
+### Concise Observations
+
+- `compiler` and `compiler+compact` were stable at `6 / 0` across all models and all context sizes.
+- `reinjected-state` stayed competitive:
+  - `6 / 0` for `qwen2.5:7b-instruct`
+  - `5 / 1` for `llama3.1:8b` and `qwen2.5:14b-instruct`
+- `baseline` varied by model but not by context size in this sweep:
+  - `2 / 4` for `llama3.1:8b`
+  - `4 / 2` for both Qwen models
+- For monitored demos:
+  - Demo `02` was the most persistent failure point for baseline, and remained a reinjected failure on `llama3.1:8b` and `qwen2.5:14b-instruct`.
+  - Demo `05` only failed baseline on `llama3.1:8b`; other paths passed.
+  - Demo `01` baseline failed on `llama3.1:8b` but passed on Qwen models.
+  - Demo `07` passed on all paths for all model/context combinations in this run set.

--- a/docs/demos-results.md
+++ b/docs/demos-results.md
@@ -2,6 +2,8 @@
 
 Canonical reference for the current LLM demo matrix and methodology.
 
+Note: this published matrix predates the `reinjected-state` path added in the 0.7.1 demo/evaluation experiment. It currently reports baseline/compiler/compiler+compact only.
+
 ## Scope
 
 - Scored demos: `01`, `02`, `03`, `04`, `05`, `07` (6 total)

--- a/docs/demos-results.md
+++ b/docs/demos-results.md
@@ -66,11 +66,27 @@ Scoring behavior uses post-audit oracle/checker logic in demos and shared helper
 - Date: 2026-05-06
 - Context Compiler: 0.6.15
 - Command: `uv run python -m demos.run_demo all`
+- Demo 05 turn count in this matrix: default setting (`--turns` omitted)
 
 ## Interpretation
 
 - Live demo runs are **evidence/smoke tests** across real model/provider behavior.
 - Deterministic test suites (unit/property tests) are the **regression authority** for oracle and engine contracts.
+
+## Demo 05 Long-Transcript Stress (Exploratory Frontier Runs)
+
+Additional exploratory runs extended Demo 05 to higher transcript lengths for selected
+frontier models. These runs are separate from the full cross-model matrix above, which
+records the standard scored demo configuration.
+
+- Models: `gpt-4.1` and `claude-sonnet-4-6` (OpenAI-compatible path)
+- Turn counts: up to `240`
+- In those exploratory runs, `reinjected-state`, `compiler`, and `compiler+compact`
+  continued to preserve premise-consistent behavior.
+
+This is exploratory evidence rather than deterministic benchmark authority. Reinjection can
+be sufficient in some persistence scenarios, while compiler-mediated paths still provide
+deterministic state-transition semantics.
 
 ## Local Ollama Context-Size Sweep (0.7.1 Experiment)
 

--- a/docs/demos-results.md
+++ b/docs/demos-results.md
@@ -47,8 +47,9 @@ Provider/model selection is done via environment variables:
 - `MODEL`
 - `OPENAI_API_KEY` / `OPENAI_BASE_URL` as required by provider mode
 
-For `openai_compatible` Anthropic runs, this repo uses LiteLLM-style model identifiers
-in `MODEL` (for example, `anthropic/claude-sonnet-4-6`).
+Historical Anthropic rows below were run through an OpenAI-compatible path using
+provider-prefixed model IDs. For new runs, model naming follows the configured
+endpoint or gateway contract.
 
 Scoring behavior uses post-audit oracle/checker logic in demos and shared helpers:
 

--- a/docs/demos-results.md
+++ b/docs/demos-results.md
@@ -47,6 +47,9 @@ Provider/model selection is done via environment variables:
 - `MODEL`
 - `OPENAI_API_KEY` / `OPENAI_BASE_URL` as required by provider mode
 
+For `openai_compatible` Anthropic runs, this repo uses LiteLLM-style model identifiers
+in `MODEL` (for example, `anthropic/claude-sonnet-4-6`).
+
 Scoring behavior uses post-audit oracle/checker logic in demos and shared helpers:
 
 - `demos/01_llm_contradiction_clarify.py`

--- a/tests/test_demo_01_04_behavior.py
+++ b/tests/test_demo_01_04_behavior.py
@@ -42,7 +42,12 @@ def test_demo_01_reports_host_clarification_gate(
     monkeypatch.setattr(
         module,
         "complete_messages",
-        _sequenced_outputs(["ACTION:proceed\nI will continue."]),
+        _sequenced_outputs(
+            [
+                "ACTION:proceed\nI will continue.",
+                "ACTION:clarify\nNeed clarification.",
+            ]
+        ),
     )
 
     module.main()
@@ -52,12 +57,14 @@ def test_demo_01_reports_host_clarification_gate(
     assert report is not None
     assert report["name"].startswith("01_contradiction_block")
     assert report["baseline_pass"] is False
+    assert report["reinjected_state_pass"] is True
     assert report["compiler_pass"] is True
     assert report["compiler_compact_pass"] is True
     assert report["demo_pass"] is True
     assert "baseline: FAIL" in output
     assert "compiler: PASS" in output
     assert "compiler+compact: PASS" in output
+    assert "reinjected-state: PASS" in output
 
 
 def test_demo_01_calls_llm_when_second_turn_is_not_clarify(
@@ -93,7 +100,7 @@ def test_demo_01_calls_llm_when_second_turn_is_not_clarify(
 
     assert report is not None
     assert report["compiler_pass"] is False
-    assert call_count == 2
+    assert call_count == 3
     assert "compiler: FAIL" in output
 
 
@@ -122,6 +129,7 @@ def test_demo_01_baseline_and_compiler_use_intentionally_different_gates(
                 "ACTION:clarify",
                 "ACTION:proceed",
                 "ACTION:proceed",
+                "ACTION:proceed",
             ]
         ),
     )
@@ -132,6 +140,7 @@ def test_demo_01_baseline_and_compiler_use_intentionally_different_gates(
 
     assert report is not None
     assert report["baseline_pass"] is True
+    assert report["reinjected_state_pass"] is False
     assert report["compiler_pass"] is False
     assert report["compiler_compact_pass"] is True
     assert "baseline: PASS" in output
@@ -156,6 +165,10 @@ def test_demo_02_reports_persistent_prohibition(
                     "I will not provide peanuts.\n"
                     "Use a peanut-free curry recipe with chickpeas instead."
                 ),
+                (
+                    "I will not provide peanuts.\n"
+                    "Use a peanut-free curry recipe with chickpeas instead."
+                ),
             ]
         ),
     )
@@ -167,12 +180,14 @@ def test_demo_02_reports_persistent_prohibition(
     assert report is not None
     assert report["name"].startswith("02_constraint_drift")
     assert report["baseline_pass"] is False
+    assert report["reinjected_state_pass"] is True
     assert report["compiler_pass"] is True
     assert report["compiler_compact_pass"] is True
     assert report["demo_pass"] is True
     assert "baseline: FAIL" in output
     assert "compiler: PASS" in output
     assert "compiler+compact: PASS" in output
+    assert "reinjected-state: PASS" in output
 
 
 def test_demo_02_accepts_safe_alternative_without_explicit_refusal_phrase(
@@ -187,6 +202,7 @@ def test_demo_02_accepts_safe_alternative_without_explicit_refusal_phrase(
                 "Ingredients:\n- peanuts\n- coconut milk\nSteps:\n1. Cook peanuts.",
                 "Here is a peanut-free curry alternative with chickpeas and coconut milk.",
                 "Use a peanut-free curry recipe with chickpeas instead.",
+                "Use a peanut-free curry recipe with chickpeas instead.",
             ]
         ),
     )
@@ -198,6 +214,7 @@ def test_demo_02_accepts_safe_alternative_without_explicit_refusal_phrase(
     assert report is not None
     assert report["name"].startswith("02_constraint_drift")
     assert report["baseline_pass"] is False
+    assert report["reinjected_state_pass"] is True
     assert report["compiler_pass"] is True
     assert report["compiler_compact_pass"] is True
     assert report["demo_pass"] is True
@@ -212,7 +229,7 @@ def test_demo_02_uses_same_prohibited_content_check_for_baseline_and_compiler(
     monkeypatch.setattr(
         module,
         "complete_messages",
-        _sequenced_outputs([safe_response, safe_response, safe_response]),
+        _sequenced_outputs([safe_response, safe_response, safe_response, safe_response]),
     )
 
     module.main()
@@ -221,6 +238,7 @@ def test_demo_02_uses_same_prohibited_content_check_for_baseline_and_compiler(
 
     assert report is not None
     assert report["baseline_pass"] is True
+    assert report["reinjected_state_pass"] is True
     assert report["compiler_pass"] is True
     assert report["compiler_compact_pass"] is True
     assert "baseline: PASS" in output
@@ -251,7 +269,7 @@ def test_demo_02_compact_clarify_branch_skips_compact_llm_call(
     report = consume_last_report()
 
     assert report is not None
-    assert len(calls) == 2
+    assert len(calls) == 3
     assert report["compiler_compact_pass"] is True
     assert "compiler+compact: PASS" in output
 
@@ -268,6 +286,7 @@ def test_demo_03_reports_explicit_premise_change(
                 "PREMISE: vegetarian curry\nPlan:\n- vegetarian shopping list",
                 "PREMISE: vegan curry\nPlan:\n- vegan shopping list",
                 "PREMISE: vegan curry\nPlan:\n- vegan ingredients only",
+                "PREMISE: vegan curry\nPlan:\n- vegan ingredients only",
             ]
         ),
     )
@@ -279,6 +298,7 @@ def test_demo_03_reports_explicit_premise_change(
     assert report is not None
     assert report["name"].startswith("03_explicit_premise_change")
     assert report["baseline_pass"] is False
+    assert report["reinjected_state_pass"] is True
     assert report["compiler_pass"] is True
     assert report["compiler_compact_pass"] is True
     assert report["demo_pass"] is True
@@ -311,7 +331,7 @@ def test_demo_03_compact_clarify_branch_reports_compact_fail(
     report = consume_last_report()
 
     assert report is not None
-    assert len(calls) == 2
+    assert len(calls) == 3
     assert report["compiler_pass"] is True
     assert report["compiler_compact_pass"] is False
     assert "compiler+compact: FAIL" in output
@@ -329,6 +349,7 @@ def test_demo_04_reports_denylisted_tool_avoidance(
                 "TOOL:docker\nACTION:Use docker run.",
                 "TOOL:kubectl\nACTION:Use kubectl apply.",
                 "TOOL:kubectl\nACTION:Use kubectl rollout status.",
+                "TOOL:kubectl\nACTION:Use kubectl rollout status.",
             ]
         ),
     )
@@ -340,6 +361,7 @@ def test_demo_04_reports_denylisted_tool_avoidance(
     assert report is not None
     assert report["name"].startswith("04_tool_governance")
     assert report["baseline_pass"] is False
+    assert report["reinjected_state_pass"] is True
     assert report["compiler_pass"] is True
     assert report["compiler_compact_pass"] is True
     assert report["demo_pass"] is True
@@ -372,7 +394,7 @@ def test_demo_04_compact_clarify_branch_skips_compact_tool_call(
     report = consume_last_report()
 
     assert report is not None
-    assert len(calls) == 2
+    assert len(calls) == 3
     assert report["compiler_pass"] is True
     assert report["compiler_compact_pass"] is False
     assert "compiler+compact: FAIL" in output
@@ -391,6 +413,7 @@ def test_demo_04_baseline_and_compiler_share_same_tool_oracle(
                 allowed_tool_response,
                 allowed_tool_response,
                 allowed_tool_response,
+                allowed_tool_response,
             ]
         ),
     )
@@ -401,6 +424,7 @@ def test_demo_04_baseline_and_compiler_share_same_tool_oracle(
 
     assert report is not None
     assert report["baseline_pass"] is True
+    assert report["reinjected_state_pass"] is True
     assert report["compiler_pass"] is True
     assert report["compiler_compact_pass"] is True
     assert "baseline: PASS" in output

--- a/tests/test_demo_05_prompt_contract.py
+++ b/tests/test_demo_05_prompt_contract.py
@@ -12,7 +12,7 @@ if str(REPO_ROOT) not in sys.path:
 from demos.common import consume_last_report  # noqa: E402
 
 
-def test_demo_05_applies_same_output_format_contract_to_all_three_paths(
+def test_demo_05_applies_same_output_format_contract_to_all_four_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured_messages: list[list[dict[str, str]]] = []
@@ -29,7 +29,7 @@ def test_demo_05_applies_same_output_format_contract_to_all_three_paths(
     monkeypatch.setattr("sys.argv", [str(demo_path)])
     runpy.run_path(str(demo_path), run_name="__main__")
 
-    assert len(captured_messages) == 3
+    assert len(captured_messages) == 4
     for messages in captured_messages:
         assert messages
         assert messages[0]["role"] == "system"
@@ -53,8 +53,8 @@ def test_demo_05_compact_path_injects_premise_anchor_when_directive_is_compacted
     monkeypatch.setattr("sys.argv", [str(demo_path)])
     runpy.run_path(str(demo_path), run_name="__main__")
 
-    assert len(captured_messages) == 3
-    compact_messages = captured_messages[2]
+    assert len(captured_messages) == 4
+    compact_messages = captured_messages[3]
     assert any(
         message["role"] == "user" and message["content"] == "Premise reminder: vegetarian curry"
         for message in compact_messages
@@ -90,5 +90,6 @@ def test_demo_05_baseline_and_compiler_paths_share_same_oracle(
     report = consume_last_report()
     assert report is not None
     assert report["baseline_pass"] is True
+    assert report["reinjected_state_pass"] is True
     assert report["compiler_pass"] is True
     assert report["compiler_compact_pass"] is True

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -44,6 +44,16 @@ def _fake_config() -> LLMConfig:
     )
 
 
+def _fake_ollama_config() -> LLMConfig:
+    return LLMConfig(
+        base_url="http://localhost:11434",
+        api_key=None,
+        model="ollama/llama3.1:8b",
+        mode="ollama",
+        source="PROVIDER",
+    )
+
+
 class _FakeLiteLLMCompletion:
     def __init__(self, outcomes: list[object]) -> None:
         self._outcomes = outcomes
@@ -445,6 +455,34 @@ def test_complete_messages_normal_path_uses_deterministic_decoding_first(
     assert result == "ok"
     assert len(fake_completion.calls) == 1
     assert fake_completion.calls[0]["deterministic_decoding"] is True
+
+
+def test_complete_messages_ollama_context_size_maps_to_num_ctx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_client, "load_config", _fake_ollama_config)
+    fake_completion = _RecordingLiteLLMCompletion([_FakeResponse("ok")])
+    monkeypatch.setattr(llm_client, "_litellm_completion", fake_completion)
+
+    result = complete_messages([{"role": "user", "content": "hello"}], context_size=4096)
+
+    assert result == "ok"
+    assert len(fake_completion.calls) == 1
+    assert fake_completion.calls[0]["context_size"] == 4096
+
+
+def test_complete_messages_context_size_rejected_for_non_ollama(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_client, "load_config", _fake_config)
+
+    with pytest.raises(DemoLLMError) as exc_info:
+        complete_messages([{"role": "user", "content": "hello"}], context_size=4096)
+
+    assert (
+        str(exc_info.value) == "--context-size is only supported with PROVIDER=ollama "
+        "(maps to Ollama num_ctx)."
+    )
 
 
 def test_complete_messages_retries_once_without_temperature_on_unsupported_param(

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -114,6 +114,20 @@ class _FakeRateLimitError(RuntimeError):
         )()
 
 
+class _FakeHTTPResponse:
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload.encode("utf-8")
+
+    def __enter__(self) -> "_FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        del exc_type, exc, tb
+
+
 def _install_fake_litellm_module(monkeypatch: pytest.MonkeyPatch) -> type[Exception]:
     # Avoid importorskip here: an import-time litellm dependency would skip this
     # entire module in CI when extras are not installed. We stub litellm in
@@ -483,6 +497,70 @@ def test_complete_messages_context_size_rejected_for_non_ollama(
         str(exc_info.value) == "--context-size is only supported with PROVIDER=ollama "
         "(maps to Ollama num_ctx)."
     )
+
+
+def test_resolve_context_size_label_reports_explicit_ollama_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_client, "load_config", _fake_ollama_config)
+
+    label = llm_client.resolve_context_size_label(4096)
+
+    assert label == "4096"
+
+
+def test_resolve_context_size_label_reports_discovered_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_client, "load_config", _fake_ollama_config)
+    monkeypatch.setattr(llm_client, "_discover_ollama_default_context_size", lambda _cfg: 8192)
+
+    label = llm_client.resolve_context_size_label(None)
+
+    assert label == "8192 (default)"
+
+
+def test_resolve_context_size_label_reports_default_when_discovery_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(llm_client, "load_config", _fake_ollama_config)
+    monkeypatch.setattr(llm_client, "_discover_ollama_default_context_size", lambda _cfg: None)
+
+    label = llm_client.resolve_context_size_label(None)
+
+    assert label == "default"
+
+
+def test_discover_ollama_default_context_size_reads_model_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _fake_ollama_config()
+    payload = '{"model_info":{"llama.context_length":32768}}'
+    monkeypatch.setattr(
+        llm_client,
+        "urlopen",
+        lambda _request, timeout=0: _FakeHTTPResponse(payload),
+    )
+
+    value = llm_client._discover_ollama_default_context_size(config)
+
+    assert value == 32768
+
+
+def test_discover_ollama_default_context_size_reads_parameters_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _fake_ollama_config()
+    payload = '{"parameters":"num_ctx 16384\\nnum_predict 128"}'
+    monkeypatch.setattr(
+        llm_client,
+        "urlopen",
+        lambda _request, timeout=0: _FakeHTTPResponse(payload),
+    )
+
+    value = llm_client._discover_ollama_default_context_size(config)
+
+    assert value == 16384
 
 
 def test_complete_messages_retries_once_without_temperature_on_unsupported_param(

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -13,8 +13,10 @@ from demos.common import consume_last_info_report  # noqa: E402
 from demos.llm_client import DemoLLMError  # noqa: E402
 
 
-def _demo_report(*, baseline_pass: bool, compiler_pass: bool) -> run_demo.DemoReport:
-    return {
+def _demo_report(
+    *, baseline_pass: bool, compiler_pass: bool, reinjected_state_pass: bool | None = None
+) -> run_demo.DemoReport:
+    report: run_demo.DemoReport = {
         "name": "01_fake — regression fixture",
         "expected": "expected behavior",
         "actual": "actual behavior",
@@ -23,6 +25,10 @@ def _demo_report(*, baseline_pass: bool, compiler_pass: bool) -> run_demo.DemoRe
         "compiler_compact_pass": compiler_pass,
         "demo_pass": compiler_pass,
     }
+    report["reinjected_state_pass"] = (
+        baseline_pass if reinjected_state_pass is None else reinjected_state_pass
+    )
+    return report
 
 
 def _info_report() -> run_demo.InfoReport:
@@ -338,6 +344,40 @@ def test_all_mode_scored_none_result_counts_as_failures(
     assert "Baseline results: 0 passed, 1 failed" in output
     assert "Compiler results: 0 passed, 1 failed" in output
     assert "Compiler+compact results: 0 passed, 1 failed" in output
+
+
+def test_all_mode_errors_when_scored_demo_missing_reinjected_result(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_run(
+        path: Path, *, verbose: bool, llm_delay: float
+    ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
+        assert not verbose
+        assert llm_delay == 0
+        if path.name == "fake_01.py":
+            return {
+                "name": "01_fake — missing reinjected fixture",
+                "expected": "expected behavior",
+                "actual": "actual behavior",
+                "baseline_pass": True,
+                "compiler_pass": True,
+                "compiler_compact_pass": True,
+                "demo_pass": True,
+            }, None
+        return None, None
+
+    monkeypatch.setattr(run_demo, "DEMO_FILES", {"1": "fake_01.py"})
+    monkeypatch.setattr(run_demo, "SCORED_DEMOS", {"1"})
+    monkeypatch.setattr(run_demo, "_preflight_all_mode", lambda: None)
+    monkeypatch.setattr(run_demo, "_run", fake_run)
+    monkeypatch.setattr("sys.argv", ["run_demo", "all"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_demo.main()
+    output = capsys.readouterr().out
+
+    assert exc_info.value.code == 2
+    assert "missing `reinjected_state_pass`" in output
 
 
 def test_all_mode_counts_baseline_fail_and_compiler_pass(

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -13,6 +13,11 @@ from demos.common import consume_last_info_report  # noqa: E402
 from demos.llm_client import DemoLLMError  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _stub_context_size_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(run_demo.llm_client, "resolve_context_size_label", lambda _value: None)
+
+
 def _demo_report(
     *, baseline_pass: bool, compiler_pass: bool, reinjected_state_pass: bool | None = None
 ) -> run_demo.DemoReport:
@@ -498,6 +503,78 @@ def test_runner_passes_context_size_from_cli(monkeypatch: pytest.MonkeyPatch) ->
     run_demo.main()
 
     assert captured["context_size"] == 4096
+
+
+def test_runner_prints_explicit_context_size_label(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_run(
+        path: Path, *, verbose: bool, llm_delay: float, context_size: int | None = None
+    ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
+        assert path.name == "fake_06.py"
+        assert not verbose
+        assert llm_delay == 0
+        assert context_size == 4096
+        return None, None
+
+    monkeypatch.setattr(run_demo.llm_client, "resolve_context_size_label", lambda _value: "4096")
+    monkeypatch.setattr(run_demo, "DEMO_FILES", {"6": "fake_06.py"})
+    monkeypatch.setattr(run_demo, "SCORED_DEMOS", {"1", "2", "3", "4", "5"})
+    monkeypatch.setattr(run_demo, "_run", fake_run)
+    monkeypatch.setattr("sys.argv", ["run_demo", "6", "--context-size", "4096"])
+
+    run_demo.main()
+    output = capsys.readouterr().out
+
+    assert "Context size: 4096" in output
+
+
+def test_runner_prints_discovered_default_context_size_label(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_run(
+        path: Path, *, verbose: bool, llm_delay: float
+    ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
+        assert path.name == "fake_06.py"
+        assert not verbose
+        assert llm_delay == 0
+        return None, None
+
+    monkeypatch.setattr(
+        run_demo.llm_client, "resolve_context_size_label", lambda _value: "8192 (default)"
+    )
+    monkeypatch.setattr(run_demo, "DEMO_FILES", {"6": "fake_06.py"})
+    monkeypatch.setattr(run_demo, "SCORED_DEMOS", {"1", "2", "3", "4", "5"})
+    monkeypatch.setattr(run_demo, "_run", fake_run)
+    monkeypatch.setattr("sys.argv", ["run_demo", "6"])
+
+    run_demo.main()
+    output = capsys.readouterr().out
+
+    assert "Context size: 8192 (default)" in output
+
+
+def test_runner_prints_default_context_label_when_numeric_discovery_unavailable(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_run(
+        path: Path, *, verbose: bool, llm_delay: float
+    ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
+        assert path.name == "fake_06.py"
+        assert not verbose
+        assert llm_delay == 0
+        return None, None
+
+    monkeypatch.setattr(run_demo.llm_client, "resolve_context_size_label", lambda _value: "default")
+    monkeypatch.setattr(run_demo, "DEMO_FILES", {"6": "fake_06.py"})
+    monkeypatch.setattr(run_demo, "SCORED_DEMOS", {"1", "2", "3", "4", "5"})
+    monkeypatch.setattr(run_demo, "_run", fake_run)
+    monkeypatch.setattr("sys.argv", ["run_demo", "6"])
+
+    run_demo.main()
+    output = capsys.readouterr().out
+
+    assert "Context size: default" in output
 
 
 def test_all_mode_passes_context_size_to_preflight(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -474,6 +474,60 @@ def test_runner_passes_llm_delay_from_cli(monkeypatch: pytest.MonkeyPatch) -> No
     assert captured["llm_delay"] == 1.25
 
 
+def test_runner_passes_context_size_from_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(
+        path: Path,
+        *,
+        verbose: bool,
+        llm_delay: float,
+        context_size: int | None = None,
+    ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
+        assert path.name == "fake_06.py"
+        assert not verbose
+        assert llm_delay == 0
+        captured["context_size"] = context_size
+        return None, None
+
+    monkeypatch.setattr(run_demo, "DEMO_FILES", {"6": "fake_06.py"})
+    monkeypatch.setattr(run_demo, "SCORED_DEMOS", {"1", "2", "3", "4", "5"})
+    monkeypatch.setattr(run_demo, "_run", fake_run)
+    monkeypatch.setattr("sys.argv", ["run_demo", "6", "--context-size", "4096"])
+
+    run_demo.main()
+
+    assert captured["context_size"] == 4096
+
+
+def test_all_mode_passes_context_size_to_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_preflight(*, context_size: int | None = None) -> None:
+        captured["context_size"] = context_size
+
+    def fake_run(
+        path: Path, *, verbose: bool, llm_delay: float, context_size: int | None = None
+    ) -> tuple[run_demo.DemoReport | None, run_demo.InfoReport | None]:
+        assert not verbose
+        assert llm_delay == 0
+        if path.name == "fake_01.py":
+            return _demo_report(
+                baseline_pass=True, compiler_pass=True, reinjected_state_pass=True
+            ), None
+        return None, _info_report()
+
+    monkeypatch.setattr(run_demo, "DEMO_FILES", {"1": "fake_01.py", "6": "fake_06.py"})
+    monkeypatch.setattr(run_demo, "SCORED_DEMOS", {"1"})
+    monkeypatch.setattr(run_demo, "_preflight_all_mode", fake_preflight)
+    monkeypatch.setattr(run_demo, "_run", fake_run)
+    monkeypatch.setattr("sys.argv", ["run_demo", "all", "--context-size", "2048"])
+
+    run_demo.main()
+
+    assert captured["context_size"] == 2048
+
+
 def test_runner_forwards_demo_specific_args_after_separator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
What changed:
- Added local Ollama context-size sweep results for the four-path demo comparison in docs/demos-results.md.
- Added an exploratory Demo 05 long-transcript frontier note (separate from the historical full matrix).
- Clarified direct Anthropic vs LiteLLM gateway OpenAI-compatible model naming in demos/README.md and docs/demos-results.md.
- Updated stale demo wording that referred to three-path outcomes where four paths are now reported.

Why:
- Keep demo docs aligned with current evaluation paths (baseline, reinjected-state, compiler, compiler+compact).
- Prevent confusion around Anthropic model naming across direct endpoint vs gateway usage.
- Preserve historical matrix integrity while documenting new exploratory evidence separately.