### PR TITLE
fix: mark package as typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.7.9"
+version = "0.7.10"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ packages = ["src/context_compiler", "experimental"]
 [tool.hatch.build.targets.wheel.force-include]
 "examples" = "examples"
 "host_support" = "host_support"
+"src/context_compiler/py.typed" = "context_compiler/py.typed"
 
 [project.optional-dependencies]
 demos = [

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.7.9"
+version = "0.7.10"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- Added the `py.typed` marker to the `context_compiler` package.
- Updated Hatch wheel packaging so `context_compiler/py.typed` is included in built wheels.
- Bumped the package version to `0.7.10`.

## Why

- Downstream projects running mypy against the installed wheel currently see `context_compiler` as untyped.
- This marks the package as typed for PEP 561-aware type checkers.
- The fix was exposed while using `context-compiler` as an installed dependency from the example integrations repo.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)