### PR TITLE
Add Markdown linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,19 @@ on:
   pull_request:
 
 jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Run Markdown lint
+        run: ./scripts/validate_markdown.sh
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,45 @@
+{
+  "globs": [
+    "**/*.md",
+    "!**/node_modules/**",
+    "!**/.venv/**",
+    "!**/.next/**",
+    "!**/.pytest_cache/**",
+    "!**/.tmp-uv-cache/**"
+  ],
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD024": {
+      "siblings_only": true
+    },
+    "MD033": false,
+    "MD046": {
+      "style": "fenced"
+    }
+  },
+  "overrides": [
+    {
+      "filter": [
+        ".github/ISSUE_TEMPLATE/*.md",
+        ".github/pull_request_template.md",
+        "evals/swe-bench/RUBRIC.md"
+      ],
+      "config": {
+        "MD041": false
+      },
+      "combine": "merge"
+    },
+    {
+      "filter": [
+        "AGENTS.md"
+      ],
+      "config": {
+        "MD004": false,
+        "MD022": false,
+        "MD032": false
+      },
+      "combine": "merge"
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ not routine feature requests.
 For README, demo, integration, and package-listing docs, explain user-visible behavior before architecture.
 
 Prefer plain, concrete wording when accurate. For example:
+
 - "rules and corrections that stick"
 - "saved compiler state"
 - "stored premise and policy rules"

--- a/README.md
+++ b/README.md
@@ -53,33 +53,41 @@ instead of relying on memory of earlier conversation text.
 
 Context Compiler makes state-change rules explicit so behavior stays repeatable.
 
-**Explicit directive**
+### Explicit directive
+
 ```text
 set premise concise replies
 ```
+
 - Base model: silently accepts / rewrites
 - Context Compiler: applies a repeatable state update
 
-**Single-directive grammar**
+### Single-directive grammar
+
 ```text
 use docker and prohibit peanuts
 ```
+
 - Without an authority layer: host/model behavior varies
 - Context Compiler: returns `clarify`, keeps authoritative state unchanged, and asks for separate directives
 
-**State-dependent operation**
+### State-dependent operation
+
 ```text
 clear state
 use podman instead of docker
 ```
+
 - Without explicit state transition rules: behavior depends on host/model handling
 - Context Compiler: returns `clarify` before changing state
 
-**Lifecycle enforcement**
+### Lifecycle enforcement
+
 ```text
 clear state
 change premise to formal tone
 ```
+
 - Without explicit transition checks: behavior depends on host/model handling
 - Context Compiler: asks for clarification and keeps saved state unchanged
 
@@ -168,12 +176,14 @@ context-compiler
 ```
 
 Preload options keep saved rules separate from confirmation state in progress:
+
 - `--initial-state-json` / `--initial-state-file` load saved state
   (via exported state JSON).
 - `--initial-checkpoint-json` / `--initial-checkpoint-file` restore full
   continuation checkpoint (saved state + pending confirmation state).
 
 REPL commands (controller layer, not engine directives):
+
 - `state` shows current saved state.
 - `preview <input>` runs deterministic dry-run without mutating live state.
 - `step <input>` is an explicit alias of normal bare-input step behavior.
@@ -190,6 +200,7 @@ context-compiler --json < input.txt
 ```
 
 Preload options keep saved rules separate from confirmation state in progress:
+
 - `--initial-state-json` / `--initial-state-file` load saved state
   (via exported state JSON).
 - `--initial-checkpoint-json` / `--initial-checkpoint-file` restore full
@@ -198,14 +209,17 @@ Preload options keep saved rules separate from confirmation state in progress:
 ## Installation
 
 Requirements:
+
 - Python 3.11+
 
 Install:
+
 ```bash
 pip install context-compiler
 ```
 
 Packaging notes:
+
 - Base install includes the core authority-layer engine and CLI.
 - Example and demo source files are available in the repository and source distribution.
 - To run the demos from this repository, clone the repo and install `context-compiler[demos]`.
@@ -231,11 +245,11 @@ class Decision(TypedDict):
 
 Meaning:
 
-| kind        | host behavior                                 |
-|:-----------:|-----------------------------------------------|
-| passthrough | forward user input to LLM                     |
-| update      | authoritative state mutated; host may call LLM with updated state |
-| clarify     | show `prompt_to_user` and do not call the LLM |
+| kind | host behavior |
+| --- | --- |
+| passthrough | forward user input to LLM |
+| update | authoritative state mutated; host may call LLM with updated state |
+| clarify | show `prompt_to_user` and do not call the LLM |
 
 For normal app code, prefer the exported decision helpers (`is_clarify`,
 `is_update`, `is_passthrough`, `get_clarify_prompt`, `get_decision_state`)

--- a/demos/README.md
+++ b/demos/README.md
@@ -15,6 +15,7 @@ authority semantics with dependency-light comparisons instead of requiring
 deeper framework integration layers.
 
 Scored demos now compare four paths:
+
 - baseline
 - reinjected-state (application-managed state text injected into the prompt, used here as a simple prompt-only comparison baseline without compiler semantics)
 - compiler-mediated (full transcript + saved compiler state added to the prompt)
@@ -31,7 +32,7 @@ Runnable application-layer enforcement-point integrations live in
 | [02](./02_llm_constraint_guardrail.py) | Policy state stays active across turns | authoritative policy state | small or quantized models |
 | [03](./03_llm_premise_guardrail.py) | Premise updates stay authoritative | fixed, repeatable premise updates | models that summarize conversation |
 | [04](./04_llm_tool_denylist_guardrail.py) | Tool governance | application-layer tool gating from saved state | general assistant models |
-| [05](./05_llm_prompt_drift_vs_state.py) | Prompt drift | long transcript failure | weaker long-context models ([see Demo 5 note](#demo-5-stress-ladder-turns)) |
+| [05](./05_llm_prompt_drift_vs_state.py) | Prompt drift | long transcript failure | weaker long-context models ([see Demo 05 example](#demo-05-example-prompt-drift-under-longer-context)) |
 | [06](./06_llm_context_compaction.py) | Context compaction | saved compiler state replacing transcript context | small or local models |
 | [07](./07_llm_prompt_vs_state.py) | Prompt engineering comparison | prompting vs saved compiler state | any model with long transcript sensitivity |
 | [08](./08_llm_replacement_precondition.py) | Replacement precondition | invalid replacement blocked without state mutation | any model |
@@ -58,6 +59,7 @@ Environment variables (strict provider mode contract):
 - `MODEL` (optional)
 - `OPENAI_API_KEY` (required in normal `openai` mode)
 - `OPENAI_BASE_URL` (explicit endpoint override; required for explicit `openai_compatible`)
+
 Note: Demos prefer fixed decoding (`temperature=0`) for reproducible PASS/FAIL behavior.
 If a model rejects deterministic sampling parameters on the LiteLLM/OpenAI-compatible path
 (for example, some `gpt-5` and Claude paths), the demo client retries once without deterministic
@@ -98,6 +100,7 @@ export MODEL=claude-sonnet-4-6
 ```
 
 Notes:
+
 - For direct Anthropic usage, `MODEL` should use the endpoint-native model ID.
 - Do not use the `anthropic/` prefix unless your endpoint/router expects it.
 - This repo passes `MODEL` through unchanged.
@@ -113,6 +116,7 @@ export MODEL=anthropic/claude-sonnet-4-6
 ```
 
 Notes:
+
 - Provider-prefixed model IDs such as `anthropic/...` are appropriate when the gateway/router expects them.
 - Model naming follows the endpoint/router contract.
 
@@ -162,12 +166,14 @@ includes:
 - the older historical 0.6.15 matrix for the earlier 6-demo scored set
 
 Notes:
+
 - There are **8 scored demos** (`01`–`05`, `07`, `08`, `09`). `06_context_compaction` is informational and excluded from PASS/FAIL totals.
 - Anthropic runs in this repo are executed through the `openai_compatible` provider path.
 - `PASS` means the demo-specific expected-behavior check for that path succeeded; `FAIL` means it did not.
 - `reinjected-state` can be enough for some persistence cases; in this demo set it is intentionally used as a prompt-only comparison baseline.
 - Scored checks focus on app-side authority rules (for example blocked mutation and confirmation-only resolution), not model prose quality. `reinjected-state` remains plain text injection only.
 - Interpretation:
+
 - Demos `01`-`05` and `07` mostly test persistence and policy-following behavior across turns.
 - Demos `08`/`09` test rules for when state is allowed to change.
 - Demos `08` and `09` cover authority semantics prompt text does not implement by itself, such as replacement preconditions, blocked mutations, and waiting for confirmation before saving changes.

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -11,7 +11,7 @@ or interpretation of assistant output.
 ## 1. Terminology
 
 | Term | Meaning |
-|---|---|
+| --- | --- |
 | User Input | Raw text from the user |
 | Directive | A string that matches one of the explicit grammar productions in Section 5 |
 | Premise | Single sticky explicit slot controlled only by premise directives |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,21 @@
 # Documentation Index
 
 ## Start Here
+
 - [Project README](../README.md)
 
 ## Core Concepts
+
 - [Architecture boundaries](architecture.md)
 - [Directive Grammar (exact command forms the engine accepts)](DirectiveGrammarSpec.md)
 - [Public API reference](api-reference.md)
 
 ## Evaluation & Evidence
+
 - [Demo results matrix](demos-results.md)
 - [Demo outputs / scored scenarios](../demos/README.md)
 - [SWE curated results](../evals/swe-bench/README.md)
 
 ## Project Background
+
 - [Description and Milestones](DescriptionAndMilestones.md)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -88,7 +88,7 @@ class Decision(TypedDict):
 Decision kinds:
 
 | kind | Intended host use |
-|---|---|
+| --- | --- |
 | `passthrough` | forward the user input to the model/runtime |
 | `update` | authoritative state changed; host may apply downstream behavior using updated state |
 | `clarify` | show `prompt_to_user`; do not continue normal downstream processing yet |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,37 +6,45 @@ authority inside a larger host application stack.
 ## Authority Layer
 
 Responsibilities:
+
 - apply deterministic state transitions
 - enforce clarification and confirmation gates
 - export/import authoritative state and checkpoints
 
 Examples:
+
 - Context Compiler core engine
 - checkpoint continuation behavior
 
 Repository:
+
 - `context-compiler`
 
 Boundary:
+
 - only core applies directives
 - only core mutates authoritative state
 
 ## Acquisition Layer
 
 Responsibilities:
+
 - recognize possible user state updates before core compilation
 - normalize candidate inputs conservatively
 - abstain when intent is uncertain
 - draft candidate directives without becoming a second authority
 
 Examples:
+
 - external directive-drafter or host-owned drafting packages
 - host-side input shaping before `engine.step(...)`
 
 Repository:
+
 - `context-compiler-directive-drafter`
 
 Boundary:
+
 - drafting is non-authoritative
 - drafting must not bypass `engine.step(...)`
 - drafting must not edit `engine.state`
@@ -44,17 +52,20 @@ Boundary:
 ## Application Layer
 
 Responsibilities:
+
 - decide how compiler state affects runtime behavior
 - render prompts and acknowledgements
 - select schemas, gate tools, route workflows, and apply runtime controls
 
 Examples:
+
 - runnable integrations owned outside core (for example
   `context-compiler-example-integrations` for OpenWebUI, LiteLLM, Ollama, or
   proxy/runtime/provider examples)
 - host-controlled prompt construction from saved state
 
 Repository:
+
 - `context-compiler-example-integrations` or host applications
 
 ## Architectural Rationale: Flat Policy Independence

--- a/evals/swe-bench/README.md
+++ b/evals/swe-bench/README.md
@@ -7,7 +7,7 @@ Across 6 models and 6 tasks, this compiler-mediated flow produces higher scores 
 ## Top-level summary
 
 | Model | Tasks | Compiler Enabled | Scored | + / 0 / - | Avg Delta |
-|---|---:|---:|---:|---:|---:|
+| --- | ---: | ---: | ---: | ---: | ---: |
 | `anthropic/claude-opus-4-20250514` | 6 | 6 | 6 | 5 / 0 / 1 | 17.33 |
 | `anthropic/claude-sonnet-4-20250514` | 6 | 6 | 6 | 5 / 1 / 0 | 19.33 |
 | `openai/gpt-4.1` | 6 | 6 | 6 | 5 / 1 / 0 | 9.83 |
@@ -27,7 +27,9 @@ Across 6 models and 6 tasks, this compiler-mediated flow produces higher scores 
 ## Task callouts
 
 ### `psf__requests-1963`
+
 Per-model score deltas:
+
 - Opus4: `+48`
 - Sonnet4: `+31`
 - GPT-4.1: `+13`
@@ -38,7 +40,9 @@ Per-model score deltas:
 Interpretation: This task shows broad, consistent uplift and appears highly aligned with compiler-style state framing (state propagation constraints across redirect hops).
 
 ### `django__django-13158`
+
 Per-model score deltas:
+
 - Opus4: `+10`
 - Sonnet4: `+18`
 - GPT-4.1: `+21`
@@ -49,7 +53,9 @@ Per-model score deltas:
 Interpretation: Very consistent positive movement across all models; the absorbing-element framing for `QuerySet.none()` appears to transfer well.
 
 ### `django__django-13964`
+
 Per-model score deltas:
+
 - Opus4: `+29`
 - Sonnet4: `+32`
 - GPT-4.1: `0`

--- a/scripts/validate_markdown.sh
+++ b/scripts/validate_markdown.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+cd "${repo_root}"
+
+npx --yes markdownlint-cli2

--- a/tests/fixtures/engine-regression/structured/README.md
+++ b/tests/fixtures/engine-regression/structured/README.md
@@ -41,19 +41,19 @@ A full checkpoint is stored and compared on every turn so regressions are visibl
 
 These fixtures validate **deterministic engine behavior only**:
 
-- `engine.step(...)` outputs (`Decision.kind`, `prompt_to_user`)
-- post-turn checkpoint (`authoritative_state` + `pending`)
+* `engine.step(...)` outputs (`Decision.kind`, `prompt_to_user`)
+* post-turn checkpoint (`authoritative_state` + `pending`)
 
 They do **not** cover:
 
-- REPL / user-facing formatting
-- LLM integration behavior
-- acquisition-layer directive drafting
+* REPL / user-facing formatting
+* LLM integration behavior
+* acquisition-layer directive drafting
 
 These surfaces are tested separately because:
 
-- REPL output may intentionally differ from the underlying state representation
-- acquisition-layer drafting is outside the engine contract
+* REPL output may intentionally differ from the underlying state representation
+* acquisition-layer drafting is outside the engine contract
 
 This fixture set is the **canonical engine-level conformance surface**, and may be reused by other implementations (e.g., TypeScript) to validate identical engine behavior.
 


### PR DESCRIPTION
## What changed

- added a low-noise `.markdownlint-cli2.jsonc` based on the `context-compiler-example-integrations` reference policy
- added `./scripts/validate_markdown.sh` as the local Markdown lint command
- added a dedicated `markdownlint` CI job in `.github/workflows/ci.yml`
- mechanically cleaned up existing repository-owned Markdown only where needed to satisfy the lint baseline
- excluded `.tmp-uv-cache` from linting because it is transient generated cache content

## Why

- establish a clean, low-noise Markdown lint baseline for repository-owned documentation
- keep Markdown validation separate from runtime, test, and conformance validation
- align the repository with the current Context Compiler cross-repository Markdown linting standard

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)

Validation completed:
- `./scripts/validate_markdown.sh` — passed
- `uv run pre-commit run --all-files` — passed
- `uv run pytest` — passed

Additional notes:
- existing Markdown was mechanically cleaned up only as required for lint compliance
- no runtime behavior changes
- no package-version changes
