### PR TITLE
docs: move acquisition responsibilities out of core grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,30 @@
 [![License](https://img.shields.io/pypi/l/context-compiler)](https://pypi.org/project/context-compiler/)
 
 Context Compiler is a deterministic conversational state authority for LLM applications.
-It handles explicit state changes, clarification and confirmation flows,
-checkpoint restore, and structured authoritative state for the host.
+It handles canonical directive execution, semantic validation, deterministic
+clarification and confirmation flows, checkpoint restore, and structured
+authoritative state for the host.
 
 ## What Context Compiler provides
 
 Context Compiler gives hosts fixed state rules:
 
-- handle explicit user state changes with deterministic rules
+- handle canonical explicit state changes with deterministic rules
 - clarification instead of silent overwrite for blocked/ambiguous changes
 - pending confirmation flows that must resolve before anything else changes
 - export and import checkpoints to restore saved state and pending confirmation flow
 - produce structured authoritative state for downstream host decisions
 
 The model generates responses. The compiler owns state.
+Human-facing normalization, malformed-input recovery, and intent drafting belong
+outside core.
 
 ## How the compiler metaphor works
 
-Like a compiler, it parses input, validates it, applies fixed rules, and
+Like a compiler, it parses canonical directives, validates them, applies fixed rules, and
 produces a stable result the host can use. It treats important instructions as
 structured state instead of temporary prompt text. It is not source-code
-compilation and not a reasoning model.
+compilation, not a reasoning model, and not a natural-language repair layer.
 
 ## 10-Second Example
 
@@ -296,6 +299,7 @@ authoritative in future turns.
 - Policies are per-item (`use` or `prohibit`)
 - State changes only through explicit directives
 - No inference or semantic reasoning
+- Non-canonical input normalization is outside the core state contract
 
 Identical input sequences always produce identical state.
 
@@ -342,6 +346,11 @@ Hosts define what policy items and premise mean in context. Common patterns incl
 
 Context Compiler enforces explicit directive and state rules. Domain reasoning
 still belongs to the host and model workflow.
+
+If a user says something non-canonical such as a near miss, alternate phrasing,
+or a failed replacement request that would need reinterpretation, that
+normalization is outside core and must happen before canonical directives reach
+the compiler.
 
 ---
 
@@ -448,6 +457,11 @@ Context Compiler is the authority layer that decides when state changes are
 allowed, when clarification is required, and how continuation state is
 restored. For runnable application-layer examples, see
 [`context-compiler-example-integrations`](https://github.com/rlippmann/context-compiler-example-integrations).
+
+Human-facing interpretation is a separate concern. If you want to recognize
+non-canonical phrasing, recover from malformed input, narrow user intent, or
+turn a failed replacement request into a different canonical directive, do that
+before calling core.
 
 **Why not just use a plain dict?**
 A plain dict can hold state for prompt construction, schema selection, tool

--- a/docs/DescriptionAndMilestones.md
+++ b/docs/DescriptionAndMilestones.md
@@ -134,12 +134,13 @@ which package owns which behavior.
 Current ownership after 0.8:
 
 - `context-compiler` owns the Authority Layer:
-  deterministic state transitions, directive application, clarification and
-  confirmation handling, checkpoints, preview/diff, controller behavior, and
-  authoritative state
+  deterministic state transitions, canonical directive application, semantic
+  validation, clarification and confirmation handling, checkpoints,
+  preview/diff, controller behavior, and authoritative state
 - `context-compiler-directive-drafter` owns Acquisition Layer drafting:
   natural-language-to-directive drafting, candidate directive generation,
-  prompt/resource usage for drafting, and drafting-oriented surfaces
+  malformed-input recovery, alternate human phrasing, prompt/resource usage for
+  drafting, and drafting-oriented surfaces
 - `context-compiler-example-integrations` owns runnable integrations:
   LiteLLM, OpenWebUI, Ollama, and other proxy/runtime/provider examples
 
@@ -148,6 +149,8 @@ Boundary:
 - drafting is non-authoritative
 - only core applies directives
 - only core mutates authoritative state
+- core is the canonical directive and execution layer, not the general
+  human-input repair layer
 
 Historical note:
 

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -4,9 +4,12 @@
 
 Provide deterministic, explicit, and model-independent conversational state updates.
 
-This specification defines the authoritative state machine for directive handling.
-It does not perform reasoning, inference, entity modeling, natural-language understanding,
-or interpretation of assistant output.
+This specification defines the authoritative state machine for canonical
+directive handling.
+It does not perform reasoning, inference, entity modeling,
+natural-language understanding, or interpretation of assistant output.
+Human-facing normalization, malformed-input recovery, and intent drafting are
+outside the core canonical directive contract.
 
 ## 1. Terminology
 
@@ -17,17 +20,19 @@ or interpretation of assistant output.
 | Premise | Single sticky explicit slot controlled only by premise directives |
 | Policy | Per-item authoritative state: `"use"` or `"prohibit"` |
 | State | Current authoritative snapshot |
-| Pending Clarification | A blocked mutation awaiting explicit user confirmation |
+| Pending Clarification | A blocked canonical mutation awaiting explicit user confirmation |
 | Decision | Compiler instruction returned to host |
 
 ## 2. System Responsibilities
 
 The compiler:
 
-1. Parses user input against explicit grammar
-2. Applies deterministic state transitions only when valid
-3. Rejects contradictory or invalid mutations with `clarify`
-4. Returns a deterministic `Decision`
+1. Parses canonical user input against explicit grammar
+2. Validates canonical directives and authoritative state
+3. Applies deterministic state transitions only when valid
+4. Returns `clarify` when a canonical operation cannot proceed under the core
+   state rules
+5. Returns a deterministic `Decision`
 
 The compiler never calls an LLM.
 All authoritative mutations originate from user directives passed to `step()`.
@@ -39,6 +44,7 @@ The host:
 - Displays clarification prompts
 - Calls the LLM only when `Decision.kind` allows it
 - Formats model context from compiler state
+- May perform non-canonical input processing before core execution
 
 ## 4. Decision API Contract
 
@@ -113,7 +119,7 @@ No stemming, synonym mapping, ontology, or semantic interpretation is allowed.
 
 ## 7. Directive Grammar (Explicit Only)
 
-Only the exact productions below are directives.
+Only the exact productions below are canonical directives.
 All other input is `passthrough` unless Section 8 says `clarify`.
 
 ```text
@@ -137,10 +143,6 @@ Notes:
 - Recognized policy directives with empty or whitespace-only `ITEM` payload return `clarify`.
 - Premise directive payload must contain at least one non-whitespace character after the prefix.
   Empty and whitespace-only premise payloads are invalid and must return `clarify`.
-- Narrow near-miss clarify exceptions are supported for premise `to` variants only:
-  - `set premise to X` -> `clarify` with canonical suggestion
-  - `change premise X` -> `clarify` with canonical suggestion
-  This does not broaden directive grammar acceptance.
 - `ITEM` is normalized via `normalize_item` before policy lookup/storage.
 - `VALUE` is stored using premise sanitation from Section 6.
 - Quote characters have no special parsing semantics. A fully quoted input remains ordinary `passthrough` unless the raw
@@ -188,63 +190,32 @@ Let `k = normalize_item(ITEM)`.
 
 ### 8.3 Explicit replacement
 
-Pending-confirmation eligibility for any repair in this section:
-
-- Core may create pending confirmation only for a uniquely recoverable,
-  semantics-preserving repair.
-- Accepting `yes` must authorize at most one repair that preserves the
-  directive already submitted in substance.
-- Core must not create pending confirmation when accepting `yes` would
-  authorize:
-  - additional policy mutations
-  - compound operations
-  - synthesized replacement directives
-  - semantic rewrites
-  - materially different directives than the one originally submitted
-- When a replacement case is not eligible for pending confirmation under this
-  rule, core must return ordinary `clarify`, leave authoritative state
-  unchanged, and require a new explicit directive from the user or a future
-  directive drafter.
+Pending confirmation in core is limited to canonical operations that are
+already fully determined by the submitted canonical directive. Core does not
+use confirmation to repair non-canonical input, infer intent, or convert a
+failed canonical operation into a different directive.
 
 For `use X instead of Y`:
 
 1. Let `kx = normalize_item(X)`, `ky = normalize_item(Y)`.
 2. If `kx == ky`: no-op `update`.
 3. Otherwise, evaluate in this exact order:
-   - if `ky not in policies`: the submitted replacement cannot be applied
-     literally, but it has one uniquely recoverable, semantics-preserving
-     repair: treat it as the single atomic directive `use X`. Enter
-     replacement-intent `clarify` with prompt
-     `Did you mean to use "X" instead?`
-   - else if `policies.get(ky) == "prohibit"`: accepting `yes` would authorize
-     a compound policy change and a materially different directive than the one
-     literally submitted. Return ordinary `clarify` with prompt
+   - if `ky not in policies`: return ordinary `clarify` with prompt
+     `"<Y>" is not currently in use.`
+     `Replacement requires an active 'use' policy.`
+   - else if `policies.get(ky) == "prohibit"`: return ordinary `clarify` with prompt
      `"Y" is currently prohibited.`
      `Submit explicit directive(s) to remove it or use a different item.`
-   - else if `policies.get(kx) == "prohibit"`: accepting `yes` would authorize
-     a compound policy change and a materially different directive than the one
-     literally submitted. Return ordinary `clarify` with prompt
+   - else if `policies.get(kx) == "prohibit"`: return ordinary `clarify` with prompt
      `"X" is currently prohibited.`
      `Submit explicit directive(s) to remove it or use a different item.`
-4. If none of the replacement-intent clarify conditions match, `Y` must currently exist in
+4. If none of the clarify conditions above match, `Y` must currently exist in
    policy state (`ky in policies`) or return `clarify`.
 5. Replacement requires `policies[ky] == "use"` in the literal path; otherwise return `clarify`.
 6. If replacement syntax is recognized but either side is empty/whitespace-only, return `clarify` and no mutation.
 7. On literal success:
    - remove `ky` from `policies`
    - set `policies[kx] = "use"`
-8. Under the pending-confirmation eligibility rule above, the missing-source
-   case is currently the only replacement case that qualifies for pending
-   confirmation.
-9. Replacement-intent clarify confirmations are deterministic only for that
-   eligible missing-source case:
-   - `Did you mean to use "X" instead?`
-     - yes: set `policies[kx] = "use"` (idempotent if already `"use"`)
-     - no: no mutation
-10. The prohibited-item replacement cases above are illustrations of the
-    ineligible category: they do not create pending confirmation, do not
-    synthesize replacement directives, and do not authorize compound policy
-    mutation through a yes/no response.
 
 This operation is authoritative replacement, not recency resolution.
 
@@ -303,9 +274,7 @@ The compiler returns `Decision.kind = "clarify"` only in these cases:
 13. `use ITEM` when `ITEM` is empty or whitespace-only after the prefix.
 14. `prohibit ITEM` when `ITEM` is empty or whitespace-only after the prefix.
 15. `use X instead of Y` when replacement syntax is recognized but `X` or `Y` is empty/whitespace-only.
-16. `set premise to X` near-miss with non-empty `X`.
-17. `change premise X` near-miss with non-empty `X`.
-18. When no pending clarification exists, an input contains more than one canonical directive start.
+16. When no pending clarification exists, an input contains more than one canonical directive start.
 
 Contradictions never silently overwrite state.
 
@@ -332,7 +301,8 @@ When `Decision.kind = "clarify"`, prompt text is deterministic only for the case
   `"<item>" is currently in use.`
   `Remove or replace it before prohibiting it.`
 - `use X instead of Y` when `Y` does not exist in policies (Section 9 case 7):
-  `Did you mean to use "X" instead?`
+  `"<Y>" is not currently in use.`
+  `Replacement requires an active 'use' policy.`
 - `use X instead of Y` when `Y` is currently `"prohibit"` (Section 9 case 8):
   `"Y" is currently prohibited.`
   `Submit explicit directive(s) to remove it or use a different item.`
@@ -356,11 +326,7 @@ When `Decision.kind = "clarify"`, prompt text is deterministic only for the case
 - Incomplete replacement payload (Section 9 case 15):
   `Replacement requires both new and old items.`
   `Use 'use <new item> instead of <old item>' with non-empty values.`
-- Premise near-miss `set premise to X` (Section 9 case 16):
-  `Did you mean 'set premise X'?`
-- Premise near-miss `change premise X` (Section 9 case 17):
-  `Did you mean 'change premise to X'?`
-- Compound directive rejection when no pending clarification exists (Section 9 case 18):
+- Compound directive rejection when no pending clarification exists (Section 9 case 16):
   `Multiple directives are not supported in one input.`
   `Submit each directive separately.`
 
@@ -368,18 +334,17 @@ When `Decision.kind = "clarify"`, prompt text is deterministic only for the case
 
 Normative eligibility rule:
 
-- Pending confirmation is reserved for uniquely recoverable,
-  semantics-preserving repairs.
-- A pending confirmation may exist only when accepting `yes` authorizes one
-  deterministic repair that preserves the submitted directive in substance.
+- Pending confirmation is reserved for deterministic continuation of canonical
+  operations already established by prior core decisions.
 - Core must not use pending confirmation to authorize:
-  - additional policy mutations
-  - compound operations
+  - near-miss repair
+  - malformed-input recovery
   - synthesized replacement directives
+  - alternate human phrasing interpretation
   - semantic rewrites
   - materially different directives than the one originally submitted
-- When an input needs user guidance but does not satisfy this rule, core must
-  return ordinary `clarify` without creating pending state.
+- When an input needs non-canonical interpretation, core does not define that
+  processing. Core operates only on canonical directives submitted to it.
 
 Internal structure:
 
@@ -455,32 +420,23 @@ Checkpoint object contract:
     },
     "version": 2
   },
-  "pending": {
-    "kind": "replacement",
-    "replacement": {
-      "kind": "use_only",
-      "new_item": "kubectl",
-      "old_item": null
-    },
-    "prompt_to_user": "..."
-  }
+  "pending": null
 }
 ```
 
 Checkpoint semantics:
 
 - `authoritative_state` uses the same validation/canonicalization boundary as `export_json` / `import_json`.
-- `pending` captures confirmation-required continuation (for example replacement clarifications).
+- `pending` captures confirmation-required continuation for supported canonical
+  operations only.
 - `pending` is `null` when there is no outstanding continuation.
-- In `"use_only"` pending replacement cases, `old_item` may be `null` because no exact existing policy matched for replacement; confirmation asks whether to apply a new `use` item while keeping current policies.
-- `"use_only"` is the only supported pending replacement shape in checkpoint restore.
 - Restore is all-or-nothing: invalid checkpoint payloads raise and no partial state restore occurs.
 - Continuation behavior is deterministic after restore (same confirmation token handling and resolution outcomes as live pending state).
 - `checkpoint_version` is independent of authoritative state `version`; it must be bumped when checkpoint contract shape changes (especially `pending`).
 
 ## 12. Invariants
 
-1. State changes only from valid directive transitions or pending-confirmation acceptance.
+1. State changes only from valid canonical directive transitions or pending-confirmation acceptance for canonical operations.
 2. Same input sequence yields identical state and decisions.
 3. LLM output never mutates state.
 4. No mutation occurs when returning `clarify`.
@@ -489,6 +445,7 @@ Checkpoint semantics:
 7. Contradictions always clarify; they never overwrite.
 8. Premise can be explicitly cleared via `clear premise` (`premise = null`).
 9. A single input never applies more than one canonical directive.
+10. Core does not repair non-canonical human input into canonical directives.
 
 ## 13. Non-Goals
 
@@ -504,6 +461,8 @@ Not implemented:
 - ontology reasoning
 - agent planning
 - output validation
+
+Non-canonical input interpretation is intentionally excluded from core.
 
 ## End
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -15,6 +15,15 @@ For behavioral semantics, use the authoritative documents above. This page
 documents the public checkpoint APIs and their contract surface without
 redefining directive or continuation behavior.
 
+Core boundary:
+
+- core consumes canonical directives and deterministic confirmation tokens
+- canonical directive validation remains in core
+- semantic validation and authoritative state transitions remain in core
+- human-facing normalization, malformed-input recovery, and intent drafting are
+  outside the core contract
+- core does not convert failed canonical operations into different directives
+
 ## Engine Lifecycle
 
 ### `create_engine(state=None)`
@@ -74,17 +83,16 @@ construction only.
 Boundary notes:
 
 - no public parser is exposed
-- validation returns `None` for any non-canonical input, including near misses,
-  compounds, and ordinary prose
+- validation returns `None` for any non-canonical input
 - rendering is syntax-only and performs no state interpretation
 - `engine.step(...)` remains the authority for clarification, state
   transitions, pending confirmation, and mutation behavior
-- pending confirmation is only used for uniquely recoverable,
-  semantics-preserving repairs
-- a pending `yes` may authorize only one deterministic repair that preserves
-  the submitted directive in substance
-- the current missing-source replacement confirmation is an application of this
-  rule, not the rule itself
+- `engine.step(...)` is not a general natural-language repair surface; host
+  code should send canonical directives when it wants deterministic mutation
+- pending confirmation is limited to deterministic continuation of supported
+  canonical operations
+- failed replacement requests are not reinterpreted by core into different
+  directives
 
 ### `engine.state`
 
@@ -222,15 +230,7 @@ Checkpoint object shape:
     },
     "version": 2
   },
-  "pending": {
-    "kind": "replacement",
-    "replacement": {
-      "kind": "use_only",
-      "new_item": "kubectl",
-      "old_item": null
-    },
-    "prompt_to_user": "..."
-  }
+  "pending": null
 }
 ```
 
@@ -239,11 +239,9 @@ At this boundary, direct key access is expected.
 API-level contract notes:
 
 - `pending` is `null` when no continuation is waiting for confirmation
-- `pending` captures confirmation-required operations such as the supported
-  missing-source replacement repair flow
-- `old_item` may be `null` for `"use_only"` when confirming “use X instead?”
-  without an existing exact policy to replace
-- `"use_only"` is the only supported pending replacement shape at this boundary
+- `pending` captures confirmation-required continuation for canonical
+  operations supported by the active engine contract
+- non-canonical repair state is not part of the intended core contract
 - imported policy keys are normalized during `import_json(...)` and checkpoint
   authoritative-state restore
 - if a policy key normalizes to `""`, the payload is invalid and is rejected

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ authority inside a larger host application stack.
 Responsibilities:
 
 - apply deterministic state transitions
-- enforce clarification and confirmation gates
+- enforce clarification and confirmation gates for core-owned state semantics
 - export/import authoritative state and checkpoints
 
 Examples:
@@ -24,14 +24,13 @@ Boundary:
 
 - only core applies directives
 - only core mutates authoritative state
-- pending yes/no confirmation is reserved for uniquely recoverable,
-  semantics-preserving repairs
-- a pending `yes` may authorize only one deterministic repair that preserves
-  the submitted directive in substance
-- core does not use yes/no confirmation to authorize compound policy mutations
-  or inferred replacement rewrites when an explicit new directive is required
-- current replacement examples are applications of this rule, not the source of
-  the rule
+- core defines the canonical directive language and deterministic execution
+  model
+- core does not own human-facing normalization, malformed-input recovery, or
+  intent inference as a general responsibility
+- core does not convert failed canonical operations into different directives
+- pending yes/no confirmation is limited to deterministic continuation of
+  canonical operations already established by core
 
 ## Acquisition Layer
 
@@ -39,13 +38,17 @@ Responsibilities:
 
 - recognize possible user state updates before core compilation
 - normalize candidate inputs conservatively
+- recover from malformed or non-canonical human input when appropriate
+- interpret alternate phrasing outside the core authority contract
+- narrow or rewrite user intent into canonical directives when justified by
+  acquisition-layer context
 - abstain when intent is uncertain
 - draft candidate directives without becoming a second authority
 
 Examples:
 
-- external directive-drafter or host-owned drafting packages
 - host-side input shaping before `engine.step(...)`
+- any non-authoritative preprocessing that emits canonical directives for core
 
 Repository:
 


### PR DESCRIPTION
## What changed

- Removed core documentation dependencies on `DrafterAcquisitionSpec.md`
- Updated core documentation to focus only on:
  - canonical directive grammar
  - canonical validation
  - authoritative state semantics
  - deterministic execution and confirmation behavior
- Moved the acquisition specification to the drafter repository
- Updated drafter documentation so acquisition behavior is defined by `DrafterAcquisitionSpec.md`
- Clarified the ownership boundary:
  - drafter handles human-facing acquisition and interpretation
  - core handles canonical directives and authoritative state changes

## Why

- The core compiler should not depend on human-facing input interpretation rules.
- Non-canonical input handling, semantic narrowing, and acquisition-layer behavior belong outside the core grammar contract.
- This creates a cleaner boundary for future grammar extraction and cross-language ports.
- Core remains implementable without requiring knowledge of the drafter layer.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)