### PR TITLE
refactor: remove pending clarification helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,11 @@ reference.
 Common API entry points:
 
 - engine lifecycle: `create_engine(...)`, `engine.step(...)`, `engine.state`,
-  `engine.has_pending_clarification()`
+  `engine.export_json(...)`, `engine.import_json(...)`
 - decision helpers: `is_clarify(...)`, `is_update(...)`, `is_passthrough(...)`,
   `get_clarify_prompt(...)`, `get_decision_state(...)`
 - state helpers: `get_premise_value(...)`, `get_policy_items(...)`
-- state transport: `export_json(...)`, `import_json(...)`
+- state transport: `engine.export_json(...)`, `engine.import_json(...)`
 - controller APIs: `preview(...)`, `step(...)`, `state_diff(...)`
 
 ### Controller API (Reusable Outside REPL)

--- a/demos/08_llm_replacement_precondition.py
+++ b/demos/08_llm_replacement_precondition.py
@@ -82,12 +82,11 @@ def main() -> None:
 
     state_applied = not _is_initial_authoritative_state(engine.state)
     compact_state_applied = not _is_initial_authoritative_state(compacted_state)
-    no_pending = not engine.has_pending_clarification()
     compact_no_pending = compacted_prompt is None
 
     baseline_has_authoritative_precondition = False
     reinjected_has_authoritative_precondition = False
