### PR TITLE
test: add mutation isolation conformance fixtures

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -79,6 +79,33 @@ These fixtures keep a minimal, language-neutral contract matrix for controller A
 They intentionally validate the raw controller result envelopes; helper accessors
 are covered separately by the public API presence contract above.
 
+## Mutation-isolation fixtures
+
+For [`conformance/mutation-isolation/`](conformance/mutation-isolation/):
+
+Portable authority-isolation fixture definitions for public APIs that return
+structured objects or accept caller-owned structured inputs.
+
+These fixtures define declarative scenarios for:
+
+* constructor input isolation
+* `engine.state` snapshot isolation
+* update `Decision.state` isolation
+* controller result isolation
+* preview result isolation
+* helper accessor ownership and identity semantics
+
+The portable contract for this family is:
+
+* no public API return value may provide a mutation path into authoritative engine state
+* no caller-supplied input may remain aliased into authoritative engine state
+* helper accessors may return caller-owned nested members by identity when that
+  behavior is intentional and documented
+
+This family is intentionally data-only in the Python 0.9 source-of-truth repo.
+It defines the shared conformance corpus first; language-specific runners may be
+added in a later synchronized change.
+
 ## Source of truth
 
 Fixtures reflect current Python behavior and tests.

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -102,9 +102,12 @@ The portable contract for this family is:
 * helper accessors may return caller-owned nested members by identity when that
   behavior is intentional and documented
 
-This family is intentionally data-only in the Python 0.9 source-of-truth repo.
-It defines the shared conformance corpus first; language-specific runners may be
-added in a later synchronized change.
+The Python source-of-truth repo executes this fixture family through the
+existing conformance runner in
+[`tests/test_fixtures.py`](../test_fixtures.py).
+
+Portable fixture data remains language-neutral. Other ports may add execution
+support in later synchronized changes.
 
 ## Source of truth
 

