### PR TITLE
Pin Markdownlint version

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -40,6 +40,15 @@
         "MD032": false
       },
       "combine": "merge"
+    },
+    {
+      "filter": [
+        "tests/fixtures/engine-regression/structured/README.md"
+      ],
+      "config": {
+        "MD004": false
+      },
+      "combine": "merge"
     }
   ]
 }

--- a/scripts/validate_markdown.sh
+++ b/scripts/validate_markdown.sh
@@ -6,4 +6,4 @@ repo_root="$(cd "${script_dir}/.." && pwd)"
 
 cd "${repo_root}"
 
-npx --yes markdownlint-cli2
+npx --yes markdownlint-cli2@0.23.0


### PR DESCRIPTION
## What changed

- pins `scripts/validate_markdown.sh` to `markdownlint-cli2@0.23.0` for reproducible Markdownlint CLI resolution
- adds a narrow `MD004: false` override for `tests/fixtures/engine-regression/structured/README.md` so the synchronized fixture content stays unchanged

## Why

- this is a post-merge reproducibility follow-up to the earlier Markdownlint rollout
- synchronized fixture content is unchanged, and there are no runtime behavior or package-version changes

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)

Additional validation run:
- `./scripts/validate_markdown.sh` — passed