-    compiler_pass = decision["kind"] == DECISION_UPDATE and state_applied and no_pending
+    compiler_pass = decision["kind"] == DECISION_UPDATE and state_applied
     compact_pass = compacted_prompt is None and compact_state_applied and compact_no_pending
 
     print_host_check(

--- a/demos/09_llm_pending_clarification.py
+++ b/demos/09_llm_pending_clarification.py
@@ -44,17 +44,14 @@ def main() -> None:
 
     first = engine.step(TURN_1)
     print_decision("turn 1", first, engine.state)
-    pending_after_first = engine.has_pending_clarification()
     state_applied_after_first = _has_podman_use(engine.state)
 
     second = engine.step(TURN_2)
     print_decision("turn 2", second, engine.state)
-    pending_after_second = engine.has_pending_clarification()
     state_preserved_after_second = _has_podman_use(engine.state)
 
     third = engine.step(TURN_3)
     print_decision("turn 3", third, engine.state)
-    pending_after_third = engine.has_pending_clarification()
 
     baseline_messages = build_baseline_messages(
         [
@@ -99,15 +96,10 @@ def main() -> None:
         print_model_output("Compiler-mediated + compact", compact_output)
 
     deterministic_initial_update = first["kind"] == DECISION_UPDATE and state_applied_after_first
-    no_pending_after_invalid_replacement = not pending_after_first
     unrelated_followup_passthrough = (
-        second["kind"] == DECISION_PASSTHROUGH
-        and not pending_after_second
-        and state_preserved_after_second
+        second["kind"] == DECISION_PASSTHROUGH and state_preserved_after_second
     )
-    confirmation_token_not_consumed = (
-        third["kind"] == DECISION_PASSTHROUGH and not pending_after_third
-    )
+    confirmation_token_not_consumed = third["kind"] == DECISION_PASSTHROUGH
     deterministic_final_state = _has_podman_use(engine.state)
 
     baseline_has_pending_state_machine = False
@@ -115,7 +107,6 @@ def main() -> None:
 
     compiler_pass = (
         deterministic_initial_update
-        and no_pending_after_invalid_replacement
         and unrelated_followup_passthrough
         and confirmation_token_not_consumed
         and deterministic_final_state
@@ -130,11 +121,6 @@ def main() -> None:
     print_host_check(
         "DETERMINISTIC_INITIAL_UPDATE",
         yes_no(deterministic_initial_update),
-        context="compiler-mediated",
-    )
-    print_host_check(
-        "NO_PENDING_AFTER_INVALID_REPLACEMENT",
-        yes_no(no_pending_after_invalid_replacement),
         context="compiler-mediated",
     )
     print_host_check(

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -103,33 +103,6 @@ The internal structure is intentionally opaque for normal host use. Prefer
 `get_premise_value(state)` and `get_policy_items(state, ...)` over direct key
 traversal unless you are working at an explicit serialization boundary.
 
-### `engine.has_pending_clarification()`
-
-Return whether a confirmation-required semantic continuation is currently
-pending.
-
-Contract boundary:
-
-- pending continuation is runtime state, not grammar
-- pending continuation must never arise from malformed or non-canonical input
-- pending continuation, when supported, comes only from semantic evaluation of
-  an already parsed canonical directive
-- the historical missing-source replacement case does not, by itself, create
-  pending continuation
-
-Current implementation note:
-
-- the updated specification allows supported pending continuation semantics
-- the current runtime implementation may still return `False` for all inputs
-  until the continuation behavior is restored
-
-Typical use:
-
-```python
-if engine.has_pending_clarification():
-    show_pending_ui()
-```
-
 ## Decision API
 
 Each user message produces a `Decision`.

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -99,10 +99,6 @@ class Engine:
     def state(self) -> State:
         return deepcopy(self._state)
 
-    def has_pending_clarification(self) -> bool:
-        """Return whether a confirmation-required clarification is pending."""
-        return False
-
     def export_json(self) -> str:
         return json.dumps(self._state, sort_keys=True, separators=(",", ":"))
 

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -255,10 +255,6 @@ def _apply_preload_from_options(engine: Engine, options: dict[str, str | bool]) 
         engine.import_json(_read_utf8_file(path))
 
 
-def _has_pending_clarification(engine: Engine) -> bool:
-    return engine.has_pending_clarification()
-
-
 def _normalize_confirmation_token(value: str) -> str:
     normalized = value.strip().lower()
     while normalized and normalized[-1] in ".,!?":
@@ -317,15 +313,6 @@ def run_repl(
                     )
                     continue
                 if payload != "" and (user_input == "step" or user_input.startswith("step ")):
-                    if _has_pending_clarification(active_engine) and not _is_confirmation_input(
-                        payload
-                    ):
-                        _print_command_error(
-                            out_stream,
-                            leading_blank=True,
-                            message=_STEP_PENDING_CONFIRMATION_ERROR,
-                        )
-                        continue
                     result: StepResult = controller_step(active_engine, payload)
                     _print_decision_lines(get_step_decision(result), out_stream, leading_blank=True)
                     continue
@@ -406,25 +393,6 @@ def run_repl(
                     )
                 continue
             if payload != "" and (user_input == "step" or user_input.startswith("step ")):
-                if _has_pending_clarification(active_engine) and not _is_confirmation_input(
-                    payload
-                ):
-                    if json_mode:
-                        _write_json_line(
-                            out_stream,
-                            _json_error_payload(
-                                command="step",
-                                code="pending_confirmation_required",
-                                message=_STEP_PENDING_CONFIRMATION_ERROR,
-                            ),
-                        )
-                    else:
-                        _print_command_error(
-                            out_stream,
-                            leading_blank=False,
-                            message=_STEP_PENDING_CONFIRMATION_ERROR,
-                        )
-                    continue
                 result = controller_step(active_engine, payload)
                 if json_mode:
                     _write_json_line(out_stream, _json_step_payload(result, command="step"))

--- a/tests/fixtures/conformance/api/public-api-v1.json
+++ b/tests/fixtures/conformance/api/public-api-v1.json
@@ -630,12 +630,6 @@
             "params": []
           }
         },
-        "has_pending_clarification": {
-          "kind": "method",
-          "signature": {
-            "params": []
-          }
-        },
         "import_json": {
           "kind": "method",
           "signature": {

--- a/tests/fixtures/conformance/controller/001_step_update_envelope_and_state_snapshot.json
+++ b/tests/fixtures/conformance/controller/001_step_update_envelope_and_state_snapshot.json
@@ -33,7 +33,6 @@
       "premise": "concise replies",
       "policies": {},
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/controller/002_preview_mutating_update_reports_would_mutate_and_no_live_mutation.json
+++ b/tests/fixtures/conformance/controller/002_preview_mutating_update_reports_would_mutate_and_no_live_mutation.json
@@ -52,7 +52,6 @@
       "premise": null,
       "policies": {},
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/controller/003_preview_idempotent_update_reports_non_mutating.json
+++ b/tests/fixtures/conformance/controller/003_preview_idempotent_update_reports_non_mutating.json
@@ -63,7 +63,6 @@
         "docker": "use"
       },
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/controller/004_preview_clarify_reports_non_mutating_and_restores_pending.json
+++ b/tests/fixtures/conformance/controller/004_preview_clarify_reports_non_mutating_and_restores_pending.json
@@ -58,7 +58,6 @@
       "premise": null,
       "policies": {},
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/controller/005_preview_pending_yes_reports_mutation_but_preserves_live_pending.json
+++ b/tests/fixtures/conformance/controller/005_preview_pending_yes_reports_mutation_but_preserves_live_pending.json
@@ -57,7 +57,6 @@
         "kubectl": "use"
       },
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/controller/006_preview_replace_prohibited_old_matches_execution_without_pending.json
+++ b/tests/fixtures/conformance/controller/006_preview_replace_prohibited_old_matches_execution_without_pending.json
@@ -61,7 +61,6 @@
         "pytest": "use"
       },
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/step/008_replace_missing_source_clarify_prompt.json
+++ b/tests/fixtures/conformance/step/008_replace_missing_source_clarify_prompt.json
@@ -19,7 +19,6 @@
         "version": 2
       }
     },
