### PR TITLE
test: add preprocessor drift fixtures

### DIFF
--- a/tests/fixtures/preprocessor/meta-prefix-the-command-is-clear-state-unknown.json
+++ b/tests/fixtures/preprocessor/meta-prefix-the-command-is-clear-state-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "meta-prefix-the-command-is-clear-state-unknown",
+  "input": "the command is clear state",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/mixed-intent-clear-state-then-continue-unknown.json
+++ b/tests/fixtures/preprocessor/mixed-intent-clear-state-then-continue-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "mixed-intent-clear-state-then-continue-unknown",
+  "input": "clear state then continue",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/mixed-intent-use-docker-because-repo-has-docker-unknown.json
+++ b/tests/fixtures/preprocessor/mixed-intent-use-docker-because-repo-has-docker-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "mixed-intent-use-docker-because-repo-has-docker-unknown",
+  "input": "use docker because this repo already has Docker",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/modal-please-change-premise-concise-replies-unknown.json
+++ b/tests/fixtures/preprocessor/modal-please-change-premise-concise-replies-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "modal-please-change-premise-concise-replies-unknown",
+  "input": "please change premise concise replies",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/modal-please-set-premise-to-concise-replies-unknown.json
+++ b/tests/fixtures/preprocessor/modal-please-set-premise-to-concise-replies-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "modal-please-set-premise-to-concise-replies-unknown",
+  "input": "please set premise to concise replies",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/multi-instruction-use-docker-actually-prohibit-unknown.json
+++ b/tests/fixtures/preprocessor/multi-instruction-use-docker-actually-prohibit-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "multi-instruction-use-docker-actually-prohibit-unknown",
+  "input": "use docker, actually prohibit docker",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/natural-language-do-not-use-unknown.json
+++ b/tests/fixtures/preprocessor/natural-language-do-not-use-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "natural-language-do-not-use-unknown",
+  "input": "do not use peanuts",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/near-miss-change-premise-missing-to-keyword-unknown.json
+++ b/tests/fixtures/preprocessor/near-miss-change-premise-missing-to-keyword-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-change-premise-missing-to-keyword-unknown",
+  "input": "change premise formal tone",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/near-miss-set-premise-to-formal-tone-unknown.json
+++ b/tests/fixtures/preprocessor/near-miss-set-premise-to-formal-tone-unknown.json
@@ -1,0 +1,8 @@
+{
+  "name": "near-miss-set-premise-to-formal-tone-unknown",
+  "input": "set premise to formal tone",
+  "expected": {
+    "classification": "unknown",
+    "output": null
+  }
+}

--- a/tests/fixtures/preprocessor/question-help-with-lunch-no-directive.json
+++ b/tests/fixtures/preprocessor/question-help-with-lunch-no-directive.json
@@ -1,0 +1,8 @@
+{
+  "name": "question-help-with-lunch-no-directive",
+  "input": "can you help with lunch?",
+  "expected": {
+    "classification": "no_directive",
+    "output": null
+  }
+}


### PR DESCRIPTION
## What changed

- Added 10 shared preprocessor heuristic fixtures under `tests/fixtures/preprocessor/` to cover regular-test-only Python cases.
- Added fixture coverage for mixed-intent, discourse-marker/meta-prefix, near-miss, modal-prefix, and no-directive question behavior currently asserted in Python tests.
- Included the confirmed drift case: `use docker, actually prohibit docker` -> `unknown`.

## Why

- Shared preprocessor conformance fixtures had drifted behind Python regular tests for several explicitly asserted behaviors.
- These fixture additions make those behaviors part of shared source-of-truth fixture coverage, reducing parity gaps across ports.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
