### PR TITLE
refactor: remove redundant state helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ reference.
 Common API entry points:
 
 - engine lifecycle: `create_engine(...)`, `engine.step(...)`, `engine.state`,
-  `engine.export_json(...)`, `engine.import_json(...)`
+  `engine.premise`, `engine.policies`, `engine.export_json(...)`,
+  `engine.import_json(...)`
 - decision helpers: `is_clarify(...)`, `is_update(...)`, `is_passthrough(...)`,
   `get_clarify_prompt(...)`, `get_decision_state(...)`
 - state helpers: `get_premise_value(...)`, `get_policy_items(...)`
@@ -312,6 +313,10 @@ Identical input sequences always produce identical state.
 The internal structure of the state is intentionally opaque to host applications.
 For normal reads, prefer `get_premise_value(state)` and
 `get_policy_items(state, ...)` over direct key traversal.
+
+For focused reads on a live engine, `engine.premise` and `engine.policies`
+expose the same authoritative state at a narrower boundary. `engine.policies`
+returns a caller-owned copy.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,6 @@ Common API entry points:
   `engine.import_json(...)`
 - decision helpers: `is_clarify(...)`, `is_update(...)`, `is_passthrough(...)`,
   `get_clarify_prompt(...)`, `get_decision_state(...)`
-- state helpers: `get_premise_value(...)`, `get_policy_items(...)`
 - state transport: `engine.export_json(...)`, `engine.import_json(...)`
 - controller APIs: `preview(...)`, `step(...)`, `state_diff(...)`
 
@@ -310,13 +309,11 @@ authoritative in future turns.
 
 Identical input sequences always produce identical state.
 
-The internal structure of the state is intentionally opaque to host applications.
-For normal reads, prefer `get_premise_value(state)` and
-`get_policy_items(state, ...)` over direct key traversal.
+For live engine-owned reads, use `engine.premise` and `engine.policies`.
+`engine.policies` returns a caller-owned copy.
 
-For focused reads on a live engine, `engine.premise` and `engine.policies`
-expose the same authoritative state at a narrower boundary. `engine.policies`
-returns a caller-owned copy.
+`engine.state` remains the public snapshot/serialization boundary when host code
+needs the full authoritative state object.
 
 ---
 

--- a/demos/05_llm_prompt_drift_vs_state.py
+++ b/demos/05_llm_prompt_drift_vs_state.py
@@ -4,7 +4,7 @@ import argparse
 import re
 
 import demos.llm_client as llm_client
