### PR TITLE
chore: bump version to 0.8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.8.2"
+version = "0.8.3"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
What changed

* Bumped the package version from 0.8.2 to 0.8.3 in pyproject.toml and uv.lock.

Why

* Prepare the next Python core patch release containing the merged transcript replay removal and related parity updates.

Checklist

* pre-commit run (uv run pre-commit run --all-files)
* tests pass (uv run pytest)