### PR TITLE
Reject compound directives and strengthen grammar validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ set premise concise replies
 - Base model: silently accepts / rewrites
 - Context Compiler: applies a repeatable state update
 
+**Single-directive grammar**
+```text
+use docker and prohibit peanuts
+```
+- Without an authority layer: host/model behavior varies
+- Context Compiler: returns `clarify`, keeps authoritative state unchanged, and asks for separate directives
+
 **State-dependent operation**
 ```text
 clear state
@@ -373,7 +380,40 @@ User: reset policies
 User: clear state
 ```
 
-Conflicting directives trigger clarification instead of changing state.
+Grammar invariant: one input may contain at most one canonical directive.
+If another canonical directive start appears later in the same input, the
+input is invalid and Context Compiler returns `clarify` without mutating
+authoritative state or creating pending confirmation state.
+
+Examples:
+
+```text
+Valid:
+use docker
+use podman instead of docker
+clear state
+
+Invalid:
+use docker and prohibit peanuts
+set premise vegetarian and use docker
+clear state then set premise new project
+```
+
+Quote behavior follows the current grammar literally:
+
+```text
+Passthrough:
+"use docker and prohibit peanuts"
+
+Invalid:
+use "docker and prohibit peanuts"
+set premise "use docker and prohibit peanuts"
+```
+
+Quotes do not create protected literal regions inside a recognized directive
+payload.
+
+Conflicting directives also trigger clarification instead of changing state.
 
 For full directive grammar and edge-case behavior, see [DirectiveGrammarSpec.md](docs/DirectiveGrammarSpec.md).
 

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -131,6 +131,9 @@ CLEAR_STATE      := "clear state"
 Notes:
 
 - `ITEM` is a non-empty raw substring after its prefix.
+- One input may contain at most one canonical directive. If another canonical
+  directive start appears later in the same input, the input is invalid under
+  the current grammar and must return `clarify`.
 - Recognized policy directives with empty or whitespace-only `ITEM` payload return `clarify`.
 - Premise directive payload must contain at least one non-whitespace character after the prefix.
   Empty and whitespace-only premise payloads are invalid and must return `clarify`.
@@ -140,6 +143,11 @@ Notes:
   This does not broaden directive grammar acceptance.
 - `ITEM` is normalized via `normalize_item` before policy lookup/storage.
 - `VALUE` is stored using premise sanitation from Section 6.
+- Quote characters do not create protected literal regions for directive
+  parsing. A fully quoted input remains ordinary `passthrough` unless the raw
+  input begins with a canonical directive. Quote characters inside a
+  recognized directive payload do not suppress later canonical directive
+  detection.
 - No conversational aliases are directives (for example: `actually`, `I meant`, `allow`, `you can`, `set X`, `I'm using X`).
 
 ## 8. State Transition Semantics
@@ -219,6 +227,35 @@ This operation is authoritative replacement, not recency resolution.
 - `remove policy ITEM`: remove one normalized policy key from `policies` if present
 - `clear state`: reset all authoritative state by setting `premise = null` and `policies = {}`
 
+### 8.5 Compound directives
+
+If an input begins with a canonical directive and a later canonical directive
+start also appears in the same input, the input is invalid under the current
+grammar.
+
+Behavior:
+
+- return `Decision.kind = "clarify"`
+- do not mutate authoritative state
+- do not create pending clarification or pending replacement state
+- reuse the normal public clarify contract; there is no separate decision kind
+
+Deterministic prompt:
+
+`Multiple directives are not supported in one input.`
+`Submit each directive separately.`
+
+Examples:
+
+- valid: `use docker`
+- valid: `use docker instead of podman`
+- invalid: `use docker and prohibit peanuts`
+- invalid: `set premise vegetarian and use docker`
+- invalid: `clear state then set premise new project`
+- passthrough: `"use docker and prohibit peanuts"`
+- invalid: `use "docker and prohibit peanuts"`
+- invalid: `set premise "use docker and prohibit peanuts"`
+
 ## 9. Clarification Rules (Exhaustive)
 
 The compiler returns `Decision.kind = "clarify"` only in these cases:
@@ -240,6 +277,7 @@ The compiler returns `Decision.kind = "clarify"` only in these cases:
 15. `use X instead of Y` when replacement syntax is recognized but `X` or `Y` is empty/whitespace-only.
 16. `set premise to X` near-miss with non-empty `X`.
 17. `change premise X` near-miss with non-empty `X`.
+18. An input contains more than one canonical directive start.
 
 Contradictions never silently overwrite state.
 
@@ -292,6 +330,9 @@ When `Decision.kind = "clarify"`, prompt text is deterministic only for the case
   `Did you mean 'set premise X'?`
 - Premise near-miss `change premise X` (Section 9 case 17):
   `Did you mean 'change premise to X'?`
+- Compound directive rejection (Section 9 case 18):
+  `Multiple directives are not supported in one input.`
+  `Submit each directive separately.`
 
 ## 10. Pending Clarification
 
@@ -401,6 +442,7 @@ Checkpoint semantics:
 6. Policy state is per-item authoritative (`"use" | "prohibit"`), never ordered/additive by history.
 7. Contradictions always clarify; they never overwrite.
 8. Premise can be explicitly cleared via `clear premise` (`premise = null`).