-from context_compiler import create_engine, get_premise_value
+from context_compiler import create_engine
 from demos.common import (
     build_baseline_messages,
     build_mediated_messages_from_transcript,
@@ -257,7 +257,7 @@ def _run_demo(turns: int = _DEFAULT_TURNS) -> None:
         compact_output = f"[no call] clarification required: {compacted_prompt}"
         print_model_output("Compiler-mediated + compact", compact_output)
     else:
-        premise_value = get_premise_value(compacted_state)
+        premise_value = compacted_state["premise"]
         if (
             premise_value is not None
             and _ORIGINAL_DIRECTIVE not in compacted_turns

--- a/demos/06_llm_context_compaction.py
+++ b/demos/06_llm_context_compaction.py
@@ -1,6 +1,6 @@
 """Demo 6: host-side prompt replacement from authoritative step-derived state."""
 
-from context_compiler import create_engine, get_premise_value
+from context_compiler import create_engine
 from demos.common import compact_user_turns, is_verbose, print_info_report
 
 DEMO_NAME = "06_context_compaction — superseded directives eliminated"
@@ -44,7 +44,7 @@ def _compile_premise(turns: list[str]) -> str:
     for turn in turns:
         decision = engine.step(turn)
         assert decision["kind"] == "update"
-    compiled_premise = get_premise_value(engine.state)
+    compiled_premise = engine.premise
     assert compiled_premise is not None
     return compiled_premise
 
@@ -149,7 +149,7 @@ def main() -> None:
     compiled_context = f"- premise: {compiled_premise}"
     compacted_turns, compacted_state, compacted_prompt = compact_user_turns(transcript_turns)
     assert compacted_prompt is None
-    assert get_premise_value(compacted_state) == FINAL_PREMISE
+    assert compacted_state["premise"] == FINAL_PREMISE
     compacted_context = "\n".join(f"User: {turn}" for turn in compacted_turns)
     baseline_prompt = _build_baseline_prompt(transcript_turns)
     compiled_prompt = _build_compiled_prompt(compiled_premise)

--- a/demos/09_llm_confirmation_passthrough.py
+++ b/demos/09_llm_confirmation_passthrough.py
@@ -3,10 +3,8 @@
 from context_compiler import (
     DECISION_PASSTHROUGH,
     DECISION_UPDATE,
-    POLICY_USE,
     State,
     create_engine,
-    get_policy_items,
 )
 from demos.common import (
     build_baseline_messages,
@@ -33,7 +31,7 @@ INITIAL_AUTHORITATIVE_STATE = create_engine().state
 
 
 def _has_podman_use(state: State) -> bool:
-    return "podman" in get_policy_items(state, POLICY_USE)
+    return state["policies"].get("podman") == "use"
 
 
 def _is_initial_authoritative_state(state: State) -> bool:

--- a/demos/common.py
+++ b/demos/common.py
@@ -10,8 +10,6 @@ from context_compiler import (
     Decision,
     State,
     create_engine,
-    get_policy_items,
-    get_premise_value,
 )
 from demos.llm_client import Message
 
@@ -48,12 +46,14 @@ LAST_INFO_REPORT: InfoReport | None = None
 
 
 def _policy_values_text(state: State, value: Literal["use", "prohibit"]) -> str:
-    items = get_policy_items(state, value)
+    items = sorted(
+        item for item, policy_value in state["policies"].items() if policy_value == value
+    )
     return ", ".join(items) if items else "(none)"
 
 
 def _print_state_summary(state: State) -> None:
-    premise_value = get_premise_value(state)
+    premise_value = state["premise"]
     premise_text = premise_value if premise_value is not None else "(none)"
     print("compiled state:")
     print(f"- premise: {premise_text}")
@@ -297,9 +297,13 @@ def consume_last_info_report() -> InfoReport | None:
 
 
 def build_compiled_system_prompt(state: State) -> str:
-    premise_value = get_premise_value(state)
-    use_items = get_policy_items(state, "use")
-    prohibit = get_policy_items(state, "prohibit")
+    premise_value = state["premise"]
+    use_items = sorted(
+        item for item, policy_value in state["policies"].items() if policy_value == "use"
+    )
+    prohibit = sorted(
+        item for item, policy_value in state["policies"].items() if policy_value == "prohibit"
+    )
     prohibit_text = ", ".join(prohibit) if prohibit else "(none)"
     use_text = ", ".join(use_items) if use_items else "(none)"
     premise_text = premise_value if premise_value is not None else "(unset)"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -103,6 +103,17 @@ The internal structure is intentionally opaque for normal host use. Prefer
 `get_premise_value(state)` and `get_policy_items(state, ...)` over direct key
 traversal unless you are working at an explicit serialization boundary.
 
+### `engine.premise`
+
+Read the current authoritative premise value from a live engine.
+
+### `engine.policies`
+
+Read the current authoritative policy mapping from a live engine.
+
+This property returns a caller-owned copy so callers cannot mutate live engine
+state through the returned mapping.
+
 ## Decision API
 
 Each user message produces a `Decision`.
@@ -145,7 +156,9 @@ elif is_update(decision):
 
 ## State Access
 
-Use the exported helpers for normal reads from a `State` snapshot.
+Use the exported helpers for normal reads from a `State` snapshot. Use
+`engine.premise` and `engine.policies` when you specifically want the current
+live engine values without reading the whole state snapshot.
 
 ### Premise helpers
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -280,7 +280,6 @@ Public result and data object names exported at package root include:
 
 - `Decision`
 - `State`
-- `Checkpoint`
 - `StepResult`
 - `PreviewResult`
 - `StructuralDiff`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -99,9 +99,8 @@ Boundary notes:
 
 Read the current authoritative in-memory state snapshot.
 
-The internal structure is intentionally opaque for normal host use. Prefer
-`get_premise_value(state)` and `get_policy_items(state, ...)` over direct key
-traversal unless you are working at an explicit serialization boundary.
+Use this when you need the full authoritative state snapshot, such as
+serialization, persistence, or snapshot-based host logic.
 
 ### `engine.premise`
 
@@ -156,26 +155,15 @@ elif is_update(decision):
 
 ## State Access
 
-Use the exported helpers for normal reads from a `State` snapshot. Use
-`engine.premise` and `engine.policies` when you specifically want the current
-live engine values without reading the whole state snapshot.
-
-### Premise helpers
-
-- `get_premise_value(state)` returns the current premise value or `None`
-
-### Policy helpers
-
-- `get_policy_items(state)` returns all policy items
-- `get_policy_items(state, "use")` returns `use` items
-- `get_policy_items(state, "prohibit")` returns `prohibit` items
+Use `engine.premise` and `engine.policies` for live engine-owned reads.
+Use `engine.state` when you need the full authoritative snapshot.
 
 Typical use:
 
 ```python
-from context_compiler import POLICY_PROHIBIT, get_policy_items
-
-blocked_tools = get_policy_items(state, POLICY_PROHIBIT)
+blocked_tools = sorted(
+    item for item, value in engine.policies.items() if value == "prohibit"
+)
 ```
 
 See the README’s [State Model](../README.md#state-model) section for conceptual

--- a/examples/01_persistent_guardrails.py
+++ b/examples/01_persistent_guardrails.py
@@ -2,11 +2,11 @@
 
 from _util import print_decision_summary, print_state_summary
 
-from context_compiler import POLICY_PROHIBIT, State, create_engine, get_policy_items
+from context_compiler import Engine, create_engine
 
 
-def build_prompt(state: State, user_input: str) -> str:
-    prohibit = get_policy_items(state, POLICY_PROHIBIT)
+def build_prompt(engine: Engine, user_input: str) -> str:
+    prohibit = sorted(item for item, value in engine.policies.items() if value == "prohibit")
     prohibit_text = ", ".join(prohibit) if prohibit else "(none)"
     return (
         "System: Follow authoritative conversation state.\n"
@@ -32,7 +32,7 @@ def main() -> None:
     print()
 
     print("Host prompt construction with persisted policy:")
-    prompt = build_prompt(engine.state, "how should I make this curry?")
+    prompt = build_prompt(engine, "how should I make this curry?")
     print(prompt)
 
 

--- a/examples/04_tool_governance_denylist.py
+++ b/examples/04_tool_governance_denylist.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from _util import print_decision_summary, print_state_summary
 
-from context_compiler import POLICY_PROHIBIT, create_engine, get_policy_items
+from context_compiler import create_engine
 
 
 @dataclass
@@ -32,7 +32,7 @@ def main() -> None:
     print()
 
     print("Host-side tool denylist behavior:")
-    prohibit = get_policy_items(state, POLICY_PROHIBIT)
+    prohibit = sorted(item for item, value in engine.policies.items() if value == "prohibit")
     tools = [Tool("docker"), Tool("kubectl")]
     for tool in tools:
         if tool.name in prohibit:

--- a/examples/_util.py
+++ b/examples/_util.py
@@ -6,8 +6,6 @@ from context_compiler import (
     POLICY_USE,
     get_clarify_prompt,
     get_decision_state,
-    get_policy_items,
-    get_premise_value,
     is_clarify,
     is_update,
 )
@@ -22,12 +20,14 @@ def print_json(obj: Any) -> None:
 
 
 def _format_policy_values(state: Any, value: Literal["use", "prohibit"]) -> str:
-    items = get_policy_items(state, value)
+    items = sorted(
+        item for item, policy_value in state["policies"].items() if policy_value == value
+    )
     return ", ".join(items) if items else "(none)"
 
 
 def print_state_summary(state: Any, label: str = "state") -> None:
-    premise = get_premise_value(state)
+    premise = state["premise"]
     premise_text = premise if premise is not None else "(none)"
 
     print(f"{label}:")

--- a/src/context_compiler/__init__.py
+++ b/src/context_compiler/__init__.py
@@ -33,8 +33,6 @@ from .engine import (
     Engine,
     State,
     create_engine,
-    get_policy_items,
-    get_premise_value,
 )
 from .grammar import DirectiveKind, is_canonical_directive, render_directive, validate_directive
 
@@ -59,8 +57,6 @@ __all__ = [
     "get_decision_state",
     "get_preview_decision",
     "get_preview_state_after",
-    "get_premise_value",
-    "get_policy_items",
     "get_step_decision",
     "get_step_state",
     "is_canonical_directive",

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import StrEnum
@@ -80,16 +81,6 @@ def create_engine(state: State | None = None) -> "Engine":
     return Engine(state=state)
 
 
-def get_premise_value(state: State) -> str | None:
-    return state[STATE_PREMISE]
-
-
-def get_policy_items(state: State, value: PolicyValue | None = None) -> list[str]:
-    if value is None:
-        return sorted(state[STATE_POLICIES].keys())
-    return sorted(k for k, v in state[STATE_POLICIES].items() if v == value)
-
-
 class Engine:
     def __init__(self, state: State | None = None) -> None:
         self._state: State
@@ -100,7 +91,7 @@ class Engine:
         return self._state[STATE_PREMISE]
 
     @property
-    def policies(self) -> dict[str, PolicyValue]:
+    def policies(self) -> Mapping[str, PolicyValue]:
         return deepcopy(self._state[STATE_POLICIES])
 
     @property

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -96,6 +96,14 @@ class Engine:
         self._replace_state(_initial_state() if state is None else _load_state_obj(state))
 
     @property
+    def premise(self) -> str | None:
+        return self._state[STATE_PREMISE]
+
+    @property
+    def policies(self) -> dict[str, PolicyValue]:
+        return deepcopy(self._state[STATE_POLICIES])
+
+    @property
     def state(self) -> State:
         return deepcopy(self._state)
 

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -2,7 +2,7 @@ import json
 import sys
 from typing import TextIO
 
-from . import __version__, create_engine, get_policy_items, get_premise_value
+from . import __version__, create_engine
 from .const import DECISION_CLARIFY, DECISION_PASSTHROUGH
 from .controller import (
     OUTPUT_VERSION,
@@ -80,18 +80,14 @@ def _print_interactive_help(out_stream: TextIO) -> None:
 
 
 def _render_state_lines(state: State) -> list[str]:
-    premise = get_premise_value(state)
+    premise = state["premise"]
     premise_line = "premise: (none)" if premise is None else f"premise: {premise}"
 
-    all_policy_items = get_policy_items(state)
-    if not all_policy_items:
+    policies = state["policies"]
+    if not policies:
         return [premise_line, "policies: (none)"]
 
-    use_items = set(get_policy_items(state, "use"))
-    policy_items: list[tuple[str, str]] = []
-    for item in all_policy_items:
-        value = "use" if item in use_items else "prohibit"
-        policy_items.append((item, value))
+    policy_items = sorted(policies.items())
 
     lines = [premise_line, "policies:"]
     for item, value in policy_items:

--- a/tests/fixtures/conformance/api/public-api-v1.json
+++ b/tests/fixtures/conformance/api/public-api-v1.json
@@ -32,8 +32,6 @@
       "get_decision_state",
       "get_preview_decision",
       "get_preview_state_after",
-      "get_premise_value",
-      "get_policy_items",
       "get_step_decision",
       "get_step_state",
       "is_canonical_directive",
@@ -233,35 +231,6 @@
               "name": "preview_result",
               "kind": "POSITIONAL_OR_KEYWORD",
               "has_default": false
-            }
-          ]
-        }
-      },
-      "get_premise_value": {
-        "kind": "callable",
-        "signature": {
-          "params": [
-            {
-              "name": "state",
-              "kind": "POSITIONAL_OR_KEYWORD",
-              "has_default": false
-            }
-          ]
-        }
-      },
-      "get_policy_items": {
-        "kind": "callable",
-        "signature": {
-          "params": [
-            {
-              "name": "state",
-              "kind": "POSITIONAL_OR_KEYWORD",
-              "has_default": false
-            },
-            {
-              "name": "value",
-              "kind": "POSITIONAL_OR_KEYWORD",
-              "has_default": true
             }
           ]
         }

--- a/tests/fixtures/conformance/api/public-api-v1.json
+++ b/tests/fixtures/conformance/api/public-api-v1.json
@@ -624,29 +624,35 @@
     "public_members": {
       "mode": "exact",
       "members": {
-        "export_json": {
-          "kind": "method",
-          "signature": {
-            "params": []
-          }
-        },
-        "import_json": {
-          "kind": "method",
-          "signature": {
+      "export_json": {
+        "kind": "method",
+        "signature": {
+          "params": []
+        }
+      },
+      "import_json": {
+        "kind": "method",
+        "signature": {
             "params": [
               {
                 "name": "payload",
                 "kind": "POSITIONAL_OR_KEYWORD",
                 "has_default": false
-              }
-            ]
-          }
-        },
-        "state": {
-          "kind": "property"
-        },
-        "step": {
-          "kind": "method",
+            }
+          ]
+        }
+      },
+      "policies": {
+        "kind": "property"
+      },
+      "premise": {
+        "kind": "property"
+      },
+      "state": {
+        "kind": "property"
+      },
+      "step": {
+        "kind": "method",
           "signature": {
             "params": [
               {

--- a/tests/fixtures/conformance/mutation-isolation/008_engine_policies_property_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/008_engine_policies_property_isolation.json
@@ -1,0 +1,39 @@
+{
+  "id": "mutation_isolation_engine_policies_property",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": "baseline",
+    "policies": {
+      "docker": "use"
+    },
+    "version": 2
+  },
+  "operation": {
+    "fn": "engine.policies",
+    "result_handle": "policies_snapshot"
+  },
+  "handles": {
+    "policies_snapshot": {
+      "kind": "defensive_snapshot"
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "policies_snapshot",
+      "path": [
+        "docker"
+      ],
+      "op": "set",
+      "value": "prohibit"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": "baseline",
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/mutation-isolation/009_engine_premise_property_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/009_engine_premise_property_isolation.json
@@ -1,0 +1,39 @@
+{
+  "id": "mutation_isolation_engine_premise_property",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": "baseline",
+    "policies": {
+      "docker": "use"
+    },
+    "version": 2
+  },
+  "operation": {
+    "fn": "engine.premise",
+    "result_handle": "premise_snapshot"
+  },
+  "handles": {
+    "premise_snapshot": {
+      "kind": "defensive_snapshot"
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "premise_snapshot",
+      "path": [
+        "value"
+      ],
+      "op": "set",
+      "value": "mutated premise"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": "baseline",
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,8 +1,9 @@
 import json
+from collections.abc import Mapping
 
 import pytest
 
-from context_compiler import create_engine, get_policy_items, get_premise_value
+from context_compiler import create_engine
 from context_compiler.engine import (
     Action,
     DecisionKind,
@@ -124,21 +125,17 @@ def test_grammar_owned_compound_detection_helpers_remain_unchanged() -> None:
     assert match_canonical_directive_start("clear premise!", 0) == len("clear premise")
 
 
-def test_initial_state_and_helpers() -> None:
+def test_initial_state_and_engine_properties() -> None:
     engine = create_engine()
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
-    assert get_premise_value(engine.state) is None
-    assert get_policy_items(engine.state) == []
+    assert engine.premise is None
+    assert engine.policies == {}
 
 
-def test_get_policy_items_filters_by_policy_value_sorted() -> None:
+def test_policies_property_returns_mapping_snapshot() -> None:
     engine = create_engine()
-    engine.step("use zeta")
-    engine.step("prohibit docker")
-    engine.step("use alpha")
-
-    assert get_policy_items(engine.state, "use") == ["alpha", "zeta"]
-    assert get_policy_items(engine.state, "prohibit") == ["docker"]
+    assert isinstance(engine.policies, Mapping)
+    assert engine.policies == {}
 
 
 def test_state_getter_returns_defensive_copy() -> None:
@@ -164,6 +161,7 @@ def test_policies_property_returns_defensive_copy() -> None:
     engine.step("use docker")
 
     policies = engine.policies
+    assert isinstance(policies, Mapping)
     policies["docker"] = "prohibit"
 
     assert engine.policies == {"docker": "use"}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -150,6 +150,26 @@ def test_state_getter_returns_defensive_copy() -> None:
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
+def test_premise_property_exposes_authoritative_premise_value() -> None:
+    engine = create_engine()
+    assert engine.premise is None
+
+    engine.step("set premise concise replies")
+
+    assert engine.premise == "concise replies"
+
+
+def test_policies_property_returns_defensive_copy() -> None:
+    engine = create_engine()
+    engine.step("use docker")
+
+    policies = engine.policies
+    policies["docker"] = "prohibit"
+
+    assert engine.policies == {"docker": "use"}
+    assert engine.state["policies"] == {"docker": "use"}
+
+
 def test_export_json_returns_complete_representation_of_state() -> None:
     engine = create_engine()
     payload = engine.export_json()

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -222,6 +222,8 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
     fn = operation["fn"]
     assert fn in {
         "create_engine",
+        "engine.policies",
+        "engine.premise",
         "engine.state",
         "engine.step",
         "controller.step",
@@ -263,7 +265,7 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
         assert constructor_state_spec["kind"] == "caller_owned_input", fixture_id
         assert set(constructor_state_spec) == {"kind", "value"}, fixture_id
         assert constructor_state_spec["value"] == fixture["initial_state"], fixture_id
-    elif fn == "engine.state":
+    elif fn == "engine.state" or fn in {"engine.policies", "engine.premise"}:
         assert set(operation) == {"fn", "result_handle"}, fixture_id
         result_handle = operation["result_handle"]
         assert isinstance(result_handle, str), fixture_id
@@ -520,6 +522,18 @@ def _execute_mutation_isolation_operation(
         result_handle = operation["result_handle"]
         assert isinstance(result_handle, str)
         handles[result_handle] = engine.state
+        return engine, handles, produced
+
+    if fn == "engine.policies":
+        result_handle = operation["result_handle"]
+        assert isinstance(result_handle, str)
+        handles[result_handle] = engine.policies
+        return engine, handles, produced
+
+    if fn == "engine.premise":
+        result_handle = operation["result_handle"]
+        assert isinstance(result_handle, str)
+        handles[result_handle] = {"value": engine.premise}
         return engine, handles, produced
 
     if fn == "engine.step":


### PR DESCRIPTION
## What changed

- add read-only `Engine` properties for stable engine-owned state: `engine.premise` and `engine.policies`
- make those properties the canonical public read API and remove redundant `get_premise_value(...)` and `get_policy_items(...)` helpers
- update docs, examples, demos, tests, API contract artifacts, and mutation-isolation conformance fixtures for the new property-based surface
- tighten the public type contract for `Engine.policies` to `Mapping[...]` while keeping the same defensive-copy runtime behavior

## Why

- the engine already had a stable authoritative state model, but callers still had to go through redundant helper functions to read engine-owned state
- exposing `engine.premise` and `engine.policies` directly makes the public API clearer while preserving mutation isolation
- removing the redundant helpers avoids maintaining two parallel state-read surfaces and keeps the public contract centered on the `Engine` itself

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
