### PR TITLE
test: add parse conformance boundary fixtures

### DIFF
--- a/tests/fixtures/conformance/api/public-api-v1.json
+++ b/tests/fixtures/conformance/api/public-api-v1.json
@@ -26,7 +26,8 @@
       "export_checkpoint",
       "import_checkpoint",
       "export_checkpoint_json",
-      "import_checkpoint_json"
+      "import_checkpoint_json",
+      "has_pending_clarification"
     ]
   }
 }

--- a/tests/fixtures/preprocessor/parse-canonical-directive-prohibit-peanuts.json
+++ b/tests/fixtures/preprocessor/parse-canonical-directive-prohibit-peanuts.json
@@ -1,0 +1,6 @@
+{
+  "name": "parse-canonical-directive-prohibit-peanuts",
+  "kind": "parse",
+  "raw_output": "prohibit peanuts",
+  "expected_parsed": "prohibit peanuts"
+}

--- a/tests/fixtures/preprocessor/parse-malformed-near-miss-rejected.json
+++ b/tests/fixtures/preprocessor/parse-malformed-near-miss-rejected.json
@@ -1,0 +1,6 @@
+{
+  "name": "parse-malformed-near-miss-rejected",
+  "kind": "parse",
+  "raw_output": "set premise to concise replies",
+  "expected_parsed": null
+}

--- a/tests/fixtures/preprocessor/parse-multiple-directives-rejected.json
+++ b/tests/fixtures/preprocessor/parse-multiple-directives-rejected.json
@@ -1,0 +1,6 @@
+{
+  "name": "parse-multiple-directives-rejected",
+  "kind": "parse",
+  "raw_output": "prohibit peanuts and use almonds",
+  "expected_parsed": null
+}

--- a/tests/fixtures/preprocessor/parse-no-directive-sentinel.json
+++ b/tests/fixtures/preprocessor/parse-no-directive-sentinel.json
@@ -1,0 +1,6 @@
+{
+  "name": "parse-no-directive-sentinel",
+  "kind": "parse",
+  "raw_output": "<NO_DIRECTIVE>",
+  "expected_parsed": null
+}

--- a/tests/fixtures/preprocessor/parse-source-input-structured-json-directive-self-accepted.json
+++ b/tests/fixtures/preprocessor/parse-source-input-structured-json-directive-self-accepted.json
@@ -1,0 +1,7 @@
+{
+  "name": "parse-source-input-structured-json-directive-self-accepted",
+  "kind": "parse",
+  "source_input": "{\"classification\":\"directive\",\"output\":\"prohibit peanuts\"}",
+  "raw_output": "{\"classification\":\"directive\",\"output\":\"prohibit peanuts\"}",
+  "expected_parsed": "prohibit peanuts"
+}

--- a/tests/fixtures/preprocessor/parse-unknown-directive-like-rejected.json
+++ b/tests/fixtures/preprocessor/parse-unknown-directive-like-rejected.json
@@ -1,0 +1,6 @@
+{
+  "name": "parse-unknown-directive-like-rejected",
+  "kind": "parse",
+  "raw_output": "<NO_DIRECTIPLE>",
+  "expected_parsed": null
+}


### PR DESCRIPTION
## What changed

- Added shared `kind: "parse"` preprocessor conformance fixtures for portable parse/validation boundary behavior.
- Added API conformance fixture coverage for `engine.has_pending_clarification` in `tests/fixtures/conformance/api/public-api-v1.json`.

## Why

- TypeScript 0.7 portability needs shared fixture-backed parse boundary expectations instead of relying on Python-only tests.
- `has_pending_clarification` is part of host-facing behavior and should be included in the public API contract fixture.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