+9. A single input never applies more than one canonical directive.
 
 ## 13. Non-Goals
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -45,6 +45,16 @@ decision = engine.step("set premise current project uses uv")
 Behavior for directive handling, clarification, and confirmation flows is
 defined by the [Directive Grammar Specification](DirectiveGrammarSpec.md).
 
+Important grammar contract:
+
+- one input may contain at most one canonical directive
+- if a later canonical directive start appears in the same input, `engine.step(...)`
+  returns the normal `clarify` decision contract
+- compound directives do not mutate authoritative state and do not create
+  pending clarification or replacement state
+- quote characters do not create protected literal regions inside recognized
+  directive payloads
+
 ### `engine.state`
 
 Read the current authoritative in-memory state snapshot.
@@ -147,6 +157,11 @@ state snapshot.
 
 Transcript replay behavior is governed by the engine semantics and transcript
 fixture contracts, not by this page.
+
+In particular, replay preserves normal `engine.step(...)` behavior for invalid
+compound directives: replay stops at the first `clarify` result, does not
+apply any directive from that input, and does not create pending replacement
+state for that turn.
 
 ## State Import/Export
 

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -82,6 +82,7 @@ ApplyResult = ApplyResultState | ApplyResultConfirm
 @dataclass(frozen=True)
 class Action:
     kind: Literal[
+        "compound_directive_invalid",
         "set_premise",
         "change_premise",
         "set_premise_to_variant",
@@ -118,6 +119,30 @@ _AFFIRMATIVE_CONFIRMATIONS = {"yes", "yes please", "yep", "yeah", "sure", "ok", 
 _NEGATIVE_CONFIRMATIONS = {"no", "nope", "no thanks"}
 _TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
 _CHECKPOINT_VERSION: Literal[1] = 1
+_COMPOUND_DIRECTIVE_PROMPT = (
+    "Multiple directives are not supported in one input.\nSubmit each directive separately."
+)
+_CLEAR_PREMISE = "clear premise"
+_RESET_POLICIES = "reset policies"
+_CLEAR_STATE = "clear state"
+_REMOVE_POLICY_BASE = "remove policy"
+_SET_PREMISE_TO_PREFIX = "set premise to "
+_CHANGE_PREMISE_PREFIX = "change premise "
+_CHANGE_PREMISE_BASE = "change premise to"
+_SET_PREMISE_BASE = "set premise"
+_USE_PREFIX = "use "
+_PROHIBIT_BASE = "prohibit"
+_PROHIBIT_PREFIX = "prohibit "
+_CANONICAL_DIRECTIVE_STARTS: tuple[tuple[str, bool], ...] = (
+    (_CHANGE_PREMISE_BASE, True),
+    (_SET_PREMISE_BASE, True),
+    (_REMOVE_POLICY_BASE, True),
+    (_RESET_POLICIES, False),
+    (_CLEAR_PREMISE, False),
+    (_CLEAR_STATE, False),
+    (_PROHIBIT_BASE, True),
+    ("use", True),
+)
 
 
 def create_engine(state: State | None = None) -> "Engine":
@@ -254,6 +279,9 @@ class Engine:
 
     def _pre_mutation_clarify(self, action: Action) -> Decision | None:
         # Single clarify path: all clarify outcomes are detected before any mutation.
+        if action.kind == "compound_directive_invalid":
+            return _clarify(_COMPOUND_DIRECTIVE_PROMPT)
+
         if action.kind in {"set_premise", "change_premise"}:
             assert action.value is not None
             if _sanitize_premise_value(action.value) == "":
@@ -439,48 +467,46 @@ class Engine:
 
 
 def _parse_directive(user_input: str) -> Action | None:
-    if user_input == "clear premise":
+    if _contains_compound_directive(user_input):
+        return Action(kind="compound_directive_invalid")
+
+    if user_input == _CLEAR_PREMISE:
         return Action(kind="clear_premise")
-    if user_input == "reset policies":
+    if user_input == _RESET_POLICIES:
         return Action(kind="reset_policies")
-    if user_input == "clear state":
+    if user_input == _CLEAR_STATE:
         return Action(kind="clear_state")
 
-    remove_policy_base = "remove policy"
-    if user_input == remove_policy_base:
+    if user_input == _REMOVE_POLICY_BASE:
         return Action(kind="remove_policy_item", item="")
-    remove_policy_prefix = f"{remove_policy_base} "
+    remove_policy_prefix = f"{_REMOVE_POLICY_BASE} "
     if user_input.startswith(remove_policy_prefix):
         return Action(kind="remove_policy_item", item=user_input[len(remove_policy_prefix) :])
 
-    set_to_prefix = "set premise to "
-    if user_input.startswith(set_to_prefix):
-        value = user_input[len(set_to_prefix) :].strip()
+    if user_input.startswith(_SET_PREMISE_TO_PREFIX):
+        value = user_input[len(_SET_PREMISE_TO_PREFIX) :].strip()
         if value != "":
             return Action(kind="set_premise_to_variant", value=value)
 
-    change_missing_to_prefix = "change premise "
     if (
-        user_input.startswith(change_missing_to_prefix)
-        and not user_input.startswith("change premise to ")
-        and user_input != "change premise to"
+        user_input.startswith(_CHANGE_PREMISE_PREFIX)
+        and not user_input.startswith(f"{_CHANGE_PREMISE_BASE} ")
+        and user_input != _CHANGE_PREMISE_BASE
     ):
-        value = user_input[len(change_missing_to_prefix) :].strip()
+        value = user_input[len(_CHANGE_PREMISE_PREFIX) :].strip()
         if value != "":
             return Action(kind="change_premise_missing_to_variant", value=value)
 
-    set_base = "set premise"
-    if user_input == set_base:
+    if user_input == _SET_PREMISE_BASE:
         return Action(kind="set_premise", value="")
-    set_prefix = f"{set_base} "
+    set_prefix = f"{_SET_PREMISE_BASE} "
     if user_input.startswith(set_prefix):
         value = user_input[len(set_prefix) :]
         return Action(kind="set_premise", value=value)
 
-    change_base = "change premise to"
-    if user_input == change_base:
+    if user_input == _CHANGE_PREMISE_BASE:
         return Action(kind="change_premise", value="")
-    change_prefix = f"{change_base} "
+    change_prefix = f"{_CHANGE_PREMISE_BASE} "
     if user_input.startswith(change_prefix):
         value = user_input[len(change_prefix) :]
         return Action(kind="change_premise", value=value)
@@ -488,9 +514,8 @@ def _parse_directive(user_input: str) -> Action | None:
     if user_input == "use":
         return Action(kind="use_item", item="")
 
-    use_prefix = "use "
-    if user_input.startswith(use_prefix):
-        payload = user_input[len(use_prefix) :]
+    if user_input.startswith(_USE_PREFIX):
+        payload = user_input[len(_USE_PREFIX) :]
         left, sep, right = payload.partition(" instead of ")
         if sep:
             if left.strip() != "" and right.strip() != "":
@@ -502,15 +527,64 @@ def _parse_directive(user_input: str) -> Action | None:
             return Action(kind="replace_use_incomplete")
         return Action(kind="use_item", item=payload)
 
-    if user_input == "prohibit":
+    if user_input == _PROHIBIT_BASE:
         return Action(kind="prohibit_item", item="")
 
-    prohibit_prefix = "prohibit "
-    if user_input.startswith(prohibit_prefix):
-        item = user_input[len(prohibit_prefix) :]
+    if user_input.startswith(_PROHIBIT_PREFIX):
+        item = user_input[len(_PROHIBIT_PREFIX) :]
         return Action(kind="prohibit_item", item=item)
 
     return None
+
+
+def _contains_compound_directive(user_input: str) -> bool:
+    first_start = _match_canonical_directive_start(user_input, 0)
+    if first_start is None:
+        return False
+
+    for index in range(first_start, len(user_input)):
+        next_start = _match_canonical_directive_start(user_input, index)
+        if next_start is not None:
+            return True
+
+    return False
+
+
+def _match_canonical_directive_start(user_input: str, start: int) -> int | None:
+    if start < 0 or start >= len(user_input):
+        return None
+
+    if start > 0 and user_input[start - 1].isalpha():
+        return None
+
+    for token, require_space_or_end in _CANONICAL_DIRECTIVE_STARTS:
+        if _matches_directive_token(
+            user_input, start, token, require_space_or_end=require_space_or_end
+        ):
+            return start + len(token)
+
+    return None
+
+
+def _matches_directive_token(
+    user_input: str,
+    start: int,
+    token: str,
+    *,
+    require_space_or_end: bool = False,
+) -> bool:
+    if not user_input.startswith(token, start):
+        return False
+
+    end = start + len(token)
+    if end == len(user_input):
+        return True
+
+    next_char = user_input[end]
+    if require_space_or_end:
+        return next_char == " "
+
+    return not next_char.isalpha()
 
 
 def _initial_state() -> State:

--- a/tests/fixtures/conformance/step/020_compound_use_and_prohibit_clarify.json
+++ b/tests/fixtures/conformance/step/020_compound_use_and_prohibit_clarify.json
@@ -1,0 +1,23 @@
+{
+  "id": "step_compound_use_and_prohibit_clarify",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "input": "use docker and prohibit peanuts",
+  "expected": {
+    "decision": {
+      "kind": "clarify",
+      "prompt_to_user": "Multiple directives are not supported in one input.\nSubmit each directive separately.",
+      "state": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/step/021_compound_set_premise_and_use_clarify.json
+++ b/tests/fixtures/conformance/step/021_compound_set_premise_and_use_clarify.json
@@ -1,0 +1,23 @@
+{
+  "id": "step_compound_set_premise_and_use_clarify",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "input": "set premise vegetarian and use docker",
+  "expected": {
+    "decision": {
+      "kind": "clarify",
+      "prompt_to_user": "Multiple directives are not supported in one input.\nSubmit each directive separately.",
+      "state": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/step/022_compound_clear_state_then_set_premise_clarify.json
+++ b/tests/fixtures/conformance/step/022_compound_clear_state_then_set_premise_clarify.json
@@ -1,0 +1,27 @@
+{
+  "id": "step_compound_clear_state_then_set_premise_clarify",
+  "kind": "step",
+  "initial_state": {
+    "premise": "baseline",
+    "policies": {
+      "docker": "use"
+    },
+    "version": 2
+  },
+  "input": "clear state then set premise project",
+  "expected": {
+    "decision": {
+      "kind": "clarify",
+      "prompt_to_user": "Multiple directives are not supported in one input.\nSubmit each directive separately.",
+      "state": null
+    },
+    "state": {
+      "premise": "baseline",
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/step/023_compound_remove_policy_and_prohibit_clarify.json
+++ b/tests/fixtures/conformance/step/023_compound_remove_policy_and_prohibit_clarify.json
@@ -1,0 +1,27 @@
+{
+  "id": "step_compound_remove_policy_and_prohibit_clarify",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {
+      "docker": "use"
+    },
+    "version": 2
+  },
+  "input": "remove policy docker and prohibit peanuts",
+  "expected": {
+    "decision": {
+      "kind": "clarify",
+      "prompt_to_user": "Multiple directives are not supported in one input.\nSubmit each directive separately.",
+      "state": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/step/024_compound_use_or_prohibit_clarify.json
+++ b/tests/fixtures/conformance/step/024_compound_use_or_prohibit_clarify.json
@@ -1,0 +1,23 @@
+{
+  "id": "step_compound_use_or_prohibit_clarify",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "input": "use docker or prohibit peanuts",
+  "expected": {
+    "decision": {
+      "kind": "clarify",
+      "prompt_to_user": "Multiple directives are not supported in one input.\nSubmit each directive separately.",
+      "state": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/step/025_compound_use_xor_prohibit_clarify.json
+++ b/tests/fixtures/conformance/step/025_compound_use_xor_prohibit_clarify.json
@@ -1,0 +1,23 @@
+{
+  "id": "step_compound_use_xor_prohibit_clarify",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "input": "use docker xor prohibit peanuts",
+  "expected": {
+    "decision": {
+      "kind": "clarify",
+      "prompt_to_user": "Multiple directives are not supported in one input.\nSubmit each directive separately.",
+      "state": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/step/026_compound_use_punctuation_prohibit_clarify.json
+++ b/tests/fixtures/conformance/step/026_compound_use_punctuation_prohibit_clarify.json
@@ -1,0 +1,23 @@
+{
+  "id": "step_compound_use_punctuation_prohibit_clarify",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "input": "use docker. prohibit peanuts",
+  "expected": {
+    "decision": {
+      "kind": "clarify",
+      "prompt_to_user": "Multiple directives are not supported in one input.\nSubmit each directive separately.",
+      "state": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/step/027_quoted_leading_directive_text_passthrough.json
+++ b/tests/fixtures/conformance/step/027_quoted_leading_directive_text_passthrough.json
@@ -1,0 +1,23 @@
+{
+  "id": "step_quoted_leading_directive_text_passthrough",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "input": "\"use docker and prohibit peanuts\"",
+  "expected": {
+    "decision": {
+      "kind": "passthrough",
+      "prompt_to_user": null,
+      "state": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/step/028_quoted_payload_compound_clarify.json
+++ b/tests/fixtures/conformance/step/028_quoted_payload_compound_clarify.json
@@ -1,0 +1,23 @@
+{
+  "id": "step_quoted_payload_compound_clarify",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "input": "use \"docker and prohibit peanuts\"",
+  "expected": {
+    "decision": {
+      "kind": "clarify",
+      "prompt_to_user": "Multiple directives are not supported in one input.\nSubmit each directive separately.",
+      "state": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "has_pending_clarification": false
+  }
+}

--- a/tests/fixtures/conformance/transcript/005_stops_at_compound_directive_and_ignores_later_messages.json
+++ b/tests/fixtures/conformance/transcript/005_stops_at_compound_directive_and_ignores_later_messages.json
@@ -1,0 +1,23 @@
+{
+  "id": "transcript_stops_at_compound_directive_and_ignores_later_messages",
+  "kind": "transcript",
+  "messages": [
+    {
+      "role": "user",
+      "content": "set premise concise"
+    },
+    {
+      "role": "user",
+      "content": "use docker and prohibit peanuts"
+    },
+    {
+      "role": "user",
+      "content": "prohibit shellfish"
+    }
+  ],
+  "expected": {
+    "clarify": {
+      "prompt_to_user": "Multiple directives are not supported in one input.\nSubmit each directive separately."
+    }
+  }
+}

--- a/tests/test_compound_directive_properties.py
+++ b/tests/test_compound_directive_properties.py
@@ -1,0 +1,174 @@
+import string
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from context_compiler import create_engine
+
+COMPOUND_DIRECTIVE_PROMPT = (
+    "Multiple directives are not supported in one input.\nSubmit each directive separately."
+)
+
+CANONICAL_SECOND_DIRECTIVES = [
+    "set premise concise",
+    "change premise to concise",
+    "use pytest",
+    "prohibit peanuts",
+    "remove policy docker",
+    "use pytest instead of docker",
+    "clear premise",
+    "reset policies",
+    "clear state",
+]
+
+CANONICAL_STARTS = [
+    "set premise",
+    "change premise to",
+    "use",
+    "prohibit",
+    "remove policy",
+    "clear premise",
+    "reset policies",
+    "clear state",
+]
+
+SEPARATOR_CHARS = " \t\n\r,.;:!?-/()[]"
+LETTER_CHARS = string.ascii_lowercase
+
+
+def _assert_compound_rejection(user_input: str) -> None:
+    engine = create_engine()
+    before = engine.state
+
+    decision = engine.step(user_input)
+
+    assert decision == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": COMPOUND_DIRECTIVE_PROMPT,
+    }
+    assert engine.state == before
+    assert engine.has_pending_clarification() is False
+
+
+@settings(max_examples=50)
+@given(
+    separator=st.text(alphabet=SEPARATOR_CHARS, min_size=1, max_size=8),
+    second=st.sampled_from(CANONICAL_SECOND_DIRECTIVES),
+)
+def test_compound_separator_robustness(separator: str, second: str) -> None:
+    _assert_compound_rejection(f"use docker{separator}{second}")
+
+
+@settings(max_examples=50)
+@given(
+    chunks=st.lists(
+        st.text(alphabet=LETTER_CHARS + " -_", min_size=1, max_size=8),
+        min_size=1,
+        max_size=3,
+    ),
+    second=st.sampled_from(CANONICAL_SECOND_DIRECTIVES),
+)
+def test_compound_arbitrary_intervening_text(chunks: list[str], second: str) -> None:
+    intervening = " ".join(chunks)
+    lowered = intervening.lower()
+    assume(all(token not in lowered for token in CANONICAL_STARTS))
+
+    _assert_compound_rejection(f"use docker {intervening} {second}")
+
+
+@settings(max_examples=50)
+@given(
+    token=st.sampled_from(CANONICAL_STARTS),
+    prefix=st.text(alphabet=LETTER_CHARS, min_size=1, max_size=4),
+    suffix=st.text(alphabet=LETTER_CHARS, min_size=1, max_size=4),
+)
+def test_embedded_canonical_tokens_do_not_trigger_compound_detection(
+    token: str, prefix: str, suffix: str
+) -> None:
+    engine = create_engine()
+    before = engine.state
+
+    decision = engine.step(f"use docker {prefix}{token}{suffix}")
+
+    assert decision["prompt_to_user"] != COMPOUND_DIRECTIVE_PROMPT
+    assert decision["kind"] == "update"
+    assert engine.state != before
+    assert engine.has_pending_clarification() is False
+
+
+@settings(max_examples=50)
+@given(
+    prefix=st.text(
+        alphabet=st.characters(blacklist_characters="\n\r"),
+        min_size=1,
+        max_size=20,
+    ),
+    second=st.sampled_from(CANONICAL_SECOND_DIRECTIVES),
+)
+def test_leading_non_directive_text_disables_compound_detection(prefix: str, second: str) -> None:
+    assume(not any(prefix.startswith(token) for token in CANONICAL_STARTS))
+
+    engine = create_engine()
+    before = engine.state
+    decision = engine.step(f"{prefix} use docker {second}")
+
+    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert engine.state == before
+    assert engine.has_pending_clarification() is False
+
+
+def _mutate_case(text: str) -> st.SearchStrategy[str]:
+    alpha_indexes = [index for index, char in enumerate(text) if char.isalpha()]
+    return st.sampled_from(alpha_indexes).map(
+        lambda index: text[:index] + text[index].upper() + text[index + 1 :],
+    )
+
+
+@settings(max_examples=50)
+@given(second_start=st.sampled_from(CANONICAL_STARTS).flatmap(_mutate_case))
+def test_case_mutated_second_directive_does_not_trigger_compound_detection(
+    second_start: str,
+) -> None:
+    engine = create_engine()
+    before = engine.state
+
+    decision = engine.step(f"use docker {second_start}")
+
+    assert decision["prompt_to_user"] != COMPOUND_DIRECTIVE_PROMPT
+    assert decision["kind"] == "update"
+    assert engine.state != before
+    assert engine.has_pending_clarification() is False
+
+
+@settings(max_examples=50)
+@given(
+    quote=st.sampled_from(['"', "'"]),
+    payload=st.text(
+        alphabet=LETTER_CHARS + " \t,.;:-",
+        min_size=0,
+        max_size=12,
+    ),
+    closing=st.sampled_from(["", '"', "'"]),
+    second=st.sampled_from(CANONICAL_SECOND_DIRECTIVES),
+)
+def test_quotes_do_not_create_protected_region_after_first_directive(
+    quote: str, payload: str, closing: str, second: str
+) -> None:
+    _assert_compound_rejection(f"use {quote}{payload}{closing} {second}")
+
+
+@settings(max_examples=20)
+@given(
+    quote=st.sampled_from(['"', "'"]),
+    second=st.sampled_from(CANONICAL_SECOND_DIRECTIVES),
+)
+def test_fully_quoted_input_remains_passthrough(quote: str, second: str) -> None:
+    engine = create_engine()
+    before = engine.state
+
+    decision = engine.step(f"{quote}use docker {second}{quote}")
+
+    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert engine.state == before
+    assert engine.has_pending_clarification() is False

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -7,6 +7,10 @@ from context_compiler.engine import DecisionKind, Engine
 
 pytestmark = pytest.mark.contract
 
+COMPOUND_DIRECTIVE_PROMPT = (
+    "Multiple directives are not supported in one input.\nSubmit each directive separately."
+)
+
 
 def test_decision_kind_strenum_behavior() -> None:
     for kind in DecisionKind:
@@ -1513,6 +1517,242 @@ def test_remove_policy_uses_normalized_item_matching() -> None:
     decision = engine.step("remove policy the docker")
     assert decision["kind"] == "update"
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
+
+
+@pytest.mark.parametrize(
+    ("user_input", "initial_state"),
+    [
+        ("use docker and prohibit peanuts", {"premise": None, "policies": {}, "version": 2}),
+        ("use docker or prohibit peanuts", {"premise": None, "policies": {}, "version": 2}),
+        ("use docker xor prohibit peanuts", {"premise": None, "policies": {}, "version": 2}),
+        ("use docker but prohibit peanuts", {"premise": None, "policies": {}, "version": 2}),
+        ("use docker; prohibit peanuts", {"premise": None, "policies": {}, "version": 2}),
+        ("use docker. prohibit peanuts", {"premise": None, "policies": {}, "version": 2}),
+        (
+            "use docker for development and prohibit peanuts",
+            {"premise": None, "policies": {}, "version": 2},
+        ),
+        (
+            "set premise vegetarian curry and prohibit peanuts",
+            {"premise": None, "policies": {}, "version": 2},
+        ),
+        (
+            "change premise to vegan curry or use docker",
+            {"premise": "baseline", "policies": {}, "version": 2},
+        ),
+        (
+            "remove policy docker and use podman",
+            {"premise": None, "policies": {"docker": "use"}, "version": 2},
+        ),
+        (
+            "clear premise and prohibit peanuts",
+            {"premise": "baseline", "policies": {}, "version": 2},
+        ),
+        (
+            "reset policies; use docker",
+            {"premise": None, "policies": {"docker": "prohibit"}, "version": 2},
+        ),
+        (
+            "clear state then set premise new project",
+            {"premise": "baseline", "policies": {"docker": "use"}, "version": 2},
+        ),
+        (
+            'use "docker and prohibit peanuts"',
+            {"premise": None, "policies": {}, "version": 2},
+        ),
+        (
+            'set premise "use docker and prohibit peanuts"',
+            {"premise": None, "policies": {}, "version": 2},
+        ),
+        (
+            "use docker instead of prohibit peanuts",
+            {"premise": None, "policies": {}, "version": 2},
+        ),
+    ],
+)
+def test_compound_directives_clarify_without_mutation(
+    user_input: str, initial_state: dict[str, object]
+) -> None:
+    engine = create_engine(state=initial_state)
+    before = engine.state
+
+    decision = engine.step(user_input)
+
+    assert decision == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": COMPOUND_DIRECTIVE_PROMPT,
+    }
+    assert engine.state == before
+    assert engine.has_pending_clarification() is False
+
+
+def test_quoted_non_directive_leading_input_remains_passthrough() -> None:
+    engine = create_engine()
+
+    decision = engine.step('"use docker and prohibit peanuts"')
+
+    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert engine.state == {"premise": None, "policies": {}, "version": 2}
+    assert engine.has_pending_clarification() is False
+
+
+@pytest.mark.parametrize(
+    ("user_input", "initial_state", "expected_decision_kind", "expected_state"),
+    [
+        (
+            "use docker for prohibitively expensive builds",
+            {"premise": None, "policies": {}, "version": 2},
+            "update",
+            {
+                "premise": None,
+                "policies": {"docker for prohibitively expensive builds": "use"},
+                "version": 2,
+            },
+        ),
+        (
+            "set premise reusable docker-prohibit-safe workflow",
+            {"premise": None, "policies": {}, "version": 2},
+            "update",
+            {"premise": "reusable docker-prohibit-safe workflow", "policies": {}, "version": 2},
+        ),
+        (
+            "change premise to reset policieset ownership",
+            {"premise": "baseline", "policies": {}, "version": 2},
+            "update",
+            {"premise": "reset policieset ownership", "policies": {}, "version": 2},
+        ),
+        (
+            "remove policy clear stateful systems",
+            {"premise": None, "policies": {"docker": "use"}, "version": 2},
+            "update",
+            {"premise": None, "policies": {"docker": "use"}, "version": 2},
+        ),
+    ],
+)
+def test_directive_like_substrings_inside_larger_words_do_not_trigger_compound_rejection(
+    user_input: str,
+    initial_state: dict[str, object],
+    expected_decision_kind: str,
+    expected_state: dict[str, object],
+) -> None:
+    engine = create_engine(state=initial_state)
+
+    decision = engine.step(user_input)
+
+    assert not (
+        decision["kind"] == "clarify" and decision["prompt_to_user"] == COMPOUND_DIRECTIVE_PROMPT
+    )
+    assert decision["kind"] == expected_decision_kind
+    assert engine.state == expected_state
+    assert engine.has_pending_clarification() is False
+
+
+@pytest.mark.parametrize(
+    ("user_input", "initial_state", "expected_state"),
+    [
+        (
+            "use docker",
+            {"premise": None, "policies": {}, "version": 2},
+            {"premise": None, "policies": {"docker": "use"}, "version": 2},
+        ),
+        (
+            "prohibit peanuts",
+            {"premise": None, "policies": {}, "version": 2},
+            {"premise": None, "policies": {"peanuts": "prohibit"}, "version": 2},
+        ),
+        (
+            "set premise vegetarian curry",
+            {"premise": None, "policies": {}, "version": 2},
+            {"premise": "vegetarian curry", "policies": {}, "version": 2},
+        ),
+        (
+            "change premise to vegan curry",
+            {"premise": "vegetarian curry", "policies": {}, "version": 2},
+            {"premise": "vegan curry", "policies": {}, "version": 2},
+        ),
+        (
+            "remove policy docker",
+            {"premise": None, "policies": {"docker": "use"}, "version": 2},
+            {"premise": None, "policies": {}, "version": 2},
+        ),
+        (
+            "clear premise",
+            {"premise": "vegetarian curry", "policies": {}, "version": 2},
+            {"premise": None, "policies": {}, "version": 2},
+        ),
+        (
+            "reset policies",
+            {"premise": None, "policies": {"docker": "use"}, "version": 2},
+            {"premise": None, "policies": {}, "version": 2},
+        ),
+        (
+            "clear state",
+            {"premise": "baseline", "policies": {"docker": "use"}, "version": 2},
+            {"premise": None, "policies": {}, "version": 2},
+        ),
+        (
+            "use docker instead of podman",
+            {"premise": None, "policies": {"podman": "use"}, "version": 2},
+            {"premise": None, "policies": {"docker": "use"}, "version": 2},
+        ),
+    ],
+)
+def test_valid_single_directives_still_work(
+    user_input: str, initial_state: dict[str, object], expected_state: dict[str, object]
+) -> None:
+    engine = create_engine(state=initial_state)
+
+    decision = engine.step(user_input)
+
+    assert decision == {"kind": "update", "state": expected_state, "prompt_to_user": None}
+    assert engine.state == expected_state
+    assert engine.has_pending_clarification() is False
+
+
+@pytest.mark.parametrize(
+    "directive_start",
+    [
+        "set premise vegetarian curry",
+        "change premise to vegan curry",
+        "use docker",
+        "prohibit peanuts",
+        "remove policy docker",
+        "use docker instead of podman",
+        "clear premise",
+        "reset policies",
+        "clear state",
+    ],
+)
+def test_all_canonical_directive_starts_remain_single_directive_when_valid(
+    directive_start: str,
+) -> None:
+    engine = create_engine(
+        state={"premise": "baseline", "policies": {"podman": "use"}, "version": 2}
+    )
+
+    decision = engine.step(directive_start)
+
+    assert not (
+        decision["kind"] == "clarify" and decision["prompt_to_user"] == COMPOUND_DIRECTIVE_PROMPT
+    )
+
+
+def test_pending_confirmation_takes_precedence_over_compound_detection() -> None:
+    engine = create_engine()
+    first = engine.step("use kubectl instead of docker")
+    assert first == {
+        "kind": "clarify",
+        "state": None,
+        "prompt_to_user": 'Did you mean to use "kubectl" instead?',
+    }
+    assert engine.has_pending_clarification() is True
+
+    decision = engine.step("use docker and prohibit peanuts")
+
+    assert decision == first
+    assert engine.state == {"premise": None, "policies": {}, "version": 2}
+    assert engine.has_pending_clarification() is True
 
 
 def test_compile_transcript_ignores_non_user_messages() -> None:

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -5,7 +5,7 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 
 from context_compiler import create_engine
-from context_compiler.engine import State
+from context_compiler.engine import _CANONICAL_DIRECTIVE_STARTS, State
 
 
 def _run_sequence(inputs: list[str]) -> State:
@@ -25,6 +25,25 @@ def _normalize_item_like_engine(value: str) -> str:
     return normalized.strip()
 
 
+def _contains_canonical_start_fragment(value: str) -> bool:
+    for start in range(len(value)):
+        if start > 0 and value[start - 1].isalpha():
+            continue
+        for token, require_space_or_end in _CANONICAL_DIRECTIVE_STARTS:
+            if not value.startswith(token, start):
+                continue
+            end = start + len(token)
+            if end == len(value):
+                return True
+            next_char = value[end]
+            if require_space_or_end:
+                if next_char == " ":
+                    return True
+            elif not next_char.isalpha():
+                return True
+    return False
+
+
 @given(st.lists(st.text(max_size=40), min_size=0, max_size=20))
 def test_determinism_same_input_sequence_same_state(inputs: list[str]) -> None:
     assert _run_sequence(inputs) == _run_sequence(inputs)
@@ -36,6 +55,7 @@ def test_idempotent_use_item_is_update_and_stable_state(item: str) -> None:
     assume(not item.startswith("instead of "))
     assume(not item.endswith(" instead of"))
     assume(_normalize_item_like_engine(item) != "")
+    assume(not _contains_canonical_start_fragment(item))
     engine = create_engine()
     d1 = engine.step(f"use {item}")
     d2 = engine.step(f"use {item}")
@@ -70,6 +90,7 @@ def test_use_item_with_empty_normalized_payload_clarifies_without_mutation(
 @given(st.text(min_size=1, max_size=30))
 def test_idempotent_prohibit_item_is_update_and_stable_state(item: str) -> None:
     assume(_normalize_item_like_engine(item) != "")
+    assume(not _contains_canonical_start_fragment(item))
     engine = create_engine()
     d1 = engine.step(f"prohibit {item}")
     d2 = engine.step(f"prohibit {item}")
@@ -126,6 +147,7 @@ def test_passthrough_sequence_preserves_state_and_decision_kind(inputs: list[str
 
 @given(st.text(min_size=1, max_size=30))
 def test_contradiction_use_after_prohibit_always_clarifies(item: str) -> None:
+    assume(not _contains_canonical_start_fragment(item))
     engine = create_engine()
     engine.step(f"prohibit {item}")
     before = engine.state
@@ -140,6 +162,7 @@ def test_contradiction_prohibit_after_use_always_clarifies(item: str) -> None:
     assume(" instead of " not in item)
     assume(not item.startswith("instead of "))
     assume(not item.endswith(" instead of"))
+    assume(not _contains_canonical_start_fragment(item))
     engine = create_engine()
     engine.step(f"use {item}")
     before = engine.state

--- a/tests/test_transcript_replay.py
+++ b/tests/test_transcript_replay.py
@@ -4,6 +4,10 @@ from context_compiler import compile_transcript, create_engine
 
 pytestmark = pytest.mark.contract
 
+COMPOUND_DIRECTIVE_PROMPT = (
+    "Multiple directives are not supported in one input.\nSubmit each directive separately."
+)
+
 
 def test_only_user_messages_affect_transcript_replay() -> None:
     result = compile_transcript(
@@ -180,3 +184,33 @@ def test_apply_transcript_matches_manual_step_replay() -> None:
 
     assert replay_result == manual_result
     assert replay_engine.state == manual_engine.state
+
+
+def test_transcript_stops_at_compound_directive_turn_and_returns_confirm() -> None:
+    result = compile_transcript(
+        [
+            {"role": "user", "content": "set premise concise"},
+            {"role": "user", "content": "use docker and prohibit peanuts"},
+            {"role": "user", "content": "prohibit shellfish"},
+        ]
+    )
+
+    assert result == {"kind": "confirm", "prompt_to_user": COMPOUND_DIRECTIVE_PROMPT}
+
+
+def test_apply_transcript_stops_at_compound_directive_turn_without_applying_either_directive() -> (
+    None
+):
+    engine = create_engine()
+
+    result = engine.apply_transcript(
+        [
+            {"role": "user", "content": "set premise concise"},
+            {"role": "user", "content": "use docker and prohibit peanuts"},
+            {"role": "user", "content": "prohibit shellfish"},
+        ]
+    )
+
+    assert result == {"kind": "confirm", "prompt_to_user": COMPOUND_DIRECTIVE_PROMPT}
+    assert engine.state == {"premise": "concise", "policies": {}, "version": 2}
+    assert engine.has_pending_clarification() is False


### PR DESCRIPTION
## Summary

Strengthen the directive grammar by enforcing the single-directive invariant.

Inputs containing more than one canonical directive are now rejected through the existing public `clarify` decision contract. No authoritative state is mutated and no pending clarification/replacement state is created.

This PR also adds comprehensive regression coverage, conformance fixtures, property-based testing, and documentation updates.

## Changes

### Grammar

- Reject inputs containing multiple canonical directive starts.
- Apply the rule uniformly across all canonical directive families.
- Base detection on canonical directive starts rather than conjunctions or separators.
- Preserve current quote semantics (quotes do not create protected parsing regions).

### Implementation

- Route compound directives through the existing recognized-invalid directive path.
- Preserve pending-confirmation precedence.
- Preserve existing single-directive behavior.
- Centralize canonical directive-start definitions to reduce parser/scanner drift.

### Tests

- Add regression coverage across directive families, separators, quoting, pending confirmation, transcript replay, and parser/scanner alignment.
- Add focused Hypothesis property tests for lexical boundary handling.
- Update existing property tests to reflect the tightened grammar.

### Conformance

- Add canonical compound-directive conformance fixtures.
- Add transcript replay conformance coverage for compound directives.

### Documentation

- Document the single-directive grammar invariant.
- Document compound directives as invalid grammar reported through the existing `clarify` contract.
- Document current quote behavior.
- Add concise grammar examples.

## Validation

- `uv run pytest`
- `uv run pytest --cov=context_compiler --cov-report=term-missing`
- `uv run pre-commit run --all-files`

All passed.

Closes #179