### PR TITLE
chore: bump version to 0.7.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.7.8"
+version = "0.7.9"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.7.8"
+version = "0.7.9"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- bump the package version from `0.7.8` to `0.7.9` in `pyproject.toml`
- update the editable package version recorded in `uv.lock` to match

## Why

- the version bump was missed from the earlier feature PRs and should land as its own small release-prep change
- keeping `pyproject.toml` and `uv.lock` aligned avoids packaging confusion for the release

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