-    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/009_pending_affirmative_normalized_token.json
+++ b/tests/fixtures/conformance/step/009_pending_affirmative_normalized_token.json
@@ -16,7 +16,6 @@
       "prompt_to_user": null,
       "state": null
     },
-    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/010_pending_negative_normalized_token.json
+++ b/tests/fixtures/conformance/step/010_pending_negative_normalized_token.json
@@ -16,7 +16,6 @@
       "prompt_to_user": null,
       "state": null
     },
-    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/011_pending_unmatched_reuses_prompt.json
+++ b/tests/fixtures/conformance/step/011_pending_unmatched_reuses_prompt.json
@@ -16,7 +16,6 @@
       "prompt_to_user": null,
       "state": null
     },
-    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/018_pending_affirmative_punctuation_token.json
+++ b/tests/fixtures/conformance/step/018_pending_affirmative_punctuation_token.json
@@ -16,7 +16,6 @@
       "prompt_to_user": null,
       "state": null
     },
-    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/019_pending_negative_punctuation_token.json
+++ b/tests/fixtures/conformance/step/019_pending_negative_punctuation_token.json
@@ -16,7 +16,6 @@
       "prompt_to_user": null,
       "state": null
     },
-    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/020_compound_use_and_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/020_compound_use_and_prohibit_invalid_boundary.json
@@ -17,7 +17,6 @@
       "premise": null,
       "policies": {},
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/step/021_compound_set_premise_and_use_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/021_compound_set_premise_and_use_invalid_boundary.json
@@ -17,7 +17,6 @@
       "premise": null,
       "policies": {},
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/step/022_compound_clear_state_then_set_premise_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/022_compound_clear_state_then_set_premise_invalid_boundary.json
@@ -21,7 +21,6 @@
         "docker": "use"
       },
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/step/023_compound_remove_policy_and_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/023_compound_remove_policy_and_prohibit_invalid_boundary.json
@@ -21,7 +21,6 @@
         "docker": "use"
       },
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/step/024_compound_use_or_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/024_compound_use_or_prohibit_invalid_boundary.json
@@ -17,7 +17,6 @@
       "premise": null,
       "policies": {},
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/step/025_compound_use_xor_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/025_compound_use_xor_prohibit_invalid_boundary.json
@@ -17,7 +17,6 @@
       "premise": null,
       "policies": {},
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/step/026_compound_use_punctuation_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/026_compound_use_punctuation_prohibit_invalid_boundary.json
@@ -17,7 +17,6 @@
       "premise": null,
       "policies": {},
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/step/026_replace_prohibited_old_clarify_no_pending.json
+++ b/tests/fixtures/conformance/step/026_replace_prohibited_old_clarify_no_pending.json
@@ -17,7 +17,6 @@
       "prompt_to_user": "\"docker\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item.",
       "state": null
     },
-    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/027_quoted_leading_directive_text_passthrough.json
+++ b/tests/fixtures/conformance/step/027_quoted_leading_directive_text_passthrough.json
@@ -17,7 +17,6 @@
       "premise": null,
       "policies": {},
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/fixtures/conformance/step/027_replace_prohibited_new_clarify_no_pending.json
+++ b/tests/fixtures/conformance/step/027_replace_prohibited_new_clarify_no_pending.json
@@ -17,7 +17,6 @@
       "prompt_to_user": "\"kubectl\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item.",
       "state": null
     },
-    "has_pending_clarification": false,
     "state": {
       "premise": null,
       "policies": {

--- a/tests/fixtures/conformance/step/028_quoted_payload_compound_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/028_quoted_payload_compound_invalid_boundary.json
@@ -17,7 +17,6 @@
       "premise": null,
       "policies": {},
       "version": 2
-    },
-    "has_pending_clarification": false
+    }
   }
 }

