### PR TITLE
docs: remove checkpoint from supported persistence workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Context Compiler is a deterministic conversational state authority for LLM applications.
 It handles canonical directive execution, semantic validation, deterministic
-clarify decisions, semantic continuation checkpoints, and structured authoritative state for
+clarify decisions, runtime semantic continuation boundaries, and structured authoritative state for
 the host.
 
 ## What Context Compiler provides
@@ -16,7 +16,7 @@ Context Compiler gives hosts fixed state rules:
 - handle canonical explicit state changes with deterministic rules
 - clarification instead of silent overwrite for blocked/ambiguous changes
 - preserve supported pending continuation when explicit confirmation is required
-- export and import checkpoints to restore saved state in a versioned engine snapshot
+- export and import authoritative state for host-managed persistence
 - produce structured authoritative state for downstream host decisions
 
 The model generates responses. The compiler owns state.
@@ -91,7 +91,9 @@ use podman instead of docker
 ```
 
 - Without explicit state transition rules: behavior depends on host/model handling
-- Context Compiler: returns `clarify` before changing state
+- Context Compiler: applies the deterministic resulting transition when
+  `docker` is absent and `use podman` is otherwise valid; other semantic
+  conflicts may still clarify
 
 ### Lifecycle enforcement
 
@@ -161,7 +163,7 @@ For runnable application-layer examples, see
 [`context-compiler-example-integrations`](https://github.com/rlippmann/context-compiler-example-integrations).
 That companion repository shows enforcement points built on compiler state,
 including retrieval filtering, schema selection, tool gating, execution
-authorization, gateway middleware, checkpoint continuation, and prompt
+authorization, gateway middleware, runtime continuation handling, and prompt
 construction.
 
 ## Does it Work?
@@ -187,12 +189,10 @@ pip install context-compiler
 context-compiler
 ```
 
-Preload options keep authoritative state transport separate from checkpoint session snapshots:
+Preload options load authoritative state:
 
 - `--initial-state-json` / `--initial-state-file` load saved state
   (via exported state JSON).
-- `--initial-checkpoint-json` / `--initial-checkpoint-file` restore the full
-  checkpoint envelope (saved state plus continuation field when supported by the active engine contract).
 
 REPL commands (controller layer, not engine directives):
 
@@ -211,12 +211,10 @@ for non-interactive usage.
 context-compiler --json < input.txt
 ```
 
-Preload options keep authoritative state transport separate from checkpoint session snapshots:
+Preload options load authoritative state:
 
 - `--initial-state-json` / `--initial-state-file` load saved state
   (via exported state JSON).
-- `--initial-checkpoint-json` / `--initial-checkpoint-file` restore the full
-  checkpoint envelope (saved state plus continuation field when supported by the active engine contract).
 
 ## Installation
 
@@ -277,8 +275,7 @@ Common API entry points:
 - decision helpers: `is_clarify(...)`, `is_update(...)`, `is_passthrough(...)`,
   `get_clarify_prompt(...)`, `get_decision_state(...)`
 - state helpers: `get_premise_value(...)`, `get_policy_items(...)`
-- state and checkpoint transport: `export_json(...)`, `import_json(...)`,
-  `export_checkpoint(...)`, `import_checkpoint(...)`
+- state transport: `export_json(...)`, `import_json(...)`
 - controller APIs: `preview(...)`, `step(...)`, `state_diff(...)`
 
 ### Controller API (Reusable Outside REPL)
@@ -363,20 +360,14 @@ the compiler.
 
 ---
 
-## Checkpoint Contract
+## Persistence Contract
 
-`export_json()` / `import_json()` and the checkpoint APIs serve different boundaries:
+`export_json()` / `import_json()` are the current persistence boundary.
 
-- `export_json()` / `import_json()` transport **authoritative state only**
-- checkpoint APIs transport a **versioned engine snapshot**:
-  - authoritative state
-  - `pending` semantic continuation state when supported by the active engine contract
-
-Use state JSON when you only need authoritative state. Use checkpoint APIs when
-you want the stable checkpoint envelope across process or request boundaries.
-
-For the checkpoint object shape, API-level usage notes, and serialization
-details, see [docs/api-reference.md](docs/api-reference.md#checkpoint-apis).
+- They transport **authoritative state only**
+- Hosts own any broader interaction or session workflow around that state
+- Pending continuation, if supported by the active engine contract, remains a
+  runtime semantic concept rather than a documented persisted artifact
 
 ---
 
@@ -402,6 +393,11 @@ Replacement:
 User: use podman instead of docker
 ```
 