--- a/tests/fixtures/conformance/mutation-isolation/001_constructor_input_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/001_constructor_input_isolation.json
@@ -1,0 +1,47 @@
+{
+  "id": "mutation_isolation_constructor_input",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": "Prefer concise replies",
+    "policies": {
+      "docker": "use"
+    },
+    "version": 2
+  },
+  "operation": {
+    "fn": "create_engine",
+    "constructor_state_handle": "constructor_state"
+  },
+  "handles": {
+    "constructor_state": {
+      "kind": "caller_owned_input",
+      "value": {
+        "premise": "Prefer concise replies",
+        "policies": {
+          "docker": "use"
+        },
+        "version": 2
+      }
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "constructor_state",
+      "path": [
+        "policies",
+        "docker"
+      ],
+      "op": "set",
+      "value": "prohibit"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": "Prefer concise replies",
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/mutation-isolation/002_engine_state_snapshot_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/002_engine_state_snapshot_isolation.json
@@ -1,0 +1,48 @@
+{
+  "id": "mutation_isolation_engine_state_snapshot",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": null,
+    "policies": {
+      "docker": "use"
+    },
+    "version": 2
+  },
+  "operation": {
+    "fn": "engine.state",
+    "result_handle": "state_snapshot"
+  },
+  "handles": {
+    "state_snapshot": {
+      "kind": "defensive_snapshot"
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "state_snapshot",
+      "path": [
+        "premise"
+      ],
+      "op": "set",
+      "value": "mutated premise"
+    },
+    {
+      "target_handle": "state_snapshot",
+      "path": [
+        "policies",
+        "docker"
+      ],
+      "op": "set",
+      "value": "prohibit"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": null,
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/mutation-isolation/003_update_decision_state_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/003_update_decision_state_isolation.json
@@ -27,6 +27,14 @@
     {
       "target_handle": "decision_state",
       "path": [
+        "premise"
+      ],
+      "op": "set",
+      "value": "mutated premise"
+    },
+    {
+      "target_handle": "decision_state",
+      "path": [
         "policies",
         "docker"
       ],

--- a/tests/fixtures/conformance/mutation-isolation/003_update_decision_state_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/003_update_decision_state_isolation.json
@@ -1,0 +1,46 @@
+{
+  "id": "mutation_isolation_update_decision_state",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "operation": {
+    "fn": "engine.step",
+    "input": "use docker",
+    "result_handle": "decision"
+  },
+  "handles": {
+    "decision": {
+      "kind": "independently_constructed_result"
+    },
+    "decision_state": {
+      "kind": "nested_state_member",
+      "from_handle": "decision",
+      "path": [
+        "state"
+      ]
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "decision_state",
+      "path": [
+        "policies",
+        "docker"
+      ],
+      "op": "set",
+      "value": "prohibit"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": null,
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/mutation-isolation/004_controller_step_result_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/004_controller_step_result_isolation.json
@@ -21,6 +21,15 @@
       "target_handle": "step_result",
       "path": [
         "state",
+        "premise"
+      ],
+      "op": "set",
+      "value": "mutated premise"
+    },
+    {
+      "target_handle": "step_result",
+      "path": [
+        "state",
         "policies",
         "docker"
       ],

--- a/tests/fixtures/conformance/mutation-isolation/004_controller_step_result_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/004_controller_step_result_isolation.json
@@ -1,0 +1,40 @@
+{
+  "id": "mutation_isolation_controller_step_result",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "operation": {
+    "fn": "controller.step",
+    "input": "use docker",
+    "result_handle": "step_result"
+  },
+  "handles": {
+    "step_result": {
+      "kind": "caller_owned_result_envelope"
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "step_result",
+      "path": [
+        "state",
+        "policies",
+        "docker"
+      ],
+      "op": "set",
+      "value": "prohibit"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": null,
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/mutation-isolation/005_preview_result_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/005_preview_result_isolation.json
@@ -34,6 +34,15 @@
     {
       "target_handle": "state_before",
       "path": [
+        "policies",
+        "docker"
+      ],
+      "op": "set",
+      "value": "prohibit"
+    },
+    {
+      "target_handle": "state_before",
+      "path": [
         "premise"
       ],
       "op": "set",

--- a/tests/fixtures/conformance/mutation-isolation/005_preview_result_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/005_preview_result_isolation.json
@@ -1,0 +1,60 @@
+{
+  "id": "mutation_isolation_preview_result",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "operation": {
+    "fn": "controller.preview",
+    "input": "use docker",
+    "result_handle": "preview_result"
+  },
+  "handles": {
+    "preview_result": {
+      "kind": "caller_owned_result_envelope"
+    },
+    "state_before": {
+      "kind": "defensive_snapshot",
+      "from_handle": "preview_result",
+      "path": [
+        "state_before"
+      ]
+    },
+    "state_after": {
+      "kind": "defensive_snapshot",
+      "from_handle": "preview_result",
+      "path": [
+        "state_after"
+      ]
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "state_before",
+      "path": [
+        "premise"
+      ],
+      "op": "set",
+      "value": "mutated before"
+    },
+    {
+      "target_handle": "state_after",
+      "path": [
+        "policies",
+        "docker"
+      ],
+      "op": "set",
+      "value": "prohibit"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "preview_live_state_unchanged": true
+  }
+}

--- a/tests/fixtures/conformance/mutation-isolation/005_preview_result_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/005_preview_result_isolation.json
@@ -42,6 +42,14 @@
     {
       "target_handle": "state_after",
       "path": [
+        "premise"
+      ],
+      "op": "set",
+      "value": "mutated after"
+    },
+    {
+      "target_handle": "state_after",
+      "path": [
         "policies",
         "docker"
       ],

--- a/tests/fixtures/conformance/mutation-isolation/006_helper_accessor_decision_state_identity.json
+++ b/tests/fixtures/conformance/mutation-isolation/006_helper_accessor_decision_state_identity.json
@@ -1,0 +1,64 @@
+{
+  "id": "mutation_isolation_helper_decision_state_identity",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "operation": {
+    "fn": "get_decision_state",
+    "input": "use docker",
+    "result_handle": "helper_result",
+    "source_handle": "decision"
+  },
+  "handles": {
+    "decision": {
+      "kind": "independently_constructed_result"
+    },
+    "helper_result": {
+      "kind": "caller_owned_nested_member"
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "helper_result",
+      "path": [
+        "policies",
+        "docker"
+      ],
+      "op": "set",
+      "value": "prohibit"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": null,
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    },
+    "identity_assertions": [
+      {
+        "left_handle": "helper_result",
+        "right_handle": "decision",
+        "right_path": [
+          "state"
+        ],
+        "same_identity": true
+      }
+    ],
+    "caller_owned_observations": [
+      {
+        "handle": "decision",
+        "path": [
+          "state",
+          "policies",
+          "docker"
+        ],
+        "value": "prohibit"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/conformance/mutation-isolation/007_helper_accessor_step_state_identity.json
+++ b/tests/fixtures/conformance/mutation-isolation/007_helper_accessor_step_state_identity.json
@@ -1,0 +1,65 @@
+{
+  "id": "mutation_isolation_helper_step_state_identity",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "operation": {
+    "fn": "get_step_state",
+    "input": "use docker",
+    "result_handle": "helper_result",
+    "source_handle": "step_result",
+    "source_fn": "controller.step"
+  },
+  "handles": {
+    "step_result": {
+      "kind": "caller_owned_result_envelope"
+    },
+    "helper_result": {
+      "kind": "caller_owned_nested_member"
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "helper_result",
+      "path": [
+        "policies",
+        "docker"
+      ],
+      "op": "set",
+      "value": "prohibit"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": null,
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    },
+    "identity_assertions": [
+      {
+        "left_handle": "helper_result",
+        "right_handle": "step_result",
+        "right_path": [
+          "state"
+        ],
+        "same_identity": true
+      }
+    ],
+    "caller_owned_observations": [
+      {
+        "handle": "step_result",
+        "path": [
+          "state",
+          "policies",
+          "docker"
+        ],
+        "value": "prohibit"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/conformance/mutation-isolation/007_helper_accessor_step_state_identity.json
+++ b/tests/fixtures/conformance/mutation-isolation/007_helper_accessor_step_state_identity.json
@@ -10,8 +10,7 @@
     "fn": "get_step_state",
     "input": "use docker",
     "result_handle": "helper_result",
-    "source_handle": "step_result",
-    "source_fn": "controller.step"
+    "source_handle": "step_result"
   },
   "handles": {
     "step_result": {

--- a/tests/fixtures/conformance/mutation-isolation/README.md
+++ b/tests/fixtures/conformance/mutation-isolation/README.md
@@ -1,0 +1,94 @@
+# Mutation-Isolation Fixtures
+
+These fixtures define a portable conformance corpus for mutation isolation and
+caller-owned result semantics on the API surface shared by Python and
+TypeScript.
+
+## Contract
+
+The contract captured here is **authority isolation**, not immutability.
+
+Returned objects may remain mutable as long as:
+
+* mutating them cannot mutate authoritative engine state
+* caller-owned envelopes remain caller-owned
+* helper accessors preserve or avoid identity only where the public contract
+  says they should
+
+## Fixture shape
+
+Each fixture is a JSON object with:
+
+* `id`: stable fixture identifier
+* `kind`: always `"mutation_isolation"`
+* `initial_state`: authoritative engine state before any operation
+* `operation`: the public API action that produces or accepts a structured
+  object
+* `handles`: named caller-owned objects or nested members exposed by the
+  operation
+* `mutations`: declarative mutations applied to caller-owned handles
+* `expected`: authoritative-state and ownership observations after mutation
+
+### `operation`
+
+`operation` identifies the shared API boundary under test and any inputs needed
+to reach it.
+
+Examples:
+
+* `create_engine`
+* `engine.state`
+* `engine.step`
+* `controller.step`
+* `controller.preview`
+* helper accessors such as `get_decision_state`, `get_step_state`, and
+  `get_preview_state_after`
+
+### `handles`
+
+`handles` names the caller-owned object graph exposed by the operation.
+
+Examples:
+
+* constructor argument object
+* returned state snapshot
+* returned `Decision`
+* returned controller result envelope
+* helper return value
+
+### `mutations`
+
+Each mutation describes:
+
+* `target_handle`: which caller-owned object to mutate
+* `path`: key path within that object
+* `op`: currently `"set"`
+* `value`: replacement value
+
+The mutation language stays language-neutral and avoids embedding Python or
+TypeScript syntax into the fixtures.
+
+### `expected`
+
+`expected` captures only observable behavior:
+
+* `authoritative_state`: engine state expected after caller-side mutation
+* `preview_live_state_unchanged`: whether preview must still leave live engine
+  state unchanged
+* `identity_assertions`: optional identity expectations between handles and
+  nested envelope members
+* `caller_owned_observations`: optional value observations within caller-owned
+  envelopes after mutation
+
+## Scope boundary
+
+These fixtures cover only the shared API surface for Python 0.9 and the
+unsynchronized TypeScript port.
+
+They intentionally do **not** include:
+
+* checkpoint APIs
+* pending-continuation APIs
+* obsolete TypeScript-only authority surfaces
+* implementation-mechanism requirements such as `deepcopy`, frozen objects, or
+  `readonly`

--- a/tests/fixtures/conformance/mutation-isolation/README.md
+++ b/tests/fixtures/conformance/mutation-isolation/README.md
@@ -41,8 +41,7 @@ Examples:
 * `engine.step`
 * `controller.step`
 * `controller.preview`
-* helper accessors such as `get_decision_state`, `get_step_state`, and
-  `get_preview_state_after`
+* helper accessors such as `get_decision_state` and `get_step_state`
 
 For the current corpus, `operation` uses a closed per-function field set.
 Unknown operation fields are invalid.

--- a/tests/fixtures/conformance/mutation-isolation/README.md
+++ b/tests/fixtures/conformance/mutation-isolation/README.md
@@ -44,6 +44,9 @@ Examples:
 * helper accessors such as `get_decision_state`, `get_step_state`, and
   `get_preview_state_after`
 
+For the current corpus, `operation` uses a closed per-function field set.
+Unknown operation fields are invalid.
+
 ### `handles`
 
 `handles` names the caller-owned object graph exposed by the operation.
@@ -56,6 +59,9 @@ Examples:
 * returned controller result envelope
 * helper return value
 
+`handle.kind` is a closed descriptive metadata set used for fixture validation.
+It documents expected ownership roles but does not currently change execution.
+
 ### `mutations`
 
 Each mutation describes:
@@ -67,6 +73,9 @@ Each mutation describes:
 
 The mutation language stays language-neutral and avoids embedding Python or
 TypeScript syntax into the fixtures.
+
+The current Python runner supports string-key dict paths only. List traversal is
+outside the scope of this fixture family for now.
 
 ### `expected`
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -27,6 +27,14 @@ _MUTATION_ISOLATION_HANDLE_KINDS = {
     "caller_owned_result_envelope",
     "caller_owned_nested_member",
 }
+_DIRECT_HANDLE_KINDS = {
+    "caller_owned_input",
+    "defensive_snapshot",
+    "independently_constructed_result",
+    "caller_owned_result_envelope",
+    "caller_owned_nested_member",
+}
+_DERIVED_HANDLE_KINDS = {"nested_state_member", "defensive_snapshot"}
 
 
 def _json_files(dir_path: Path) -> list[Path]:
@@ -35,6 +43,12 @@ def _json_files(dir_path: Path) -> list[Path]:
 
 def _load(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _assert_allowed_keys(
+    obj: dict[str, object], allowed_keys: set[str], fixture_id: object, label: str
+) -> None:
+    assert set(obj) == allowed_keys, f"{fixture_id}: invalid keys for {label}"
 
 
 def _get_path_value(obj: object, path: list[object]) -> object:
@@ -233,14 +247,22 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
         assert isinstance(handle_name, str), fixture_id
         assert isinstance(handle_spec, dict), fixture_id
         assert handle_spec["kind"] in _MUTATION_ISOLATION_HANDLE_KINDS, fixture_id
-        if "from_handle" in handle_spec:
+        if "from_handle" in handle_spec or "path" in handle_spec:
+            _assert_allowed_keys(
+                handle_spec, {"kind", "from_handle", "path"}, fixture_id, f"handle {handle_name}"
+            )
+            assert handle_spec["kind"] in _DERIVED_HANDLE_KINDS, fixture_id
             assert isinstance(handle_spec["from_handle"], str), fixture_id
             assert handle_spec["from_handle"] in handles, fixture_id
-        if "path" in handle_spec:
             assert isinstance(handle_spec["path"], list), fixture_id
+            assert handle_spec["path"], fixture_id
             assert all(isinstance(part, str) for part in handle_spec["path"]), fixture_id
-        if "value" in handle_spec:
-            assert "from_handle" not in handle_spec, fixture_id
+        else:
+            allowed_keys = (
+                {"kind", "value"} if handle_spec["kind"] == "caller_owned_input" else {"kind"}
+            )
+            _assert_allowed_keys(handle_spec, allowed_keys, fixture_id, f"handle {handle_name}")
+            assert handle_spec["kind"] in _DIRECT_HANDLE_KINDS, fixture_id
 
     if fn == "create_engine":
         assert set(operation) == {"fn", "constructor_state_handle"}, fixture_id
@@ -263,6 +285,12 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
         result_handle = operation["result_handle"]
         assert isinstance(result_handle, str), fixture_id
         assert result_handle in handles, fixture_id
+        expected_result_kind = (
+            "independently_constructed_result"
+            if fn == "engine.step"
+            else "caller_owned_result_envelope"
+        )
+        assert handles[result_handle]["kind"] == expected_result_kind, fixture_id
     else:
         assert fn in {"get_decision_state", "get_step_state"}, fixture_id
         assert set(operation) == {"fn", "input", "result_handle", "source_handle"}, fixture_id
@@ -273,6 +301,28 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
         assert isinstance(source_handle, str), fixture_id
         assert result_handle in handles, fixture_id
         assert source_handle in handles, fixture_id
+        assert handles[result_handle]["kind"] == "caller_owned_nested_member", fixture_id
+        expected_source_kind = (
+            "independently_constructed_result"
+            if fn == "get_decision_state"
+            else "caller_owned_result_envelope"
+        )
+        assert handles[source_handle]["kind"] == expected_source_kind, fixture_id
+
+    for _handle_name, handle_spec in handles.items():
+        from_handle = handle_spec.get("from_handle")
+        if from_handle is None:
+            continue
+        assert isinstance(from_handle, str), fixture_id
+        source_kind = handles[from_handle]["kind"]
+        derived_kind = handle_spec["kind"]
+        if derived_kind == "nested_state_member":
+            assert source_kind == "independently_constructed_result", fixture_id
+            assert handle_spec["path"] == ["state"], fixture_id
+        else:
+            assert derived_kind == "defensive_snapshot", fixture_id
+            assert source_kind == "caller_owned_result_envelope", fixture_id
+            assert handle_spec["path"] in (["state_before"], ["state_after"]), fixture_id
 
     mutations = fixture["mutations"]
     assert isinstance(mutations, list), fixture_id
@@ -287,6 +337,19 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
 
     expected = fixture["expected"]
     assert isinstance(expected, dict), fixture_id
+    _assert_allowed_keys(
+        expected,
+        {
+            "authoritative_state",
+            "preview_live_state_unchanged",
+            "identity_assertions",
+            "caller_owned_observations",
+        }
+        & set(expected.keys())
+        | {"authoritative_state"},
+        fixture_id,
+        "expected",
+    )
     assert isinstance(expected["authoritative_state"], dict), fixture_id
 
     for assertion in expected.get("identity_assertions", []):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -224,6 +224,12 @@ def test_grammar_fixtures() -> None:
 
 
 def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id: object) -> None:
+    _assert_allowed_keys(
+        fixture,
+        {"id", "kind", "initial_state", "operation", "handles", "mutations", "expected"},
+        fixture_id,
+        "fixture",
+    )
     assert fixture["kind"] == "mutation_isolation", fixture_id
     assert isinstance(fixture["initial_state"], dict), fixture_id
 
@@ -339,20 +345,26 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
     assert isinstance(expected, dict), fixture_id
     _assert_allowed_keys(
         expected,
-        {
-            "authoritative_state",
-            "preview_live_state_unchanged",
-            "identity_assertions",
-            "caller_owned_observations",
-        }
-        & set(expected.keys())
-        | {"authoritative_state"},
+        {"authoritative_state"}
+        | (
+            {
+                "preview_live_state_unchanged",
+                "identity_assertions",
+                "caller_owned_observations",
+            }
+            & set(expected.keys())
+        ),
         fixture_id,
         "expected",
     )
     assert isinstance(expected["authoritative_state"], dict), fixture_id
+    if "preview_live_state_unchanged" in expected:
+        assert fn == "controller.preview", fixture_id
+        assert expected["preview_live_state_unchanged"] is True, fixture_id
 
-    for assertion in expected.get("identity_assertions", []):
+    identity_assertions = expected.get("identity_assertions", [])
+    assert isinstance(identity_assertions, list), fixture_id
+    for assertion in identity_assertions:
         assert isinstance(assertion, dict), fixture_id
         assert set(assertion) == {"left_handle", "right_handle", "right_path", "same_identity"}, (
             fixture_id
@@ -364,13 +376,141 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
         assert all(isinstance(part, str) for part in assertion["right_path"]), fixture_id
         assert isinstance(assertion["same_identity"], bool), fixture_id
 
-    for observation in expected.get("caller_owned_observations", []):
+    caller_owned_observations = expected.get("caller_owned_observations", [])
+    assert isinstance(caller_owned_observations, list), fixture_id
+    for observation in caller_owned_observations:
         assert isinstance(observation, dict), fixture_id
         assert set(observation) == {"handle", "path", "value"}, fixture_id
         assert observation["handle"] in handles, fixture_id
         assert isinstance(observation["path"], list), fixture_id
         assert observation["path"], fixture_id
         assert all(isinstance(part, str) for part in observation["path"]), fixture_id
+
+
+def test_mutation_isolation_validator_rejects_unknown_top_level_field() -> None:
+    fixture = {
+        "id": "invalid_unknown_top_level",
+        "kind": "mutation_isolation",
+        "initial_state": {"premise": None, "policies": {}, "version": 2},
+        "operation": {"fn": "engine.state", "result_handle": "state_snapshot"},
+        "handles": {"state_snapshot": {"kind": "defensive_snapshot"}},
+        "mutations": [
+            {
+                "target_handle": "state_snapshot",
+                "path": ["premise"],
+                "op": "set",
+                "value": "mutated",
+            }
+        ],
+        "expected": {"authoritative_state": {"premise": None, "policies": {}, "version": 2}},
+        "unexpected": True,
+    }
+
+    with pytest.raises(AssertionError):
+        _validate_mutation_isolation_fixture(fixture, fixture["id"])
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("identity_assertions", {}),
+        ("caller_owned_observations", {}),
+    ],
+)
+def test_mutation_isolation_validator_rejects_non_list_optional_expected_collections(
+    field: str, value: object
+) -> None:
+    fixture = {
+        "id": f"invalid_{field}",
+        "kind": "mutation_isolation",
+        "initial_state": {"premise": None, "policies": {}, "version": 2},
+        "operation": {"fn": "engine.state", "result_handle": "state_snapshot"},
+        "handles": {"state_snapshot": {"kind": "defensive_snapshot"}},
+        "mutations": [
+            {
+                "target_handle": "state_snapshot",
+                "path": ["premise"],
+                "op": "set",
+                "value": "mutated",
+            }
+        ],
+        "expected": {
+            "authoritative_state": {"premise": None, "policies": {}, "version": 2},
+            field: value,
+        },
+    }
+
+    with pytest.raises(AssertionError):
+        _validate_mutation_isolation_fixture(fixture, fixture["id"])
+
+
+@pytest.mark.parametrize("value", [False, "true", 1, None])
+def test_mutation_isolation_validator_rejects_invalid_preview_live_state_unchanged_values(
+    value: object,
+) -> None:
+    fixture = {
+        "id": "invalid_preview_live_state_unchanged_value",
+        "kind": "mutation_isolation",
+        "initial_state": {"premise": None, "policies": {}, "version": 2},
+        "operation": {
+            "fn": "controller.preview",
+            "input": "use docker",
+            "result_handle": "preview_result",
+        },
+        "handles": {
+            "preview_result": {"kind": "caller_owned_result_envelope"},
+            "state_before": {
+                "kind": "defensive_snapshot",
+                "from_handle": "preview_result",
+                "path": ["state_before"],
+            },
+            "state_after": {
+                "kind": "defensive_snapshot",
+                "from_handle": "preview_result",
+                "path": ["state_after"],
+            },
+        },
+        "mutations": [
+            {
+                "target_handle": "state_before",
+                "path": ["premise"],
+                "op": "set",
+                "value": "mutated",
+            }
+        ],
+        "expected": {
+            "authoritative_state": {"premise": None, "policies": {}, "version": 2},
+            "preview_live_state_unchanged": value,
+        },
+    }
+
+    with pytest.raises(AssertionError):
+        _validate_mutation_isolation_fixture(fixture, fixture["id"])
+
+
+def test_mutation_isolation_validator_rejects_preview_flag_on_non_preview_operation() -> None:
+    fixture = {
+        "id": "invalid_preview_live_state_unchanged_non_preview",
+        "kind": "mutation_isolation",
+        "initial_state": {"premise": None, "policies": {}, "version": 2},
+        "operation": {"fn": "engine.state", "result_handle": "state_snapshot"},
+        "handles": {"state_snapshot": {"kind": "defensive_snapshot"}},
+        "mutations": [
+            {
+                "target_handle": "state_snapshot",
+                "path": ["premise"],
+                "op": "set",
+                "value": "mutated",
+            }
+        ],
+        "expected": {
+            "authoritative_state": {"premise": None, "policies": {}, "version": 2},
+            "preview_live_state_unchanged": True,
+        },
+    }
+
+    with pytest.raises(AssertionError):
+        _validate_mutation_isolation_fixture(fixture, fixture["id"])
 
 
 def _execute_mutation_isolation_operation(

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -19,6 +19,14 @@ _GRAMMAR_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "conforma
 _MUTATION_ISOLATION_FIXTURES_DIR = (
     Path(__file__).resolve().parent / "fixtures" / "conformance" / "mutation-isolation"
 )
+_MUTATION_ISOLATION_HANDLE_KINDS = {
+    "caller_owned_input",
+    "defensive_snapshot",
+    "independently_constructed_result",
+    "nested_state_member",
+    "caller_owned_result_envelope",
+    "caller_owned_nested_member",
+}
 
 
 def _json_files(dir_path: Path) -> list[Path]:
@@ -207,7 +215,8 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
 
     operation = fixture["operation"]
     assert isinstance(operation, dict), fixture_id
-    assert operation["fn"] in {
+    fn = operation["fn"]
+    assert fn in {
         "create_engine",
         "engine.state",
         "engine.step",
@@ -216,27 +225,64 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
         "get_decision_state",
         "get_step_state",
     }, fixture_id
+    assert all(isinstance(key, str) for key in operation), fixture_id
 
     handles = fixture["handles"]
     assert isinstance(handles, dict), fixture_id
     for handle_name, handle_spec in handles.items():
         assert isinstance(handle_name, str), fixture_id
         assert isinstance(handle_spec, dict), fixture_id
-        assert isinstance(handle_spec["kind"], str), fixture_id
+        assert handle_spec["kind"] in _MUTATION_ISOLATION_HANDLE_KINDS, fixture_id
         if "from_handle" in handle_spec:
             assert isinstance(handle_spec["from_handle"], str), fixture_id
             assert handle_spec["from_handle"] in handles, fixture_id
         if "path" in handle_spec:
             assert isinstance(handle_spec["path"], list), fixture_id
             assert all(isinstance(part, str) for part in handle_spec["path"]), fixture_id
+        if "value" in handle_spec:
+            assert "from_handle" not in handle_spec, fixture_id
+
+    if fn == "create_engine":
+        assert set(operation) == {"fn", "constructor_state_handle"}, fixture_id
+        constructor_state_handle = operation["constructor_state_handle"]
+        assert isinstance(constructor_state_handle, str), fixture_id
+        assert constructor_state_handle in handles, fixture_id
+        constructor_state_spec = handles[constructor_state_handle]
+        assert constructor_state_spec["kind"] == "caller_owned_input", fixture_id
+        assert set(constructor_state_spec) == {"kind", "value"}, fixture_id
+        assert constructor_state_spec["value"] == fixture["initial_state"], fixture_id
+    elif fn == "engine.state":
+        assert set(operation) == {"fn", "result_handle"}, fixture_id
+        result_handle = operation["result_handle"]
+        assert isinstance(result_handle, str), fixture_id
+        assert result_handle in handles, fixture_id
+        assert handles[result_handle]["kind"] == "defensive_snapshot", fixture_id
+    elif fn in {"engine.step", "controller.step", "controller.preview"}:
+        assert set(operation) == {"fn", "input", "result_handle"}, fixture_id
+        assert isinstance(operation["input"], str), fixture_id
+        result_handle = operation["result_handle"]
+        assert isinstance(result_handle, str), fixture_id
+        assert result_handle in handles, fixture_id
+    else:
+        assert fn in {"get_decision_state", "get_step_state"}, fixture_id
+        assert set(operation) == {"fn", "input", "result_handle", "source_handle"}, fixture_id
+        assert isinstance(operation["input"], str), fixture_id
+        result_handle = operation["result_handle"]
+        source_handle = operation["source_handle"]
+        assert isinstance(result_handle, str), fixture_id
+        assert isinstance(source_handle, str), fixture_id
+        assert result_handle in handles, fixture_id
+        assert source_handle in handles, fixture_id
 
     mutations = fixture["mutations"]
     assert isinstance(mutations, list), fixture_id
     for mutation in mutations:
         assert isinstance(mutation, dict), fixture_id
+        assert set(mutation) == {"target_handle", "path", "op", "value"}, fixture_id
         assert mutation["target_handle"] in handles, fixture_id
         assert mutation["op"] == "set", fixture_id
         assert isinstance(mutation["path"], list), fixture_id
+        assert mutation["path"], fixture_id
         assert all(isinstance(part, str) for part in mutation["path"]), fixture_id
 
     expected = fixture["expected"]
@@ -245,16 +291,22 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
 
     for assertion in expected.get("identity_assertions", []):
         assert isinstance(assertion, dict), fixture_id
+        assert set(assertion) == {"left_handle", "right_handle", "right_path", "same_identity"}, (
+            fixture_id
+        )
         assert assertion["left_handle"] in handles, fixture_id
         assert assertion["right_handle"] in handles, fixture_id
         assert isinstance(assertion["right_path"], list), fixture_id
+        assert assertion["right_path"], fixture_id
         assert all(isinstance(part, str) for part in assertion["right_path"]), fixture_id
         assert isinstance(assertion["same_identity"], bool), fixture_id
 
     for observation in expected.get("caller_owned_observations", []):
         assert isinstance(observation, dict), fixture_id
+        assert set(observation) == {"handle", "path", "value"}, fixture_id
         assert observation["handle"] in handles, fixture_id
         assert isinstance(observation["path"], list), fixture_id
+        assert observation["path"], fixture_id
         assert all(isinstance(part, str) for part in observation["path"]), fixture_id
 
 
@@ -269,7 +321,7 @@ def _execute_mutation_isolation_operation(
     if fn == "create_engine":
         constructor_handle = operation["constructor_state_handle"]
         assert isinstance(constructor_handle, str)
-        constructor_state = deepcopy(fixture["handles"][constructor_handle]["value"])
+        constructor_state = deepcopy(initial_state)
         handles[constructor_handle] = constructor_state
         engine = create_engine(state=constructor_state)
         return engine, handles, {}

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,10 +1,11 @@
 import json
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
 
-from context_compiler import create_engine
-from context_compiler.controller import preview, state_diff, step
+from context_compiler import create_engine, get_decision_state
+from context_compiler.controller import get_step_state, preview, state_diff, step
 from context_compiler.grammar import DirectiveKind, render_directive, validate_directive
 
 _STEP_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "conformance" / "step"
@@ -15,6 +16,9 @@ _CONTROLLER_FIXTURES_DIR = (
     Path(__file__).resolve().parent / "fixtures" / "conformance" / "controller"
 )
 _GRAMMAR_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "conformance" / "grammar"
+_MUTATION_ISOLATION_FIXTURES_DIR = (
+    Path(__file__).resolve().parent / "fixtures" / "conformance" / "mutation-isolation"
+)
 
 
 def _json_files(dir_path: Path) -> list[Path]:
@@ -23,6 +27,28 @@ def _json_files(dir_path: Path) -> list[Path]:
 
 def _load(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _get_path_value(obj: object, path: list[object]) -> object:
+    current = obj
+    for key in path:
+        assert isinstance(current, dict)
+        assert isinstance(key, str)
+        current = current[key]
+    return current
+
+
+def _set_path_value(obj: object, path: list[object], value: object) -> None:
+    assert path
+    current = obj
+    for key in path[:-1]:
+        assert isinstance(current, dict)
+        assert isinstance(key, str)
+        current = current[key]
+    assert isinstance(current, dict)
+    final_key = path[-1]
+    assert isinstance(final_key, str)
+    current[final_key] = value
 
 
 def _assert_optional_pending_flag(expected_obj: object, engine: object, fixture_id: object) -> None:
@@ -173,3 +199,176 @@ def test_grammar_fixtures() -> None:
         validated = validate_directive(rendered)
         assert validated is not None, fixture_id
         assert validated.kind.value == expected["validated_kind"], fixture_id
+
+
+def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id: object) -> None:
+    assert fixture["kind"] == "mutation_isolation", fixture_id
+    assert isinstance(fixture["initial_state"], dict), fixture_id
+
+    operation = fixture["operation"]
+    assert isinstance(operation, dict), fixture_id
+    assert operation["fn"] in {
+        "create_engine",
+        "engine.state",
+        "engine.step",
+        "controller.step",
+        "controller.preview",
+        "get_decision_state",
+        "get_step_state",
+    }, fixture_id
+
+    handles = fixture["handles"]
+    assert isinstance(handles, dict), fixture_id
+    for handle_name, handle_spec in handles.items():
+        assert isinstance(handle_name, str), fixture_id
+        assert isinstance(handle_spec, dict), fixture_id
+        assert isinstance(handle_spec["kind"], str), fixture_id
+        if "from_handle" in handle_spec:
+            assert isinstance(handle_spec["from_handle"], str), fixture_id
+            assert handle_spec["from_handle"] in handles, fixture_id
+        if "path" in handle_spec:
+            assert isinstance(handle_spec["path"], list), fixture_id
+            assert all(isinstance(part, str) for part in handle_spec["path"]), fixture_id
+
+    mutations = fixture["mutations"]
+    assert isinstance(mutations, list), fixture_id
+    for mutation in mutations:
+        assert isinstance(mutation, dict), fixture_id
+        assert mutation["target_handle"] in handles, fixture_id
+        assert mutation["op"] == "set", fixture_id
+        assert isinstance(mutation["path"], list), fixture_id
+        assert all(isinstance(part, str) for part in mutation["path"]), fixture_id
+
+    expected = fixture["expected"]
+    assert isinstance(expected, dict), fixture_id
+    assert isinstance(expected["authoritative_state"], dict), fixture_id
+
+    for assertion in expected.get("identity_assertions", []):
+        assert isinstance(assertion, dict), fixture_id
+        assert assertion["left_handle"] in handles, fixture_id
+        assert assertion["right_handle"] in handles, fixture_id
+        assert isinstance(assertion["right_path"], list), fixture_id
+        assert all(isinstance(part, str) for part in assertion["right_path"]), fixture_id
+        assert isinstance(assertion["same_identity"], bool), fixture_id
+
+    for observation in expected.get("caller_owned_observations", []):
+        assert isinstance(observation, dict), fixture_id
+        assert observation["handle"] in handles, fixture_id
+        assert isinstance(observation["path"], list), fixture_id
+        assert all(isinstance(part, str) for part in observation["path"]), fixture_id
+
+
+def _execute_mutation_isolation_operation(
+    fixture: dict[str, object],
+) -> tuple[object, dict[str, object], dict[str, object]]:
+    operation = fixture["operation"]
+    initial_state = fixture["initial_state"]
+    handles: dict[str, object] = {}
+    fn = operation["fn"]
+
+    if fn == "create_engine":
+        constructor_handle = operation["constructor_state_handle"]
+        assert isinstance(constructor_handle, str)
+        constructor_state = deepcopy(fixture["handles"][constructor_handle]["value"])
+        handles[constructor_handle] = constructor_state
+        engine = create_engine(state=constructor_state)
+        return engine, handles, {}
+
+    engine = create_engine(state=initial_state)
+    produced: dict[str, object] = {}
+
+    if fn == "engine.state":
+        result_handle = operation["result_handle"]
+        assert isinstance(result_handle, str)
+        handles[result_handle] = engine.state
+        return engine, handles, produced
+
+    if fn == "engine.step":
+        decision = engine.step(operation["input"])
+        result_handle = operation["result_handle"]
+        assert isinstance(result_handle, str)
+        handles[result_handle] = decision
+        produced[result_handle] = decision
+    elif fn == "controller.step":
+        step_result = step(engine, operation["input"])
+        result_handle = operation["result_handle"]
+        assert isinstance(result_handle, str)
+        handles[result_handle] = step_result
+        produced[result_handle] = step_result
+    elif fn == "controller.preview":
+        step_result = preview(engine, operation["input"])
+        result_handle = operation["result_handle"]
+        assert isinstance(result_handle, str)
+        handles[result_handle] = step_result
+        produced[result_handle] = step_result
+    elif fn == "get_decision_state":
+        decision = engine.step(operation["input"])
+        source_handle = operation["source_handle"]
+        result_handle = operation["result_handle"]
+        assert isinstance(source_handle, str)
+        assert isinstance(result_handle, str)
+        handles[source_handle] = decision
+        produced[source_handle] = decision
+        handles[result_handle] = get_decision_state(decision)
+    else:
+        assert fn == "get_step_state"
+        step_result = step(engine, operation["input"])
+        source_handle = operation["source_handle"]
+        result_handle = operation["result_handle"]
+        assert isinstance(source_handle, str)
+        assert isinstance(result_handle, str)
+        handles[source_handle] = step_result
+        produced[source_handle] = step_result
+        handles[result_handle] = get_step_state(step_result)
+
+    for handle_name, handle_spec in fixture["handles"].items():
+        if handle_name in handles:
+            continue
+        from_handle = handle_spec.get("from_handle")
+        if from_handle is None:
+            continue
+        assert isinstance(from_handle, str)
+        handles[handle_name] = _get_path_value(handles[from_handle], handle_spec["path"])
+
+    return engine, handles, produced
+
+
+def test_mutation_isolation_fixtures() -> None:
+    for path in _json_files(_MUTATION_ISOLATION_FIXTURES_DIR):
+        fixture = _load(path)
+        fixture_id = fixture["id"]
+        _validate_mutation_isolation_fixture(fixture, fixture_id)
+
+        engine, handles, _ = _execute_mutation_isolation_operation(fixture)
+        expected = fixture["expected"]
+
+        live_state_before_mutation = engine.state
+
+        for mutation in fixture["mutations"]:
+            target_handle = mutation["target_handle"]
+            assert isinstance(target_handle, str), fixture_id
+            _set_path_value(handles[target_handle], mutation["path"], mutation["value"])
+
+        assert engine.state == expected["authoritative_state"], fixture_id
+
+        if expected.get("preview_live_state_unchanged") is True:
+            assert engine.state == live_state_before_mutation, fixture_id
+
+        for assertion in expected.get("identity_assertions", []):
+            left_handle = assertion["left_handle"]
+            right_handle = assertion["right_handle"]
+            assert isinstance(left_handle, str), fixture_id
+            assert isinstance(right_handle, str), fixture_id
+            left_value = handles[left_handle]
+            right_value = _get_path_value(handles[right_handle], assertion["right_path"])
+            if assertion["same_identity"]:
+                assert left_value is right_value, fixture_id
+            else:
+                assert left_value is not right_value, fixture_id
+
+        for observation in expected.get("caller_owned_observations", []):
+            handle = observation["handle"]
+            assert isinstance(handle, str), fixture_id
+            assert _get_path_value(handles[handle], observation["path"]) == observation["value"], (
+                fixture_id
+            )


### PR DESCRIPTION
## What changed

- added a new portable `tests/fixtures/conformance/mutation-isolation/` fixture family for public API mutation-isolation and caller-ownership semantics
- extended the existing Python conformance runner in `tests/test_fixtures.py` to execute the new fixture family
- tightened the mutation-isolation fixture schema so fixture roots, operations, handles, mutations, and expectations reject unsupported fields
- added focused validator tests for malformed mutation-isolation fixtures, including invalid optional expectation collection types and invalid `preview_live_state_unchanged` usage
- strengthened fixture coverage for top-level and nested aliasing checks, including preview `state_before` and `state_after`

## Why

- issue #201 is about ensuring no public API return value or caller-supplied input provides a mutation path into authoritative engine state
- this change defines and executes a portable conformance corpus for that contract in the Python source-of-truth implementation
- the stricter schema checks make malformed fixtures fail fast instead of being silently accepted or partially ignored
- the negative validator tests lock in the intended mutation-isolation schema rules before TypeScript support is added later

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
