### PR TITLE
chore: prep 0.7.5 metadata and integration literal cleanup

### DIFF
--- a/examples/integrations/litellm/basic.py
+++ b/examples/integrations/litellm/basic.py
@@ -175,7 +175,7 @@ def _persist_session_checkpoint_if_needed(
 ) -> None:
     if session_key is None:
         return
-    if kind not in {"update", "clarify"}:
+    if kind not in {DECISION_UPDATE, DECISION_CLARIFY}:
         return
     _CHECKPOINTS_BY_SESSION_KEY[session_key] = engine.export_checkpoint_json()
 
@@ -305,7 +305,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             near_miss_prompt,
             original_input=user_input,
             compiler_input=user_input,
-            decision={"kind": "clarify", "prompt_to_user": near_miss_prompt},
+            decision={"kind": DECISION_CLARIFY, "prompt_to_user": near_miss_prompt},
             state_before=state_before,
             state_after=engine.state,
             llm_called=False,

--- a/examples/integrations/litellm/with_preprocessor.py
+++ b/examples/integrations/litellm/with_preprocessor.py
@@ -286,7 +286,7 @@ def _persist_session_checkpoint_if_needed(
 ) -> None:
     if session_key is None:
         return
-    if kind not in {"update", "clarify"}:
+    if kind not in {DECISION_UPDATE, DECISION_CLARIFY}:
         return
     _CHECKPOINTS_BY_SESSION_KEY[session_key] = engine.export_checkpoint_json()
 
@@ -430,7 +430,7 @@ def handle_turn(user_input: str, engine: Engine, *, session_key: str | None = No
             original_input=user_input,
             compiler_input=compile_input,
             preprocessor_output=preprocessd,
-            decision={"kind": "clarify", "prompt_to_user": near_miss_prompt},
+            decision={"kind": DECISION_CLARIFY, "prompt_to_user": near_miss_prompt},
             state_before=state_before,
             state_after=engine.state,
             llm_called=False,

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -643,7 +643,7 @@ class Pipe:
                 near_miss_prompt,
                 original_input=latest_user_text,
                 compiler_input=latest_user_text,
-                decision={"kind": "clarify", "prompt_to_user": near_miss_prompt},
+                decision={"kind": DECISION_CLARIFY, "prompt_to_user": near_miss_prompt},
                 state_before=state_before,
                 state_after=state_after,
                 llm_called=False,

--- a/examples/integrations/openwebui/open_webui_pipe.py
+++ b/examples/integrations/openwebui/open_webui_pipe.py
@@ -3,7 +3,7 @@ title: Context Compiler Pipe
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.9.2
+version: 0.9.3
 requirements: context-compiler>=0.7.4
 
 Minimal Open WebUI Pipe integration for Context Compiler.

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -3,7 +3,7 @@ title: Context Compiler Pipe (Preprocessor)
 author: rlippmann
 author_url: https://github.com/rlippmann/context-compiler
 funding_url: https://github.com/rlippmann/context-compiler
-version: 0.9.2
+version: 0.9.3
 requirements: context-compiler[experimental]>=0.7.4
 
 Open WebUI integration with Context Compiler preprocessor.

--- a/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
+++ b/examples/integrations/openwebui/open_webui_pipe_with_preprocessor.py
@@ -922,7 +922,7 @@ class Pipe:
                 near_miss_prompt,
                 original_input=latest_user_text,
                 compiler_input=compile_input,
-                decision={"kind": "clarify", "prompt_to_user": near_miss_prompt},
+                decision={"kind": DECISION_CLARIFY, "prompt_to_user": near_miss_prompt},
                 state_before=state_before,
                 state_after=state_after,
                 preprocessor_output=preprocessd,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.7.4"
+version = "0.7.5"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- Bumped package version from `0.7.4` to `0.7.5`.
- Updated lockfile via `uv lock` for the version bump.
- Replaced remaining low-risk semantic decision literals in integration host code with exported decision constants.
- Updated OpenWebUI example frontmatter metadata:
  - `open_webui_pipe.py`: `version: 0.9.3`
  - `open_webui_pipe_with_preprocessor.py`: `version: 0.9.3`

## Why

- Keep release metadata aligned for the 0.7.5 release.
- Reduce copy-paste drift in user-facing integrations by preferring exported constants for semantic decision values.
- Keep integration examples consistent with the current helper/constants guidance.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