+If `docker` is absent from saved state, that does not make the directive
+pending. The user's intended resulting state is still unambiguous, so the
+replacement follows the deterministic `use podman` transition when otherwise
+semantically valid.
+
 Removal and reset:
 
 ```text
@@ -418,6 +414,8 @@ evaluation against authoritative state.
 Pending continuation is a separate runtime layer. It may exist only after a
 canonical directive reaches a supported semantic `clarify` case. It never
 repairs malformed syntax or reinterprets non-canonical input as a directive.
+An absent source item in a canonical replacement directive is not, by itself,
+such a `clarify` case.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Context Compiler is a deterministic conversational state authority for LLM applications.
 It handles canonical directive execution, semantic validation, deterministic
-clarify decisions, checkpoint restore, and structured authoritative state for
+clarify decisions, semantic continuation checkpoints, and structured authoritative state for
 the host.
 
 ## What Context Compiler provides
@@ -15,6 +15,7 @@ Context Compiler gives hosts fixed state rules:
 
 - handle canonical explicit state changes with deterministic rules
 - clarification instead of silent overwrite for blocked/ambiguous changes
+- preserve supported pending continuation when explicit confirmation is required
 - export and import checkpoints to restore saved state in a versioned engine snapshot
 - produce structured authoritative state for downstream host decisions
 
@@ -55,6 +56,15 @@ instead of relying on memory of earlier conversation text.
 
 Context Compiler makes state-change rules explicit so behavior stays repeatable.
 
+The architecture has three layers:
+
+- syntax classification decides whether input is a canonical directive, invalid
+  directive-shaped syntax, or ordinary passthrough
+- semantic evaluation decides whether a canonical directive updates state,
+  clarifies, or no-ops
+- semantic continuation optionally preserves a deterministic blocked transition
+  that needs explicit `yes` / `no`
+
 ### Explicit directive
 
 ```text