--- a/tests/test_compound_directive_properties.py
+++ b/tests/test_compound_directive_properties.py
@@ -40,7 +40,6 @@ def _assert_compound_passthrough(user_input: str) -> None:
 
     assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
     assert engine.state == before
-    assert engine.has_pending_clarification() is False
 
 
 @settings(max_examples=50)
@@ -86,7 +85,6 @@ def test_embedded_canonical_tokens_do_not_trigger_compound_detection(
     assert decision["prompt_to_user"] is not None or decision["kind"] != "clarify"
     assert decision["kind"] == "update"
     assert engine.state != before
-    assert engine.has_pending_clarification() is False
 
 
 @settings(max_examples=50)
@@ -107,7 +105,6 @@ def test_leading_non_directive_text_disables_compound_detection(prefix: str, sec
 
     assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
     assert engine.state == before
-    assert engine.has_pending_clarification() is False
 
 
 def _mutate_case(text: str) -> st.SearchStrategy[str]:
@@ -129,7 +126,6 @@ def test_case_mutated_second_directive_does_not_trigger_compound_detection(
 
     assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
     assert engine.state == before
-    assert engine.has_pending_clarification() is False
 
 
 @settings(max_examples=50)
@@ -162,4 +158,3 @@ def test_fully_quoted_input_remains_passthrough(quote: str, second: str) -> None
 
     assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
     assert engine.state == before
-    assert engine.has_pending_clarification() is False

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -49,7 +49,6 @@ def test_preview_update_does_not_mutate_engine_state() -> None:
     assert result["would_mutate"] is True
     assert result["would_mutate"] is result["diff"]["changed"]
     assert engine.state == before
-    assert engine.has_pending_clarification() is False
 
 
 def test_preview_missing_source_replacement_reports_update_without_live_mutation() -> None:
@@ -69,7 +68,6 @@ def test_preview_missing_source_replacement_reports_update_without_live_mutation
     }
     assert result["diff"]["changed"] is True
     assert result["would_mutate"] is True
-    assert engine.has_pending_clarification() is False
 
     yes = engine.step("yes")
     assert yes["kind"] == "passthrough"
@@ -92,7 +90,6 @@ def test_preview_prohibited_replacement_clarify_matches_execution_without_pendin
     }
     assert result["state_before"] == result["state_after"] == engine.state
     assert result["would_mutate"] is False
-    assert engine.has_pending_clarification() is False
 
 
 def test_preview_idempotent_update_is_not_a_mutation() -> None:
@@ -256,7 +253,6 @@ def test_preview_followup_tokens_after_invalid_replacement_are_passthrough(
         "state": {"premise": None, "policies": {"kubectl": "use"}, "version": 2},
         "prompt_to_user": None,
     }
-    assert engine.has_pending_clarification() is False
 
     preview_result = preview(engine, confirmation)
     assert preview_result["decision"] == {
@@ -271,10 +267,8 @@ def test_preview_followup_tokens_after_invalid_replacement_are_passthrough(
     }
     assert preview_result["would_mutate"] is False
 
-    assert engine.has_pending_clarification() is False
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
     final = step(engine, confirmation)
     assert final["decision"] == {"kind": "passthrough", "state": None, "prompt_to_user": None}
     assert final["state"] == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
-    assert engine.has_pending_clarification() is False

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -127,7 +127,6 @@ def test_grammar_owned_compound_detection_helpers_remain_unchanged() -> None:
 def test_initial_state_and_helpers() -> None:
     engine = create_engine()
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
-    assert engine.has_pending_clarification() is False
     assert get_premise_value(engine.state) is None
     assert get_policy_items(engine.state) == []
 
@@ -287,31 +286,9 @@ def test_import_json_accepts_valid_policy_key_and_normalizes_it() -> None:
     assert engine.state == {"premise": None, "policies": {"docker": "use"}, "version": 2}
 
 
-def test_has_pending_clarification_remains_false_after_invalid_replacement_followup() -> None:
-    engine = create_engine()
-    decision = engine.step("use kubectl instead of docker")
-    assert decision["kind"] == "update"
-    assert engine.has_pending_clarification() is False
-
-    no_decision = engine.step("no")
-    assert no_decision["kind"] == "passthrough"
-    assert engine.has_pending_clarification() is False
-
-
 def test_normalize_confirmation_collapses_unicode_spacing_and_trailing_punctuation() -> None:
     assert _normalize_confirmation("  YES!!  ") == "yes"
     assert _normalize_confirmation("No\t\tthanks...\n") == "no thanks"
-
-
-def test_has_pending_clarification_stays_false_after_import_json() -> None:
-    engine = create_engine()
-    clarify = engine.step("use kubectl instead of docker")
-    assert clarify["kind"] == "update"
-    assert engine.has_pending_clarification() is False
-
-    engine.import_json('{"policies":{},"premise":null,"version":2}')
-
-    assert engine.has_pending_clarification() is False
 
 
 def test_replace_use_clarifies_when_old_policy_is_not_use_in_invalid_internal_state() -> None:
@@ -759,7 +736,6 @@ def test_replace_use_missing_source_applies_as_use_update_without_pending() -> N
         "prompt_to_user": None,
     }
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
-    assert engine.has_pending_clarification() is False
 
 
 def test_replace_use_missing_source_yes_confirmation_is_passthrough() -> None:
@@ -858,8 +834,6 @@ def test_replace_use_ky_prohibit_returns_non_pending_clarify() -> None:
     }
     assert engine.state["policies"] == {"docker": "prohibit", "pytest": "use"}
 
