### PR TITLE
docs: update fixture api surface version wording

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -13,7 +13,7 @@ This directory contains multiple fixture suites with different contracts.
 
 ## API contract fixture
 
-[`conformance/api/public-api-v1.json`](conformance/api/public-api-v1.json) defines a small public API presence contract for the Python 0.6 surface that ports must expose.
+[`conformance/api/public-api-v1.json`](conformance/api/public-api-v1.json) defines a small public API presence contract for the Python 0.7.x surface that ports must expose.
 
 Ports may sync this artifact with conformance fixtures.
 


### PR DESCRIPTION
## What changed

- Updated stale wording in `tests/fixtures/README.md` from `Python 0.6 surface` to `Python 0.7.x surface` for the conformance API contract description.

## Why

- The fixture README referenced an older version line and no longer matched the current Python source-of-truth version family.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
