### PR TITLE
docs: add controller preview example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ else:
     render(call_llm(user_input))
 ```
 
+Controller quick example:
+
+```python
+from context_compiler import create_engine, preview, state_diff, step
+
+engine = create_engine()
+
+before = engine.state
+dry_run = preview(engine, "prohibit peanuts")
+print(dry_run["would_mutate"])  # True
+planned_change = state_diff(before, dry_run["state_after"])
+print(planned_change["changed"])  # True
+
+after_preview = engine.state
+print(state_diff(before, after_preview)["changed"])  # False (preview does not mutate state)
+
+applied = step(engine, "prohibit peanuts")
+print(applied["decision"]["kind"])  # update
+```
+
 ## Installation
 
 Requirements:

--- a/examples/08_controller_preview_diff.py
+++ b/examples/08_controller_preview_diff.py
@@ -1,0 +1,30 @@
+"""Example 8: controller preview + state diff + apply flow."""
+
+from _util import print_decision_summary, print_state_summary
+
+from context_compiler import create_engine, preview, state_diff, step
+
+
+def main() -> None:
+    engine = create_engine()
+
+    state_before = engine.state
+    print_state_summary(state_before, "state before preview")
+
+    print("\nPreview: prohibit peanuts")
+    preview_result = preview(engine, "prohibit peanuts")
+    print("would_mutate:", preview_result["would_mutate"])
+    print_decision_summary(preview_result["decision"])
+
+    state_after_preview = engine.state
+    diff_after_preview = state_diff(state_before, state_after_preview)
+    print("state changed after preview:", diff_after_preview["changed"])
+
+    print("\nApply: prohibit peanuts")
+    step_result = step(engine, "prohibit peanuts")
+    print_decision_summary(step_result["decision"])
+    print_state_summary(step_result["state"], "state after step")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,3 +40,9 @@ Shows `compile_transcript(messages)` from a fresh engine and `engine.apply_trans
 
 Demonstrates explicit single-policy correction without `reset policies`.  
 Shows `prohibit peanuts` -> `remove policy peanuts` -> `use peanuts`.
+
+## 08_controller_preview_diff.py
+
+Shows controller-layer dry-run behavior with `preview(engine, user_input)`.  
+Shows structural state inspection with `state_diff(state_before, state_after)`.  
+Shows `step(engine, user_input)` after preview to apply the same input.

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -17,7 +17,7 @@ export OPENAI_API_KEY=...
 export PROVIDER=openai
 ```
 
-Checkpoint continuation in these integration examples requires `context-compiler>=0.6.14`.
+Checkpoint continuation in these integration examples requires `context-compiler>=0.7.0`.
 
 ### Run
 


### PR DESCRIPTION
## What changed

- Added a new focused example: `examples/08_controller_preview_diff.py`.
- Added the new example to `examples/README.md`.
- Added a short controller quick example to `README.md` showing `preview(...)`, `state_diff(...)`, and `step(...)`.
- Updated `examples/integrations/README.md` to align the checkpoint continuation version note to `context-compiler>=0.7.0`.
- Adjusted the README quick example to avoid encouraging direct nested state-shape access and instead show change inspection through `state_diff(...)`.

## Why

- Improve discoverability of the 0.7 controller/auditability APIs with one short, user-facing example.
- Keep existing lower-level examples intact while adding a clear path for users who want preview and structural diff behavior.
- Encourage API usage patterns that are less coupled to internal state structure.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