-    assert engine.has_pending_clarification() is False
-
 
 def test_replace_use_ky_prohibit_yes_does_not_authorize_mutation() -> None:
     engine = create_engine()
@@ -890,8 +864,6 @@ def test_replace_use_kx_prohibit_returns_non_pending_clarify() -> None:
         "prompt_to_user": expected,
     }
     assert engine.state["policies"] == {"docker": "use", "kubectl": "prohibit"}
-
-    assert engine.has_pending_clarification() is False
 
 
 def test_replace_use_priority_prefers_source_prohibit_clarify_when_both_prohibit() -> None:
@@ -1155,7 +1127,6 @@ def test_compound_directives_remain_passthrough_without_mutation(
 
     assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
     assert engine.state == before
-    assert engine.has_pending_clarification() is False
 
 
 def test_quoted_non_directive_leading_input_remains_passthrough() -> None:
@@ -1165,7 +1136,6 @@ def test_quoted_non_directive_leading_input_remains_passthrough() -> None:
 
     assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
-    assert engine.has_pending_clarification() is False
 
 
 @pytest.mark.parametrize(
@@ -1216,7 +1186,6 @@ def test_directive_like_substrings_inside_larger_words_do_not_trigger_compound_r
     )
     assert decision["kind"] == expected_decision_kind
     assert engine.state == expected_state
-    assert engine.has_pending_clarification() is False
 
 
 @pytest.mark.parametrize(
@@ -1278,7 +1247,6 @@ def test_valid_single_directives_still_work(
 
     assert decision == {"kind": "update", "state": expected_state, "prompt_to_user": None}
     assert engine.state == expected_state
-    assert engine.has_pending_clarification() is False
 
 
 @pytest.mark.parametrize(
@@ -1317,13 +1285,11 @@ def test_compound_passthrough_after_prior_missing_source_replacement_update() ->
         "state": {"premise": None, "policies": {"kubectl": "use"}, "version": 2},
         "prompt_to_user": None,
     }
-    assert engine.has_pending_clarification() is False
 
     decision = engine.step("use docker and prohibit peanuts")
 
     assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
-    assert engine.has_pending_clarification() is False
 
 
 def test_constructor_with_state_initializes_from_valid_state() -> None:

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -73,17 +73,6 @@ def _set_path_value(obj: object, path: list[object], value: object) -> None:
     current[final_key] = value
 
 
-def _assert_optional_pending_flag(expected_obj: object, engine: object, fixture_id: object) -> None:
-    if not isinstance(expected_obj, dict):
-        return
-    if "has_pending_clarification" not in expected_obj:
-        return
-
-    expected_pending = expected_obj["has_pending_clarification"]
-    assert isinstance(expected_pending, bool), fixture_id
-    assert engine.has_pending_clarification() is expected_pending, fixture_id
-
-
 def test_step_fixtures() -> None:
     for path in _json_files(_STEP_FIXTURES_DIR):
         fixture = _load(path)
@@ -117,7 +106,6 @@ def test_step_fixtures() -> None:
             assert decision["state"] == engine.state, fixture_id
 
         assert engine.state == expected["state"], fixture_id
-        _assert_optional_pending_flag(expected, engine, fixture_id)
 
 
 def _apply_prelude(engine: object, prelude: object) -> None:
@@ -174,19 +162,15 @@ def test_controller_fixtures() -> None:
             result = step(engine, action["input"])
             assert result == expected["result"], fixture_id
             assert engine.state == expected["state"], fixture_id
-            _assert_optional_pending_flag(expected, engine, fixture_id)
             continue
 
         if fn == "preview":
             before = engine.state
-            pending_before = engine.has_pending_clarification()
             result = preview(engine, action["input"])
 
             assert result == expected["result"], fixture_id
             assert engine.state == before, fixture_id
             assert engine.state == expected["state_after_preview"], fixture_id
-            assert engine.has_pending_clarification() is pending_before, fixture_id
-            _assert_optional_pending_flag(expected, engine, fixture_id)
             continue
 
         assert fn == "state_diff", fixture_id

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -457,12 +457,10 @@ def test_deterministic_replacement_matches_equivalent_explicit_transition(
     assert expected_decision == {"kind": "update", "state": expected_state, "prompt_to_user": None}
     assert decision == expected_decision
     assert engine.state == expected_state
-    assert engine.has_pending_clarification() is False
 
     if not old_present:
         followup = engine.step("yes")
         assert followup == {"kind": "passthrough", "state": None, "prompt_to_user": None}
-        assert engine.has_pending_clarification() is False
         assert engine.state == expected_state
 
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -234,63 +234,6 @@ def test_interactive_step_without_payload_prints_command_error() -> None:
     assert _contains_subsequence(lines, ["error: step requires input.", "Use 'step <input>'."])
 
 
-def test_interactive_step_command_with_non_confirmation_payload_prints_pending_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    engine = create_engine()
-    monkeypatch.setattr(engine, "has_pending_clarification", lambda: True)
-
-    out = _TTYStringIO()
-    run_repl(_TTYStringIO("step set premise concise\nquit\n"), out, engine=engine)
-    lines = [line for line in out.getvalue().splitlines() if line.strip()]
-
-    assert _contains_subsequence(
-        lines,
-        [
-            "error: step command only accepts confirmation while clarification is pending.",
-            "Use yes/no (or variants), or use preview/state.",
-        ],
-    )
-
-
-def test_non_interactive_step_command_with_non_confirmation_payload_emits_json_pending_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    engine = create_engine()
-    monkeypatch.setattr(engine, "has_pending_clarification", lambda: True)
-
-    out = StringIO()
-    run_repl(StringIO("step set premise concise\n"), out, json_mode=True, engine=engine)
-
-    assert json.loads(out.getvalue()) == {
-        "mode": "error",
-        "output_version": 1,
-        "command": "step",
-        "error": {
-            "code": "pending_confirmation_required",
-            "message": (
-                "step command only accepts confirmation while clarification is pending.\n"
-                "Use yes/no (or variants), or use preview/state."
-            ),
-        },
-    }
-
-
-def test_non_interactive_step_command_with_non_confirmation_payload_prints_text_pending_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    engine = create_engine()
-    monkeypatch.setattr(engine, "has_pending_clarification", lambda: True)
-
-    out = StringIO()
-    run_repl(StringIO("step set premise concise\n"), out, engine=engine)
-
-    assert out.getvalue() == (
-        "error: step command only accepts confirmation while clarification is pending.\n"
-        "Use yes/no (or variants), or use preview/state.\n"
-    )
-
-
 def test_main_unknown_flag_prints_error_hint_and_exits_nonzero(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## What changed
- removed `Engine.has_pending_clarification()` from the Python public API
- removed the API-contract entry, fixture fields, and fixture-runner support tied to that helper
- removed REPL plumbing and tests that modeled pending clarification as engine-owned runtime state
- renamed Demo 09 to `09_llm_confirmation_passthrough.py` and updated references and wording to describe confirmation-style followups as ordinary passthrough

## Why this change was needed
The helper no longer reflected the actual architecture. Core does not own a pending clarification state for this flow, so the old API and demo naming implied behavior that the engine does not provide. This cleanup aligns the public surface, conformance artifacts, demos, and docs with the real 0.9 boundary while preserving demonstrated behavior.

## Impact
Python callers no longer have a `has_pending_clarification()` method on `Engine`, and the renamed demo now describes the confirmation-passthrough boundary more accurately. The change was validated with `uv run pytest` and `uv run pre-commit run --all-files`, and the demo rename was additionally checked with the targeted demo test modules.