### PR TITLE
fix: package core runtime only

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,9 @@ pip install context-compiler
 
 Packaging notes:
 - Base install includes the core authority-layer engine and CLI.
-- Install example files with `pip install "context-compiler[examples]"`.
-- Install demo files and demo dependencies with `pip install "context-compiler[demos]"`.
+- Example and demo source files are available in the repository and source distribution.
+- To run the demos from this repository, clone the repo and install `context-compiler[demos]`.
+- The `[demos]` extra installs optional dependencies such as LiteLLM. It does not install demo source files into site-packages.
 
 ### Development
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -35,11 +35,15 @@ patterns still appear in real applications.
 
 ## Requirements
 
-Install demo dependencies:
+To run the demos from this repository, clone the repo and install the demo dependency extra:
 
 ```bash
+git clone https://github.com/rlippmann/context-compiler.git
+cd context-compiler
 pip install "context-compiler[demos]"
 ```
+
+The `[demos]` extra installs optional dependencies such as LiteLLM. It does not install demo source files into site-packages.
 
 Environment variables (strict provider mode contract):
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,13 +2,13 @@
 
 This directory contains small authority-layer examples showing typical app-side usage of Context Compiler.
 
-Install examples with:
+Install the core package with:
 
 ```bash
-pip install "context-compiler[examples]"
+pip install context-compiler
 ```
 
-Non-integration example files in this directory are standalone scripts and can be run directly.
+Example files in this directory are included in the repository and source distribution, and can be run directly.
 
 ## 01_persistent_guardrails.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,6 @@ context-compiler = "context_compiler.repl:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/context_compiler"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"demos" = "demos"
-"examples" = "examples"
-"host_support" = "host_support"
-"src/context_compiler/py.typed" = "context_compiler/py.typed"
-
 [tool.hatch.build.targets.sdist]
 include = [
   "/README.md",
@@ -57,7 +51,6 @@ include = [
 ]
 
 [project.optional-dependencies]
-examples = []
 demos = [
   "litellm>=1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.8.0"
+version = "0.8.1"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -324,7 +324,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12,<1.0" },
 ]
-provides-extras = ["examples", "demos", "dev"]
+provides-extras = ["demos", "dev"]
 
 [[package]]
 name = "coverage"


### PR DESCRIPTION
What changed

* Removed examples/, demos/, and host_support/ from the Python wheel.
* Kept example and demo source files in the repository and source distribution.
* Removed the unused examples extra.
* Retained the demos extra as a dependency bundle for running repository demos.
* Updated packaging and installation documentation to clarify the distinction between runtime installs and repository artifacts.
* Bumped the Python package version to 0.8.1.

Why

* Extras control dependencies, not which files are included in a wheel.
* The 0.8.0 wheel unintentionally shipped repository artifacts that are not part of the core runtime contract.
* The intended packaging model is:
    * pip install context-compiler → core runtime only
    * repository checkout → examples, demos, and integration artifacts
    * context-compiler[demos] → optional dependencies for running repository demo scripts

Checklist

* pre-commit run (uv run pre-commit run --all-files)
* tests pass (uv run pytest)