@@ -71,7 +81,7 @@ use docker and prohibit peanuts
 ```
 
 - Without an authority layer: host/model behavior varies
-- Context Compiler: returns `clarify`, keeps authoritative state unchanged, and asks for separate directives
+- Context Compiler: treats this as invalid directive-shaped syntax, keeps authoritative state unchanged, and does not create pending continuation
 
 ### State-dependent operation
 
@@ -182,7 +192,7 @@ Preload options keep authoritative state transport separate from checkpoint sess
 - `--initial-state-json` / `--initial-state-file` load saved state
   (via exported state JSON).
 - `--initial-checkpoint-json` / `--initial-checkpoint-file` restore the full
-  checkpoint envelope (saved state plus reserved continuation field).
+  checkpoint envelope (saved state plus continuation field when supported by the active engine contract).
 
 REPL commands (controller layer, not engine directives):
 
@@ -206,7 +216,7 @@ Preload options keep authoritative state transport separate from checkpoint sess
 - `--initial-state-json` / `--initial-state-file` load saved state
   (via exported state JSON).
 - `--initial-checkpoint-json` / `--initial-checkpoint-file` restore the full
-  checkpoint envelope (saved state plus reserved continuation field).
+  checkpoint envelope (saved state plus continuation field when supported by the active engine contract).
 
 ## Installation
 
@@ -360,7 +370,7 @@ the compiler.
 - `export_json()` / `import_json()` transport **authoritative state only**
 - checkpoint APIs transport a **versioned engine snapshot**:
   - authoritative state
-  - reserved `pending` field for canonical continuation compatibility
+  - `pending` semantic continuation state when supported by the active engine contract
 
 Use state JSON when you only need authoritative state. Use checkpoint APIs when
 you want the stable checkpoint envelope across process or request boundaries.
@@ -404,6 +414,10 @@ Grammar invariant: one input may contain at most one canonical directive.
 Directive-shaped invalid input is outside the canonical language, and
 `clarify` is reserved for canonical directives that later fail semantic
 evaluation against authoritative state.
+
+Pending continuation is a separate runtime layer. It may exist only after a
+canonical directive reaches a supported semantic `clarify` case. It never
+repairs malformed syntax or reinterprets non-canonical input as a directive.
 
 Examples:
 
@@ -487,6 +501,7 @@ overwriting state.
 - Identical input sequences produce identical compiler state.
 - Model responses never modify compiler state.
 - Ambiguous directives trigger clarification instead of changing state.
+- Syntax errors never create pending continuation.
 
 Behavioral tests and Hypothesis-based property tests verify these invariants.
 

--- a/docs/DescriptionAndMilestones.md
+++ b/docs/DescriptionAndMilestones.md
@@ -73,29 +73,25 @@ Help apps safely reuse saved exported state.
 - Export current authoritative state
 - Initialize a new engine from previously exported authoritative state
 - Ensure restored authoritative state behaves identically to live state
-- Support serialized continuation checkpoints for restoring both:
-  - authoritative state
-  - pending confirmation-required continuation state
 
 **Deliverables:**
 
 - App-side storage and recovery patterns built on the existing import/export API
-- App-side storage and recovery patterns for checkpoint object and checkpoint JSON restore
 
 **User-visible outcome:**
 
-When apps persist exported state, assistants can carry decisions across sessions without reintroducing old conflicts.
-Pending confirmation-required flows can be resumed when the app persists checkpoints.
+When apps persist exported state, assistants can carry decisions across
+sessions without reintroducing old conflicts.
 
-`export_json()` / `import_json()` remain authoritative-state only.
-Checkpoint APIs are separate and represent runtime continuation.
-Long-term memory remains an app persistence responsibility, not an engine-owned store.
+`export_json()` / `import_json()` are the authoritative persistence boundary.
+Long-term memory remains an app persistence responsibility, not an engine-owned
+store.
 
 ### 0.6.x
 
-The 0.6.x line completed checkpoint support, authority-layer boundary hardening,
-and regression/conformance surfaces that prepared the project for the later
-clean break between core authority behavior, acquisition-layer drafting, and
+The 0.6.x line expanded authority-layer boundary hardening and
+regression/conformance surfaces that prepared the project for the later clean
+break between core authority behavior, acquisition-layer drafting, and
 runnable integrations.
 
 ### 0.7 — Auditability & Boundary Hardening
@@ -112,11 +108,9 @@ Make engine behavior inspectable and externally controllable without guessing.
 - Machine-readable REPL JSON output containing:
   - versioned one-object-per-line output (`output_version`)
   - step / preview / state command result envelopes
-- JSON preload for authoritative state and checkpoint continuation:
+- JSON preload for authoritative state:
   - `--initial-state-json`
   - `--initial-state-file`
-  - `--initial-checkpoint-json`
-  - `--initial-checkpoint-file`
 
 **Constraints:**
 
@@ -135,8 +129,8 @@ Current ownership after 0.8:
 
 - `context-compiler` owns the Authority Layer:
   deterministic state transitions, canonical directive application, semantic
-  validation, clarification and confirmation handling, checkpoints,
-  preview/diff, controller behavior, and authoritative state
+  validation, clarification and confirmation handling, preview/diff,
+  controller behavior, and authoritative state
 - `context-compiler-directive-drafter` owns Acquisition Layer drafting:
   natural-language-to-directive drafting, candidate directive generation,
   malformed-input recovery, alternate human phrasing, prompt/resource usage for
@@ -173,7 +167,6 @@ Design notes:
 - Any future thread-safety work should evaluate:
   - atomic preview semantics
   - export/import consistency
-  - checkpoint operations
   - concurrency testing
 - Thread-safety should be designed holistically rather than added through ad hoc locking.
 

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -427,6 +427,11 @@ continuation runtime state. That state represents a deterministic blocked
 transition that core has already identified but must not apply without explicit
 user authorization.
 
+An absent source item in a canonical replacement directive is not, by itself,
+such a blocked transition. If `use <new> instead of <old>` parses
+canonically and `<old>` is absent from authoritative state, that absence is a
+state-fact mismatch, not an ambiguity of user intent.
+
 ### 8.3 Family-by-family semantic boundary
 
 - `set premise <value>`
@@ -551,6 +556,17 @@ Let `kx` be the policy identity key for `REPLACE_NEW` under Section 10.1 and
 The replacement-specific `clarify` cases are state-dependent and belong to
 semantic evaluation, not parsing.
 
+Normative classification for the historical missing-source case:
+
+- if `ky` is absent and applying `use <new>` is otherwise semantically valid,
+  `use <new> instead of <old>` is not a clarification case;
+- core applies the deterministic resulting transition of asserting
+  `REPLACE_NEW` as `use`;
+- the user's incorrect assumption about the current presence of `<old>` does
+  not by itself create semantic ambiguity or pending continuation;
+- malformed replacement syntax remains invalid grammar, and other semantic
+  conflicts for a canonical replacement may still return `clarify`.
+
 ### 9.5 Clarify rule
 
 Core returns `clarify` only after:
@@ -609,8 +625,11 @@ This specification preserves the grammar hardening established after `0.8.x`:
 
 Within semantic evaluation, pending continuation is intended only for
 deterministic blocked transitions that do not expand authority beyond the
-parsed canonical operation. Historical replacement clarifications that would
-authorize broader policy mutation are not implicitly restored by this document.
+parsed canonical operation. In particular, the historical missing-source
+replacement case (`use <new> instead of <old>` when `<old>` is absent) is not
+a pending or clarification case under this specification; it deterministically
+applies the resulting `use <new>` transition when otherwise semantically
+valid.
 
 ## 11. Storage Normalization
 
@@ -692,7 +711,7 @@ source material for later conformance fixtures.
 | `prohibit peanuts` | canonical directive | prohibit item | may apply, no-op, or clarify |
 | `remove policy docker` | canonical directive | remove policy | may apply or no-op |
 | `use podman instead of docker` | canonical directive | replace use | may apply, no-op, or clarify |
-| `use podman instead of docker` when semantic rules require explicit confirmation for a deterministic blocked transition | canonical directive | replace use | may return `clarify` and establish pending continuation under the active engine contract |
+| `use podman instead of docker` when `docker` is absent and `use podman` is otherwise valid | canonical directive | replace use | applies deterministically as the resulting `use podman` transition; not a pending/clarification case |
 | `clear premise` | canonical directive | clear premise | may apply or no-op |
 | `reset policies` | canonical directive | reset policies | may apply or no-op |
 | `clear state` | canonical directive | clear state | may apply or no-op |

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -34,9 +34,11 @@ Later implementation and conformance work must follow this document.
 | Policy | Per-item authoritative state: `"use"` or `"prohibit"` |
 | State | Current authoritative snapshot |
 | Semantic evaluation | State-dependent evaluation that occurs only after a canonical directive parses successfully |
+| Pending continuation | Runtime state representing a deterministic blocked semantic transition awaiting explicit user authorization |
 | Decision | Compiler instruction returned to the host |
 
 `clarify` is a semantic outcome, not a parsing category.
+Pending continuation is a semantic runtime concept, not a parsing category.
 
 ## 2. System Responsibilities
 
@@ -81,6 +83,10 @@ Semantics:
 This specification does not add a new runtime `Decision.kind` for
 directive-shaped invalid input. Section 6 defines that classification
 normatively for future parser and conformance work.
+
+This specification does not define pending continuation as a grammar feature.
+Pending continuation, when supported by the engine contract, is a runtime
+consequence of semantic evaluation after successful canonical parsing.
 
 ## 5. Engine/Host State Contract
 
@@ -416,6 +422,11 @@ Semantic evaluation may produce:
 `clarify` is reserved for state-dependent conflicts or precondition failures of
 an already parsed canonical directive.
 
+Some semantic `clarify` outcomes may additionally establish pending
+continuation runtime state. That state represents a deterministic blocked
+transition that core has already identified but must not apply without explicit
+user authorization.
+
 ### 8.3 Family-by-family semantic boundary
 
 - `set premise <value>`
@@ -551,12 +562,62 @@ Core returns `clarify` only after:
 Malformed, incomplete, near-canonical, and compound directive-shaped inputs are
 outside this category.
 
-## 10. Storage Normalization
+## 10. Semantic Continuation
+
+Pending continuation belongs to runtime semantics, not grammar.
+
+It may exist only after:
+
+1. lexical normalization and classification succeed under Sections 6 and 7;
+2. canonical parsing succeeds; and
+3. semantic evaluation reaches a supported deterministic blocked transition.
+
+Pending continuation must never:
+
+- repair malformed syntax;
+- reinterpret non-canonical input as a directive;
+- guess missing operands;
+- authorize multiple directive effects from one input;
+- convert a semantic conflict into a broader mutation than the parsed
+  canonical directive justifies.
+
+### 10.1 Supported contract shape
+
+When the active engine contract supports pending continuation, it is limited to
+semantic `clarify` cases where:
+
+- the triggering input was already a canonical directive;
+- the blocked transition is deterministic;
+- accepting `yes` authorizes exactly one known continuation outcome;
+- rejecting with `no` leaves authoritative state unchanged and clears the
+  pending continuation.
+
+Unrelated input while pending must behave deterministically under the active
+engine contract. At minimum, it must not be reinterpreted as retroactive repair
+of the original non-applied operation.
+
+### 10.2 Replacement-family boundary
+
+`use <new> instead of <old>` remains a canonical directive family, but pending
+continuation is narrower than replacement syntax itself.
+
+This specification preserves the grammar hardening established after `0.8.x`:
+
+- incomplete replacement forms are directive-shaped invalid input;
+- malformed replacement forms are never confirmable;
+- compound replacement-like input is never decomposed into multiple operations.
+
+Within semantic evaluation, pending continuation is intended only for
+deterministic blocked transitions that do not expand authority beyond the
+parsed canonical operation. Historical replacement clarifications that would
+authorize broader policy mutation are not implicitly restored by this document.
+
+## 11. Storage Normalization
 
 Normalization below applies after successful parsing, during storage or lookup.
 It is not part of syntax repair.
 
-### 10.1 Policy identity
+### 11.1 Policy identity
 
 Policy-bearing directives derive a canonical policy identity for storage,
 lookup, and semantic comparison.
@@ -589,7 +650,7 @@ Repository drift note:
 - those behaviors are current implementation details and test-backed runtime
   behavior, but they are not frozen here as the intended core semantic contract.
 
-### 10.2 Premise-value sanitation
+### 11.2 Premise-value sanitation
 
 Premise values are stored as semantically opaque strings with
 representation-level sanitation only:
@@ -600,26 +661,21 @@ representation-level sanitation only:
 
 No stemming, synonym mapping, ontology, or semantic rewriting is allowed.
 
-## 11. Non-Current Pending Confirmation Language
+## 12. Confirmation Boundary
 
-The current intended core grammar contract does not add or rely on pending
-confirmation behavior.
+Confirmation tokens are not part of directive grammar classification.
 
-Repository code may still expose checkpoint fields or helper APIs that mention
-pending continuation for compatibility reasons, but pending confirmation is not
-part of the current directive grammar contract defined here.
+When an engine implementation supports pending continuation, confirmation
+handling is a runtime continuation rule layered on top of semantic evaluation.
+It must not redefine malformed syntax as confirmable canonical input.
 
 This specification therefore does not define:
 
-- confirmation tokens as grammar input;
-- pending-only parsing mode;
-- pending-only semantic continuation rules.
+- confirmation tokens as canonical directives;
+- pending-only grammar productions;
+- any syntax-repair path that becomes confirmable through `yes` / `no`.
 
-If future work reintroduces reachable pending continuation semantics, that
-behavior must be specified separately and must not redefine malformed syntax as
-confirmable canonical input.
-
-## 12. Normative Example Matrix
+## 13. Normative Example Matrix
 
 These examples are normative illustrations of the contract and are suitable
 source material for later conformance fixtures.
@@ -636,6 +692,7 @@ source material for later conformance fixtures.
 | `prohibit peanuts` | canonical directive | prohibit item | may apply, no-op, or clarify |
 | `remove policy docker` | canonical directive | remove policy | may apply or no-op |
 | `use podman instead of docker` | canonical directive | replace use | may apply, no-op, or clarify |
+| `use podman instead of docker` when semantic rules require explicit confirmation for a deterministic blocked transition | canonical directive | replace use | may return `clarify` and establish pending continuation under the active engine contract |
 | `clear premise` | canonical directive | clear premise | may apply or no-op |
 | `reset policies` | canonical directive | reset policies | may apply or no-op |
 | `clear state` | canonical directive | clear state | may apply or no-op |
@@ -660,8 +717,10 @@ source material for later conformance fixtures.
 | `clear state then set premise project` | directive-shaped invalid input | none | compound attempt |
 | `use "docker and prohibit peanuts"` | directive-shaped invalid input | none | quotes do not protect embedded directive text |
 | `set premise "use docker and prohibit peanuts"` | directive-shaped invalid input | none | quotes do not protect embedded directive text |
+| `yes` with no pending continuation | passthrough | none | confirmation text has no standalone directive grammar meaning |
+| malformed replacement followed later by `yes` | directive-shaped invalid input, then passthrough | none | invalid syntax never creates confirmable pending state |
 
-## 13. Invariants
+## 14. Invariants
 
 1. State changes only from canonical directives that pass semantic evaluation.
 2. Same input sequence yields identical state and decisions.
@@ -669,8 +728,12 @@ source material for later conformance fixtures.
 4. `clarify` is semantic, not syntactic.
 5. A single input never applies more than one canonical directive.
 6. Core does not repair non-canonical human input into canonical directives.
+7. Pending continuation, when supported, originates only from successful
+   canonical parsing followed by semantic evaluation.
+8. Syntax errors never create pending continuation state.
+9. Pending continuation never authorizes malformed-input repair.
 
-## 14. Non-Goals
+## 15. Non-Goals
 
 Not part of the current core grammar:
 
@@ -679,7 +742,7 @@ Not part of the current core grammar:
 - implicit operands;
 - quoting or escaping syntax;
 - multiple directives in one input;
+- pending-confirmation grammar;
 - entity modeling;
 - ordered policy history;
-- pending-confirmation grammar;
 - readonly or locked-state modifiers.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -20,6 +20,8 @@ Core boundary:
 - core consumes canonical directives
 - canonical directive validation remains in core
 - semantic validation and authoritative state transitions remain in core
+- pending continuation, when supported, is created only by semantic evaluation
+  of canonical directives
 - human-facing normalization, malformed-input recovery, and intent drafting are
   outside the core contract
 - core does not convert failed canonical operations into different directives
@@ -100,10 +102,21 @@ traversal unless you are working at an explicit serialization boundary.
 
 ### `engine.has_pending_clarification()`
 
-Return whether a confirmation-required clarification is currently pending.
+Return whether a confirmation-required semantic continuation is currently
+pending.
 
-In the current engine contract, this returns `False` because no canonical
-operation currently produces pending clarification state.
+Contract boundary:
+
+- pending continuation is runtime state, not grammar
+- pending continuation must never arise from malformed or non-canonical input
+- pending continuation, when supported, comes only from semantic evaluation of
+  an already parsed canonical directive
+
+Current implementation note:
+
+- the updated specification allows supported pending continuation semantics
+- the current runtime implementation may still return `False` for all inputs
+  until the continuation behavior is restored
 
 Typical use:
 
@@ -212,9 +225,9 @@ Export a checkpoint as canonical JSON text.
 
 Validate and restore a checkpoint from JSON text.
 
-Use checkpoint APIs when you need a versioned engine-session snapshot. Today,
-that means authoritative state plus a reserved `pending` field for canonical
-continuation compatibility.
+Use checkpoint APIs when you need a versioned engine-session snapshot. The
+contract shape is authoritative state plus pending semantic continuation state
+when the active engine contract supports it.
 
 Checkpoint object shape:
 
@@ -237,9 +250,10 @@ At this boundary, direct key access is expected.
 API-level contract notes:
 
 - `pending` is `null` when no continuation is waiting for confirmation
-- `pending` captures confirmation-required continuation for canonical
+- `pending` captures confirmation-required semantic continuation for canonical
   operations supported by the active engine contract
-- in the current engine contract, `pending` is always `null`
+- `pending` is never a syntax-repair buffer and must not encode malformed-input
+  recovery
 - non-canonical repair state is not part of the intended core contract
 - imported policy keys are normalized during `import_json(...)` and checkpoint
   authoritative-state restore
@@ -250,6 +264,12 @@ API-level contract notes:
   partial restore occurs
 - `checkpoint_version` is independent of authoritative state `version` and must
   be bumped when checkpoint contract shape changes, especially `pending`
+
+Current implementation note:
+
+- the repository runtime currently exports `pending: null`
+- that implementation status does not narrow the intended checkpoint contract
+  for restored semantic continuation behavior
 
 Typical use cases:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -12,8 +12,8 @@ Authoritative behavior documents:
 - [Project README](../README.md)
 
 For behavioral semantics, use the authoritative documents above. This page
-documents the public checkpoint APIs and their contract surface without
-redefining directive or continuation behavior.
+documents the supported public package surface without redefining directive or
+continuation behavior.
 
 Core boundary:
 
@@ -91,6 +91,9 @@ Boundary notes:
   code should send canonical directives when it wants deterministic mutation
 - failed replacement requests are not reinterpreted by core into different
   directives
+- `use <new> instead of <old>` with an absent `<old>` is not a pending or
+  clarification-only runtime category; it follows the deterministic semantic
+  rules defined in the specification
 
 ### `engine.state`
 
@@ -111,6 +114,8 @@ Contract boundary:
 - pending continuation must never arise from malformed or non-canonical input
 - pending continuation, when supported, comes only from semantic evaluation of
   an already parsed canonical directive
+- the historical missing-source replacement case does not, by itself, create
+  pending continuation
 
 Current implementation note:
 
@@ -204,78 +209,11 @@ Use these APIs for authoritative-state transport or persistence only.
 
 Conceptual boundary:
 
-- `export_json()` / `import_json()` transport authoritative state only
-- checkpoint APIs transport authoritative state plus resumable continuation state
-
-## Checkpoint APIs
-
-### `engine.export_checkpoint()`
-
-Export a resumable checkpoint object.
-
-### `engine.import_checkpoint(payload)`
-
-Validate and restore a checkpoint object.
-
-### `engine.export_checkpoint_json()`
-
-Export a checkpoint as canonical JSON text.
-
-### `engine.import_checkpoint_json(payload)`
-
-Validate and restore a checkpoint from JSON text.
-
-Use checkpoint APIs when you need a versioned engine-session snapshot. The
-contract shape is authoritative state plus pending semantic continuation state
-when the active engine contract supports it.
-
-Checkpoint object shape:
-
-```json
-{
-  "checkpoint_version": 1,
-  "authoritative_state": {
-    "premise": "concise replies",
-    "policies": {
-      "docker": "use"
-    },
-    "version": 2
-  },
-  "pending": null
-}
-```
-
-At this boundary, direct key access is expected.
-
-API-level contract notes:
-
-- `pending` is `null` when no continuation is waiting for confirmation
-- `pending` captures confirmation-required semantic continuation for canonical
-  operations supported by the active engine contract
-- `pending` is never a syntax-repair buffer and must not encode malformed-input
-  recovery
-- non-canonical repair state is not part of the intended core contract
-- imported policy keys are normalized during `import_json(...)` and checkpoint
-  authoritative-state restore
+- `export_json()` / `import_json()` are the current persistence contract
+- pending continuation, when supported by the engine contract, is runtime state
+  rather than a documented persistence feature
+- imported policy keys are normalized during `import_json(...)`
 - if a policy key normalizes to `""`, the payload is invalid and is rejected
-- checkpoint restore is full and deterministic: authoritative state and pending
-  continuation are restored together
-- checkpoint validation is all-or-nothing; invalid payloads raise and no
-  partial restore occurs
-- `checkpoint_version` is independent of authoritative state `version` and must
-  be bumped when checkpoint contract shape changes, especially `pending`
-
-Current implementation note:
-
-- the repository runtime currently exports `pending: null`
-- that implementation status does not narrow the intended checkpoint contract
-  for restored semantic continuation behavior
-
-Typical use cases:
-
-- stateless host or integration boundaries where engine instances are short-lived
-- authoritative-state persistence with a stable checkpoint envelope
-- future-compatible storage where hosts want one artifact for engine session snapshots
 
 ## Controller APIs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,12 +9,12 @@ Responsibilities:
 
 - apply deterministic state transitions
 - enforce deterministic clarification gates for core-owned state semantics
-- export/import authoritative state and checkpoints
+- export/import authoritative state
 
 Examples:
 
 - Context Compiler core engine
-- checkpoint/session snapshot behavior
+- authoritative state import/export behavior
 
 Repository:
 
@@ -37,11 +37,16 @@ Boundary:
   canonical operations already established by core
 - pending continuation is runtime state, not grammar
 - malformed or non-canonical input must never create pending continuation
+- a missing source item in `use <new> instead of <old>` is evaluated as a
+  deterministic state transition question, not as a justification for pending
+  continuation
 
 Current repository note:
 
 - the intended contract allows semantic pending continuation for supported
   deterministic blocked transitions
+- that continuation boundary is independent from the historical replacement
+  case where the requested old item is absent from state
 - the current runtime implementation does not yet fully restore that contract
   and should be treated as lagging the updated specification until runtime work
   lands
@@ -118,12 +123,11 @@ Policy independence is a major contributor to:
 - determinism
 - portability
 - replay consistency
-- checkpoint stability
 - cross-language conformance
 
 Because policies are independent flat assertions, directive semantics stay
-simple, exported state stays portable, replay remains exact, and any future
-checkpoint continuation does not depend on hidden relational logic.
+simple, exported state stays portable, and replay remains exact without hidden
+relational logic.
 
 Relationship-heavy semantics may still be useful, but they generally belong in
 drafting, orchestration, or domain-specific layers rather than in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,9 +29,22 @@ Boundary:
 - core does not own human-facing normalization, malformed-input recovery, or
   intent inference as a general responsibility
 - core does not convert failed canonical operations into different directives
-- pending yes/no confirmation is reserved for deterministic continuation of
+- core separates three layers:
+  - syntax classification
+  - semantic evaluation
+  - semantic continuation
+- pending yes/no confirmation belongs only to semantic continuation of
   canonical operations already established by core
-- the current engine contract produces no live pending continuation state
+- pending continuation is runtime state, not grammar
+- malformed or non-canonical input must never create pending continuation
+
+Current repository note:
+
+- the intended contract allows semantic pending continuation for supported
+  deterministic blocked transitions
+- the current runtime implementation does not yet fully restore that contract
+  and should be treated as lagging the updated specification until runtime work
+  lands
 
 ## Acquisition Layer
 

--- a/docs/demos-results.md
+++ b/docs/demos-results.md
@@ -112,4 +112,4 @@ records the standard scored demo configuration.
 This is exploratory evidence, not benchmark authority. Reinjection can be
 enough in some persistence scenarios, while compiler-mediated paths still
 provide authority semantics such as replacement preconditions, blocked
-mutations, pending confirmation handling, and checkpoint continuation.
+mutations, and pending confirmation handling.

--- a/docs/multi-engine.md
+++ b/docs/multi-engine.md
@@ -18,7 +18,7 @@ A single engine can manage:
 - conversational stance  
 - explicit correction and replacement flows  
 - policy removal and reset  
-- persistence and checkpoint restore  
+- authoritative-state persistence  
 
 Example:
 
@@ -60,7 +60,7 @@ The app is responsible for:
 
 - selecting which engine(s) apply  
 - combining state into model context  
-- managing lifecycle (reset, persistence, checkpoint restore) per engine  
+- managing lifecycle (reset and persistence) per engine  
 
 The compiler only maintains a single state instance per engine.
 

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -53,7 +53,7 @@ Then asserts:
 
 ### Prelude
 
-`prelude` simulates prior user inputs to reach states that are not representable via `initial_state` (for example, pending clarification).
+`prelude` simulates prior user inputs to reach states that are not representable via `initial_state` (for example, pending semantic continuation when the active engine contract supports it).
 
 ## State JSON fixtures
 
@@ -69,7 +69,8 @@ For [`conformance/checkpoint/`](conformance/checkpoint/):
 
 Portable checkpoint import contract coverage for
 `engine.import_checkpoint(...)`, including deterministic validation/error
-boundaries, atomic failure behavior, and pending-clarification clearing semantics.
+boundaries, atomic failure behavior, and pending semantic-continuation restore
+and clearing semantics.
 
 ## Controller fixtures
 
@@ -104,6 +105,19 @@ They validate:
 * clarification prompt behavior
 * checkpoint export parity against expected snapshots
 * continuation state restoration from checkpoints
+
+Planned conformance coverage for the restored continuation contract should
+include:
+
+* incomplete directives do not create pending continuation
+* compound directives do not create pending continuation
+* malformed replacement syntax does not create pending continuation
+* valid canonical directives that clarify without pending continuation
+* valid canonical directives that clarify and create pending continuation
+* checkpoint round-trip of supported pending continuation
+* deterministic `yes` resolution of the exact blocked transition
+* deterministic `no` rejection that clears pending continuation
+* deterministic handling of unrelated input while pending
 
 ## Test runner
 

--- a/tests/fixtures/conformance/step/020_compound_use_and_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/020_compound_use_and_prohibit_invalid_boundary.json
@@ -1,12 +1,12 @@
 {
-  "id": "step_compound_use_punctuation_prohibit_clarify",
+  "id": "step_compound_use_and_prohibit_invalid_boundary",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "input": "use docker. prohibit peanuts",
+  "input": "use docker and prohibit peanuts",
   "expected": {
     "decision": {
       "kind": "passthrough",

--- a/tests/fixtures/conformance/step/021_compound_set_premise_and_use_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/021_compound_set_premise_and_use_invalid_boundary.json
@@ -1,12 +1,12 @@
 {
-  "id": "step_quoted_payload_compound_clarify",
+  "id": "step_compound_set_premise_and_use_invalid_boundary",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "input": "use \"docker and prohibit peanuts\"",
+  "input": "set premise vegetarian and use docker",
   "expected": {
     "decision": {
       "kind": "passthrough",

--- a/tests/fixtures/conformance/step/022_compound_clear_state_then_set_premise_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/022_compound_clear_state_then_set_premise_invalid_boundary.json
@@ -1,14 +1,14 @@
 {
-  "id": "step_compound_remove_policy_and_prohibit_clarify",
+  "id": "step_compound_clear_state_then_set_premise_invalid_boundary",
   "kind": "step",
   "initial_state": {
-    "premise": null,
+    "premise": "baseline",
     "policies": {
       "docker": "use"
     },
     "version": 2
   },
-  "input": "remove policy docker and prohibit peanuts",
+  "input": "clear state then set premise project",
   "expected": {
     "decision": {
       "kind": "passthrough",
@@ -16,7 +16,7 @@
       "state": null
     },
     "state": {
-      "premise": null,
+      "premise": "baseline",
       "policies": {
         "docker": "use"
       },

--- a/tests/fixtures/conformance/step/023_compound_remove_policy_and_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/023_compound_remove_policy_and_prohibit_invalid_boundary.json
@@ -1,12 +1,14 @@
 {
-  "id": "step_compound_use_or_prohibit_clarify",
+  "id": "step_compound_remove_policy_and_prohibit_invalid_boundary",
   "kind": "step",
   "initial_state": {
     "premise": null,
-    "policies": {},
+    "policies": {
+      "docker": "use"
+    },
     "version": 2
   },
-  "input": "use docker or prohibit peanuts",
+  "input": "remove policy docker and prohibit peanuts",
   "expected": {
     "decision": {
       "kind": "passthrough",
@@ -15,7 +17,9 @@
     },
     "state": {
       "premise": null,
-      "policies": {},
+      "policies": {
+        "docker": "use"
+      },
       "version": 2
     },
     "has_pending_clarification": false

--- a/tests/fixtures/conformance/step/024_compound_use_or_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/024_compound_use_or_prohibit_invalid_boundary.json
@@ -1,14 +1,12 @@
 {
-  "id": "step_compound_clear_state_then_set_premise_clarify",
+  "id": "step_compound_use_or_prohibit_invalid_boundary",
   "kind": "step",
   "initial_state": {
-    "premise": "baseline",
-    "policies": {
-      "docker": "use"
-    },
+    "premise": null,
+    "policies": {},
     "version": 2
   },
-  "input": "clear state then set premise project",
+  "input": "use docker or prohibit peanuts",
   "expected": {
     "decision": {
       "kind": "passthrough",
@@ -16,10 +14,8 @@
       "state": null
     },
     "state": {
-      "premise": "baseline",
-      "policies": {
-        "docker": "use"
-      },
+      "premise": null,
+      "policies": {},
       "version": 2
     },
     "has_pending_clarification": false

--- a/tests/fixtures/conformance/step/025_compound_use_xor_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/025_compound_use_xor_prohibit_invalid_boundary.json
@@ -1,12 +1,12 @@
 {
-  "id": "step_compound_use_and_prohibit_clarify",
+  "id": "step_compound_use_xor_prohibit_invalid_boundary",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "input": "use docker and prohibit peanuts",
+  "input": "use docker xor prohibit peanuts",
   "expected": {
     "decision": {
       "kind": "passthrough",

--- a/tests/fixtures/conformance/step/026_compound_use_punctuation_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/026_compound_use_punctuation_prohibit_invalid_boundary.json
@@ -1,12 +1,12 @@
 {
-  "id": "step_compound_use_xor_prohibit_clarify",
+  "id": "step_compound_use_punctuation_prohibit_invalid_boundary",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "input": "use docker xor prohibit peanuts",
+  "input": "use docker. prohibit peanuts",
   "expected": {
     "decision": {
       "kind": "passthrough",

--- a/tests/fixtures/conformance/step/028_quoted_payload_compound_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/028_quoted_payload_compound_invalid_boundary.json
@@ -1,12 +1,12 @@
 {
-  "id": "step_compound_set_premise_and_use_clarify",
+  "id": "step_quoted_payload_compound_invalid_boundary",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "input": "set premise vegetarian and use docker",
+  "input": "use \"docker and prohibit peanuts\"",
   "expected": {
     "decision": {
       "kind": "passthrough",


### PR DESCRIPTION
## What changed

- Removed checkpoint as a supported documentation workflow.
- Updated persistence guidance so `export_json()` / `import_json()` are the only current persistence contract.
- Clarified that pending continuation is a runtime semantic concept and is not a persisted artifact.
- Updated API, architecture, README, milestone, and documentation references to remove checkpoint workflow guidance.
- Preserved historical references where they describe legacy fixture/runtime coverage rather than current supported behavior.

## Why

- Checkpoint was primarily introduced to persist pending continuation state.
- The current architecture does not require persisted continuation state.
- Keeping checkpoint documented as a supported workflow implied a capability boundary that no longer exists.
- Establishing a clean baseline allows future persistence features (such as transactions or staged workflows) to be designed around concrete requirements rather than preserving unused infrastructure.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)