### PR TITLE
test: add controller conformance fixtures

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -73,6 +73,18 @@ Portable checkpoint import contract coverage for
 `engine.import_checkpoint(...)`, including deterministic validation/error
 boundaries, atomic failure behavior, and pending-clarification clearing semantics.
 
+## Controller fixtures
+
+For [`conformance/controller/`](conformance/controller/):
+
+Portable controller contract coverage for:
+
+* `step(engine, user_input)` result envelope and state snapshot
+* `preview(engine, user_input)` result envelope, `would_mutate`, and non-mutation of live engine state
+* `state_diff(state_before, state_after)` deterministic structural diff output
+
+These fixtures keep a minimal, language-neutral contract matrix for controller APIs.
+
 ## Source of truth
 
 Fixtures reflect current Python behavior and tests.

--- a/tests/fixtures/conformance/controller/001_step_update_envelope_and_state_snapshot.json
+++ b/tests/fixtures/conformance/controller/001_step_update_envelope_and_state_snapshot.json
@@ -1,0 +1,39 @@
+{
+  "id": "controller_step_update_envelope_and_state_snapshot",
+  "kind": "controller",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "action": {
+    "fn": "step",
+    "input": "set premise concise replies"
+  },
+  "expected": {
+    "result": {
+      "output_version": 1,
+      "mode": "step",
+      "decision": {
+        "kind": "update",
+        "state": {
+          "premise": "concise replies",
+          "policies": {},
+          "version": 2
+        },
+        "prompt_to_user": null
+      },
+      "state": {
+        "premise": "concise replies",
+        "policies": {},
+        "version": 2
+      }
+    },
+    "state": {
+      "premise": "concise replies",
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/controller/002_preview_mutating_update_reports_would_mutate_and_no_live_mutation.json
+++ b/tests/fixtures/conformance/controller/002_preview_mutating_update_reports_would_mutate_and_no_live_mutation.json
@@ -1,0 +1,58 @@
+{
+  "id": "controller_preview_mutating_update_reports_would_mutate_and_no_live_mutation",
+  "kind": "controller",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "action": {
+    "fn": "preview",
+    "input": "set premise concise replies"
+  },
+  "expected": {
+    "result": {
+      "output_version": 1,
+      "mode": "preview",
+      "decision": {
+        "kind": "update",
+        "state": {
+          "premise": "concise replies",
+          "policies": {},
+          "version": 2
+        },
+        "prompt_to_user": null
+      },
+      "state_before": {
+        "premise": null,
+        "policies": {},
+        "version": 2
+      },
+      "state_after": {
+        "premise": "concise replies",
+        "policies": {},
+        "version": 2
+      },
+      "diff": {
+        "changed": true,
+        "premise": {
+          "before": null,
+          "after": "concise replies",
+          "changed": true
+        },
+        "policies": {
+          "added": {},
+          "removed": {},
+          "changed": {}
+        }
+      },
+      "would_mutate": true
+    },
+    "state_after_preview": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/controller/003_preview_idempotent_update_reports_non_mutating.json
+++ b/tests/fixtures/conformance/controller/003_preview_idempotent_update_reports_non_mutating.json
@@ -1,0 +1,69 @@
+{
+  "id": "controller_preview_idempotent_update_reports_non_mutating",
+  "kind": "controller",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "prelude": [
+    "use docker"
+  ],
+  "action": {
+    "fn": "preview",
+    "input": "use docker"
+  },
+  "expected": {
+    "result": {
+      "output_version": 1,
+      "mode": "preview",
+      "decision": {
+        "kind": "update",
+        "state": {
+          "premise": null,
+          "policies": {
+            "docker": "use"
+          },
+          "version": 2
+        },
+        "prompt_to_user": null
+      },
+      "state_before": {
+        "premise": null,
+        "policies": {
+          "docker": "use"
+        },
+        "version": 2
+      },
+      "state_after": {
+        "premise": null,
+        "policies": {
+          "docker": "use"
+        },
+        "version": 2
+      },
+      "diff": {
+        "changed": false,
+        "premise": {
+          "before": null,
+          "after": null,
+          "changed": false
+        },
+        "policies": {
+          "added": {},
+          "removed": {},
+          "changed": {}
+        }
+      },
+      "would_mutate": false
+    },
+    "state_after_preview": {
+      "premise": null,
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/controller/004_preview_clarify_reports_non_mutating_and_restores_pending.json
+++ b/tests/fixtures/conformance/controller/004_preview_clarify_reports_non_mutating_and_restores_pending.json
@@ -1,0 +1,54 @@
+{
+  "id": "controller_preview_clarify_reports_non_mutating_and_restores_pending",
+  "kind": "controller",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "action": {
+    "fn": "preview",
+    "input": "use kubectl instead of docker"
+  },
+  "expected": {
+    "result": {
+      "output_version": 1,
+      "mode": "preview",
+      "decision": {
+        "kind": "clarify",
+        "state": null,
+        "prompt_to_user": "Did you mean to use \"kubectl\" instead?"
+      },
+      "state_before": {
+        "premise": null,
+        "policies": {},
+        "version": 2
+      },
+      "state_after": {
+        "premise": null,
+        "policies": {},
+        "version": 2
+      },
+      "diff": {
+        "changed": false,
+        "premise": {
+          "before": null,
+          "after": null,
+          "changed": false
+        },
+        "policies": {
+          "added": {},
+          "removed": {},
+          "changed": {}
+        }
+      },
+      "would_mutate": false
+    },
+    "state_after_preview": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/controller/005_preview_pending_yes_reports_mutation_but_preserves_live_pending.json
+++ b/tests/fixtures/conformance/controller/005_preview_pending_yes_reports_mutation_but_preserves_live_pending.json
@@ -1,0 +1,67 @@
+{
+  "id": "controller_preview_pending_yes_reports_mutation_but_preserves_live_pending",
+  "kind": "controller",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "prelude": [
+    "use kubectl instead of docker"
+  ],
+  "action": {
+    "fn": "preview",
+    "input": "yes"
+  },
+  "expected": {
+    "result": {
+      "output_version": 1,
+      "mode": "preview",
+      "decision": {
+        "kind": "update",
+        "state": {
+          "premise": null,
+          "policies": {
+            "kubectl": "use"
+          },
+          "version": 2
+        },
+        "prompt_to_user": null
+      },
+      "state_before": {
+        "premise": null,
+        "policies": {},
+        "version": 2
+      },
+      "state_after": {
+        "premise": null,
+        "policies": {
+          "kubectl": "use"
+        },
+        "version": 2
+      },
+      "diff": {
+        "changed": true,
+        "premise": {
+          "before": null,
+          "after": null,
+          "changed": false
+        },
+        "policies": {
+          "added": {
+            "kubectl": "use"
+          },
+          "removed": {},
+          "changed": {}
+        }
+      },
+      "would_mutate": true
+    },
+    "state_after_preview": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": true
+  }
+}

--- a/tests/fixtures/conformance/controller/006_state_diff_structural_changes.json
+++ b/tests/fixtures/conformance/controller/006_state_diff_structural_changes.json
@@ -1,0 +1,52 @@
+{
+  "id": "controller_state_diff_structural_changes",
+  "kind": "controller",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "action": {
+    "fn": "state_diff",
+    "before": {
+      "premise": "concise",
+      "policies": {
+        "docker": "use",
+        "pytest": "prohibit"
+      },
+      "version": 2
+    },
+    "after": {
+      "premise": "formal",
+      "policies": {
+        "docker": "prohibit",
+        "uv": "use"
+      },
+      "version": 2
+    }
+  },
+  "expected": {
+    "diff": {
+      "changed": true,
+      "premise": {
+        "before": "concise",
+        "after": "formal",
+        "changed": true
+      },
+      "policies": {
+        "added": {
+          "uv": "use"
+        },
+        "removed": {
+          "pytest": "prohibit"
+        },
+        "changed": {
+          "docker": {
+            "before": "use",
+            "after": "prohibit"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from context_compiler import compile_transcript, create_engine
+from context_compiler.controller import preview, state_diff, step
 
 _STEP_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "conformance" / "step"
 _TRANSCRIPT_FIXTURES_DIR = (
@@ -14,6 +15,9 @@ _STATE_JSON_FIXTURES_DIR = (
 )
 _CHECKPOINT_FIXTURES_DIR = (
     Path(__file__).resolve().parent / "fixtures" / "conformance" / "checkpoint"
+)
+_CONTROLLER_FIXTURES_DIR = (
+    Path(__file__).resolve().parent / "fixtures" / "conformance" / "controller"
 )
 
 
@@ -185,3 +189,40 @@ def test_checkpoint_fixtures() -> None:
             assert decision == followup["decision"], fixture_id
             assert engine.state == followup["state"], fixture_id
             _assert_optional_pending_flag(followup, engine, fixture_id)
+
+
+def test_controller_fixtures() -> None:
+    for path in _json_files(_CONTROLLER_FIXTURES_DIR):
+        fixture = _load(path)
+        fixture_id = fixture["id"]
+
+        assert fixture["kind"] == "controller", fixture_id
+        engine = create_engine(state=fixture["initial_state"])
+        _apply_prelude(engine, fixture.get("prelude", []))
+
+        action = fixture["action"]
+        expected = fixture["expected"]
+        fn = action["fn"]
+
+        if fn == "step":
+            result = step(engine, action["input"])
+            assert result == expected["result"], fixture_id
+            assert engine.state == expected["state"], fixture_id
+            _assert_optional_pending_flag(expected, engine, fixture_id)
+            continue
+
+        if fn == "preview":
+            before = engine.state
+            pending_before = engine.has_pending_clarification()
+            result = preview(engine, action["input"])
+
+            assert result == expected["result"], fixture_id
+            assert engine.state == before, fixture_id
+            assert engine.state == expected["state_after_preview"], fixture_id
+            assert engine.has_pending_clarification() is pending_before, fixture_id
+            _assert_optional_pending_flag(expected, engine, fixture_id)
+            continue
+
+        assert fn == "state_diff", fixture_id
+        diff = state_diff(action["before"], action["after"])
+        assert diff == expected["diff"], fixture_id


### PR DESCRIPTION
## What changed

- Added a new shared controller conformance fixture suite under `tests/fixtures/conformance/controller/`.
- Added portable fixture coverage for:
  - `step(engine, user_input)` result envelope and state snapshot
  - `preview(engine, user_input)` mutating and non-mutating paths
  - preview clarify path and pending-state consistency
  - `state_diff(state_before, state_after)` structural diff output
- Extended `tests/test_fixtures.py` with a new conformance runner for controller fixtures.
- Documented the controller fixture suite in `tests/fixtures/README.md`.

## Why

- TypeScript 0.7 needs portable shared controller contracts, rather than relying on Python-only unit tests.
- These fixtures provide deterministic, language-neutral expectations for controller APIs without changing semantics.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
