### PR TITLE
fix: remove continuation semantics artifacts

### DIFF
--- a/examples/03_ambiguity_with_clarification.py
+++ b/examples/03_ambiguity_with_clarification.py
@@ -24,7 +24,7 @@ def main() -> None:
     print()
 
     if is_clarify(decision2):
-        print("Host behavior: clarification pending, do NOT call LLM.")
+        print("Host behavior: clarification returned, do NOT call LLM.")
         print(f"Clarify prompt: {get_clarify_prompt(decision2)}")
     else:
         fake_llm("use peanuts")

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -45,14 +45,12 @@ class Decision(TypedDict):
 @dataclass(frozen=True)
 class Action:
     kind: Literal[
-        "compound_directive_invalid",
         "set_premise",
         "change_premise",
         "use_item",
         "prohibit_item",
         "remove_policy_item",
         "replace_use",
-        "replace_use_incomplete",
         "clear_premise",
         "reset_policies",
         "clear_state",
@@ -68,13 +66,6 @@ _PASSTHROUGH: Decision = {
     "state": None,
     "prompt_to_user": None,
 }
-
-_AFFIRMATIVE_CONFIRMATIONS = {"yes", "yes please", "yep", "yeah", "sure", "ok", "okay"}
-_NEGATIVE_CONFIRMATIONS = {"no", "nope", "no thanks"}
-_TRAILING_CONFIRM_PUNCT_RE = re.compile(r"[.,!?]+$")
-_COMPOUND_DIRECTIVE_PROMPT = (
-    "Multiple directives are not supported in one input.\nSubmit each directive separately."
-)
 
 
 def create_engine(state: State | None = None) -> "Engine":
@@ -120,9 +111,6 @@ class Engine:
 
     def _pre_mutation_clarify(self, action: Action) -> Decision | None:
         # Single clarify path: all clarify outcomes are detected before any mutation.
-        if action.kind == "compound_directive_invalid":
-            return _clarify(_COMPOUND_DIRECTIVE_PROMPT)
-
         if action.kind in {"set_premise", "change_premise"}:
             assert action.value is not None
             if _sanitize_premise_value(action.value) == "":
@@ -157,12 +145,6 @@ class Engine:
                 return _clarify(
                     "Policy item cannot be empty.\nUse 'prohibit <item>' with a non-empty value."
                 )
-
-        if action.kind == "replace_use_incomplete":
-            return _clarify(
-                "Replacement requires both new and old items.\n"
-                "Use 'use <new item> instead of <old item>' with non-empty values."
-            )
 
         if action.kind == "set_premise" and self._state[STATE_PREMISE] is not None:
             return _clarify("Premise already set.\nUse 'change premise to <value>' to modify it.")
@@ -373,14 +355,6 @@ def _normalize_item(value: str) -> str:
     normalized = re.sub(r"\s+", " ", normalized).strip()
     normalized = re.sub(r"^(?:a|an|the)\b\s*", "", normalized)
     return normalized.strip()
-
-
-def _normalize_confirmation(text: str) -> str:
-    normalized = unicode_normalize("NFKC", text)
-    normalized = normalized.lower().strip()
-    normalized = re.sub(r"\s+", " ", normalized)
-    normalized = _TRAILING_CONFIRM_PUNCT_RE.sub("", normalized).strip()
-    return re.sub(r"\s+", " ", normalized)
 
 
 def _clarify(prompt: str) -> Decision:

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -19,12 +19,6 @@ from .engine import Decision, DecisionKind, Engine, State
 _EXIT_TOKENS = {"exit", "quit"}
 _HELP_TOKENS = {"help", "?"}
 _MULTI_COMMAND_PROMPT = "Multiple commands detected.\nEnter one command per line."
-_AFFIRMATIVE_CONFIRMATIONS = {"yes", "yes please", "yep", "yeah", "sure", "ok", "okay"}
-_NEGATIVE_CONFIRMATIONS = {"no", "nope", "no thanks"}
-_STEP_PENDING_CONFIRMATION_ERROR = (
-    "step command only accepts confirmation while clarification is pending.\n"
-    "Use yes/no (or variants), or use preview/state."
-)
 _CLI_HELP_TEXT = """Usage:
   context-compiler [--help] [--version] [--json]
                    [--initial-state-json <json> | --initial-state-file <path>]
@@ -75,8 +69,7 @@ def _print_interactive_help(out_stream: TextIO) -> None:
     print("  clear state", file=out_stream)
     print("Bare input behavior remains unchanged.", file=out_stream)
     print("preview is a deterministic dry-run and never mutates live state.", file=out_stream)
-    print("Only question prompts accept yes/no confirmations", file=out_stream)
-    print("Other clarify prompts are errors and do not accept yes/no", file=out_stream)
+    print("clarify results are immediate messages and do not reserve later input.", file=out_stream)
 
 
 def _render_state_lines(state: State) -> list[str]:
@@ -102,8 +95,6 @@ def _render_decision_lines(decision: Decision) -> list[str]:
     if kind == DECISION_CLARIFY:
         prompt = decision["prompt_to_user"] or ""
         prompt_lines = prompt.splitlines() if prompt else [""]
-        if prompt.endswith("?"):
-            return [f"confirm: {prompt_lines[0]}", *prompt_lines[1:]]
         return [f"error: {prompt_lines[0]}", *prompt_lines[1:]]
 
     state = decision["state"]
@@ -249,18 +240,6 @@ def _apply_preload_from_options(engine: Engine, options: dict[str, str | bool]) 
         path = options["initial_state_file"]
         assert isinstance(path, str)
         engine.import_json(_read_utf8_file(path))
-
-
-def _normalize_confirmation_token(value: str) -> str:
-    normalized = value.strip().lower()
-    while normalized and normalized[-1] in ".,!?":
-        normalized = normalized[:-1]
-    return " ".join(normalized.split())
-
-
-def _is_confirmation_input(value: str) -> bool:
-    normalized = _normalize_confirmation_token(value)
-    return normalized in _AFFIRMATIVE_CONFIRMATIONS or normalized in _NEGATIVE_CONFIRMATIONS
 
 
 def run_repl(

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -60,9 +60,8 @@ Unknown top-level and documented nested fields are rejected.
 
 ### Prelude
 
-`prelude` simulates prior user inputs to reach states that are not representable
-via `initial_state` (for example, runtime-only semantic continuation when the
-active engine contract supports it).
+`prelude` simulates prior user inputs to reach states through the public engine
+surface before the main fixture input runs.
 
 Shared `step` fixtures intentionally cover representative parser and passthrough
 boundaries. They do not attempt to freeze every ambiguous natural-language edge
@@ -153,17 +152,9 @@ They validate:
 * clarification prompt behavior
 * authoritative state parity against expected snapshots
 
-If a future engine contract restores supported continuation behavior,
-planned conformance coverage should include:
-
-* incomplete directives do not create pending continuation
-* compound directives do not create pending continuation
-* malformed replacement syntax does not create pending continuation
-* valid canonical directives that clarify without pending continuation
-* valid canonical directives that clarify and create pending continuation
-* deterministic `yes` resolution of the exact blocked transition
-* deterministic `no` rejection that clears pending continuation
-* deterministic handling of unrelated input while pending
+The current conformance corpus assumes the engine owns authoritative state only.
+Clarify results do not reserve later user input or create portable continuation
+state.
 
 ## Test runner
 

--- a/tests/fixtures/conformance/controller/controller_preview_affirmative_followup_passthrough_after_replace_update.json
+++ b/tests/fixtures/conformance/controller/controller_preview_affirmative_followup_passthrough_after_replace_update.json
@@ -1,5 +1,5 @@
 {
-  "id": "controller_preview_replace_prohibited_old_matches_execution_without_pending",
+  "id": "controller_preview_affirmative_followup_passthrough_after_replace_update",
   "kind": "controller",
   "initial_state": {
     "premise": null,
@@ -7,35 +7,32 @@
     "version": 2
   },
   "prelude": [
-    "prohibit docker",
-    "use pytest"
+    "use kubectl instead of docker"
   ],
   "action": {
     "fn": "preview",
-    "input": "use kubectl instead of docker"
+    "input": "yes"
   },
   "expected": {
     "result": {
       "output_version": 1,
       "mode": "preview",
       "decision": {
-        "kind": "clarify",
+        "kind": "passthrough",
         "state": null,
-        "prompt_to_user": "\"docker\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item."
+        "prompt_to_user": null
       },
       "state_before": {
         "premise": null,
         "policies": {
-          "docker": "prohibit",
-          "pytest": "use"
+          "kubectl": "use"
         },
         "version": 2
       },
       "state_after": {
         "premise": null,
         "policies": {
-          "docker": "prohibit",
-          "pytest": "use"
+          "kubectl": "use"
         },
         "version": 2
       },
@@ -57,8 +54,7 @@
     "state_after_preview": {
       "premise": null,
       "policies": {
-        "docker": "prohibit",
-        "pytest": "use"
+        "kubectl": "use"
       },
       "version": 2
     }

--- a/tests/fixtures/conformance/controller/controller_preview_clarify_reports_non_mutating_and_restores_live_state.json
+++ b/tests/fixtures/conformance/controller/controller_preview_clarify_reports_non_mutating_and_restores_live_state.json
@@ -1,32 +1,33 @@
 {
-  "id": "controller_preview_pending_yes_reports_mutation_but_preserves_live_pending",
+  "id": "controller_preview_clarify_reports_non_mutating_and_restores_live_state",
   "kind": "controller",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "prelude": [
-    "use kubectl instead of docker"
-  ],
   "action": {
     "fn": "preview",
-    "input": "yes"
+    "input": "use kubectl instead of docker"
   },
   "expected": {
     "result": {
       "output_version": 1,
       "mode": "preview",
       "decision": {
-        "kind": "passthrough",
-        "state": null,
+        "kind": "update",
+        "state": {
+          "premise": null,
+          "policies": {
+            "kubectl": "use"
+          },
+          "version": 2
+        },
         "prompt_to_user": null
       },
       "state_before": {
         "premise": null,
-        "policies": {
-          "kubectl": "use"
-        },
+        "policies": {},
         "version": 2
       },
       "state_after": {
@@ -37,25 +38,25 @@
         "version": 2
       },
       "diff": {
-        "changed": false,
+        "changed": true,
         "premise": {
           "before": null,
           "after": null,
           "changed": false
         },
         "policies": {
-          "added": {},
+          "added": {
+            "kubectl": "use"
+          },
           "removed": {},
           "changed": {}
         }
       },
-      "would_mutate": false
+      "would_mutate": true
     },
     "state_after_preview": {
       "premise": null,
-      "policies": {
-        "kubectl": "use"
-      },
+      "policies": {},
       "version": 2
     }
   }

--- a/tests/fixtures/conformance/controller/controller_preview_replace_prohibited_old_matches_execution_without_mutation.json
+++ b/tests/fixtures/conformance/controller/controller_preview_replace_prohibited_old_matches_execution_without_mutation.json
@@ -1,11 +1,15 @@
 {
-  "id": "controller_preview_clarify_reports_non_mutating_and_restores_pending",
+  "id": "controller_preview_replace_prohibited_old_matches_execution_without_mutation",
   "kind": "controller",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
+  "prelude": [
+    "prohibit docker",
+    "use pytest"
+  ],
   "action": {
     "fn": "preview",
     "input": "use kubectl instead of docker"
@@ -15,48 +19,47 @@
       "output_version": 1,
       "mode": "preview",
       "decision": {
-        "kind": "update",
-        "state": {
-          "premise": null,
-          "policies": {
-            "kubectl": "use"
-          },
-          "version": 2
-        },
-        "prompt_to_user": null
+        "kind": "clarify",
+        "state": null,
+        "prompt_to_user": "\"docker\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item."
       },
       "state_before": {
         "premise": null,
-        "policies": {},
+        "policies": {
+          "docker": "prohibit",
+          "pytest": "use"
+        },
         "version": 2
       },
       "state_after": {
         "premise": null,
         "policies": {
-          "kubectl": "use"
+          "docker": "prohibit",
+          "pytest": "use"
         },
         "version": 2
       },
       "diff": {
-        "changed": true,
+        "changed": false,
         "premise": {
           "before": null,
           "after": null,
           "changed": false
         },
         "policies": {
-          "added": {
-            "kubectl": "use"
-          },
+          "added": {},
           "removed": {},
           "changed": {}
         }
       },
-      "would_mutate": true
+      "would_mutate": false
     },
     "state_after_preview": {
       "premise": null,
-      "policies": {},
+      "policies": {
+        "docker": "prohibit",
+        "pytest": "use"
+      },
       "version": 2
     }
   }

--- a/tests/fixtures/conformance/mutation-isolation/README.md
+++ b/tests/fixtures/conformance/mutation-isolation/README.md
@@ -96,7 +96,7 @@ unsynchronized TypeScript port.
 They intentionally do **not** include:
 
 * checkpoint APIs
-* pending-continuation APIs
+* removed continuation-state APIs
 * obsolete TypeScript-only authority surfaces
 * implementation-mechanism requirements such as `deepcopy`, frozen objects, or
   `readonly`

--- a/tests/fixtures/conformance/step/step_affirmative_followup_passthrough_normalized_token.json
+++ b/tests/fixtures/conformance/step/step_affirmative_followup_passthrough_normalized_token.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_pending_affirmative_normalized_token",
+  "id": "step_affirmative_followup_passthrough_normalized_token",
   "kind": "step",
   "initial_state": {
     "premise": null,

--- a/tests/fixtures/conformance/step/step_affirmative_followup_passthrough_punctuation_token.json
+++ b/tests/fixtures/conformance/step/step_affirmative_followup_passthrough_punctuation_token.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_pending_unmatched_reuses_prompt",
+  "id": "step_affirmative_followup_passthrough_punctuation_token",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -9,7 +9,7 @@
   "prelude": [
     "use kubectl instead of docker"
   ],
-  "input": "sounds good",
+  "input": " okay!!! ",
   "expected": {
     "decision": {
       "kind": "passthrough",

--- a/tests/fixtures/conformance/step/step_independent_followup_passthrough_after_replace_update.json
+++ b/tests/fixtures/conformance/step/step_independent_followup_passthrough_after_replace_update.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_pending_negative_punctuation_token",
+  "id": "step_independent_followup_passthrough_after_replace_update",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -9,7 +9,7 @@
   "prelude": [
     "use kubectl instead of docker"
   ],
-  "input": " NOPE?? ",
+  "input": "sounds good",
   "expected": {
     "decision": {
       "kind": "passthrough",

--- a/tests/fixtures/conformance/step/step_negative_followup_passthrough_normalized_token.json
+++ b/tests/fixtures/conformance/step/step_negative_followup_passthrough_normalized_token.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_pending_affirmative_punctuation_token",
+  "id": "step_negative_followup_passthrough_normalized_token",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -9,7 +9,7 @@
   "prelude": [
     "use kubectl instead of docker"
   ],
-  "input": " okay!!! ",
+  "input": "no thanks.",
   "expected": {
     "decision": {
       "kind": "passthrough",

--- a/tests/fixtures/conformance/step/step_negative_followup_passthrough_punctuation_token.json
+++ b/tests/fixtures/conformance/step/step_negative_followup_passthrough_punctuation_token.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_pending_negative_normalized_token",
+  "id": "step_negative_followup_passthrough_punctuation_token",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -9,7 +9,7 @@
   "prelude": [
     "use kubectl instead of docker"
   ],
-  "input": "no thanks.",
+  "input": " NOPE?? ",
   "expected": {
     "decision": {
       "kind": "passthrough",

--- a/tests/fixtures/conformance/step/step_replace_prohibited_new_clarify_without_mutation.json
+++ b/tests/fixtures/conformance/step/step_replace_prohibited_new_clarify_without_mutation.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_replace_prohibited_old_clarify_no_pending",
+  "id": "step_replace_prohibited_new_clarify_without_mutation",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -7,21 +7,21 @@
     "version": 2
   },
   "prelude": [
-    "prohibit docker",
-    "use pytest"
+    "use docker",
+    "prohibit kubectl"
   ],
   "input": "use kubectl instead of docker",
   "expected": {
     "decision": {
       "kind": "clarify",
-      "prompt_to_user": "\"docker\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item.",
+      "prompt_to_user": "\"kubectl\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item.",
       "state": null
     },
     "state": {
       "premise": null,
       "policies": {
-        "docker": "prohibit",
-        "pytest": "use"
+        "docker": "use",
+        "kubectl": "prohibit"
       },
       "version": 2
     }

--- a/tests/fixtures/conformance/step/step_replace_prohibited_old_clarify_without_mutation.json
+++ b/tests/fixtures/conformance/step/step_replace_prohibited_old_clarify_without_mutation.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_replace_prohibited_new_clarify_no_pending",
+  "id": "step_replace_prohibited_old_clarify_without_mutation",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -7,21 +7,21 @@
     "version": 2
   },
   "prelude": [
-    "use docker",
-    "prohibit kubectl"
+    "prohibit docker",
+    "use pytest"
   ],
   "input": "use kubectl instead of docker",
   "expected": {
     "decision": {
       "kind": "clarify",
-      "prompt_to_user": "\"kubectl\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item.",
+      "prompt_to_user": "\"docker\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item.",
       "state": null
     },
     "state": {
       "premise": null,
       "policies": {
-        "docker": "use",
-        "kubectl": "prohibit"
+        "docker": "prohibit",
+        "pytest": "use"
       },
       "version": 2
     }

--- a/tests/test_04_grammar_edge_cases.py
+++ b/tests/test_04_grammar_edge_cases.py
@@ -115,7 +115,7 @@ def test_invalid_replacement_does_not_block_following_directives() -> None:
     }
 
 
-def test_invalid_replacement_non_confirmation_followup_is_passthrough() -> None:
+def test_replace_update_independent_followup_is_passthrough() -> None:
     engine = create_engine()
     first = engine.step("use kubectl instead of docker")
     second = engine.step("sounds good")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -73,7 +73,7 @@ def test_preview_missing_source_replacement_reports_update_without_live_mutation
     assert yes["kind"] == "passthrough"
 
 
-def test_preview_prohibited_replacement_clarify_matches_execution_without_pending() -> None:
+def test_preview_prohibited_replacement_clarify_matches_execution_without_mutation() -> None:
     engine = create_engine()
     engine.step("use docker")
     engine.step("prohibit kubectl")
@@ -242,9 +242,9 @@ def test_controller_helpers_are_importable_from_package_root() -> None:
     assert callable(diff_has_changes)
 
 
-@pytest.mark.parametrize("confirmation", ["yes", "no"])
-def test_preview_followup_tokens_after_invalid_replacement_are_passthrough(
-    confirmation: str,
+@pytest.mark.parametrize("followup_token", ["yes", "no"])
+def test_preview_followup_tokens_after_replace_update_are_passthrough(
+    followup_token: str,
 ) -> None:
     engine = create_engine()
     initial = engine.step("use kubectl instead of docker")
@@ -254,7 +254,7 @@ def test_preview_followup_tokens_after_invalid_replacement_are_passthrough(
         "prompt_to_user": None,
     }
 
-    preview_result = preview(engine, confirmation)
+    preview_result = preview(engine, followup_token)
     assert preview_result["decision"] == {
         "kind": "passthrough",
         "state": None,
@@ -269,6 +269,6 @@ def test_preview_followup_tokens_after_invalid_replacement_are_passthrough(
 
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
-    final = step(engine, confirmation)
+    final = step(engine, followup_token)
     assert final["decision"] == {"kind": "passthrough", "state": None, "prompt_to_user": None}
     assert final["state"] == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}

--- a/tests/test_demo_08_09_behavior.py
+++ b/tests/test_demo_08_09_behavior.py
@@ -108,7 +108,7 @@ def test_demo_08_reinjected_path_does_not_instantiate_engine(
     assert report["reinjected_state_pass"] is False
 
 
-def test_demo_09_reports_invalid_replacement_non_pending_boundary(
+def test_demo_09_reports_independent_followup_passthrough_boundary(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     module = _load_demo_module("09_llm_confirmation_passthrough.py")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8,7 +8,6 @@ from context_compiler.engine import (
     Action,
     DecisionKind,
     Engine,
-    _normalize_confirmation,
     _parse_directive,
 )
 from context_compiler.grammar import (
@@ -17,10 +16,6 @@ from context_compiler.grammar import (
 )
 
 pytestmark = pytest.mark.contract
-
-COMPOUND_DIRECTIVE_PROMPT = (
-    "Multiple directives are not supported in one input.\nSubmit each directive separately."
-)
 
 
 def test_decision_kind_strenum_behavior() -> None:
@@ -61,14 +56,9 @@ def test_parse_directive_returns_none_for_invalid_syntax_and_passthrough_inputs(
     assert _parse_directive("hello there") is None
 
 
-def test_pre_mutation_clarify_legacy_invalid_action_branches_remain_stable() -> None:
+def test_pre_mutation_clarify_empty_operand_branches_remain_stable() -> None:
     engine = create_engine()
 
-    assert engine._pre_mutation_clarify(Action(kind="compound_directive_invalid")) == {
-        "kind": "clarify",
-        "state": None,
-        "prompt_to_user": COMPOUND_DIRECTIVE_PROMPT,
-    }
     assert engine._pre_mutation_clarify(Action(kind="set_premise", value="")) == {
         "kind": "clarify",
         "state": None,
@@ -101,14 +91,6 @@ def test_pre_mutation_clarify_legacy_invalid_action_branches_remain_stable() -> 
         "state": None,
         "prompt_to_user": (
             "Policy item cannot be empty.\nUse 'prohibit <item>' with a non-empty value."
-        ),
-    }
-    assert engine._pre_mutation_clarify(Action(kind="replace_use_incomplete")) == {
-        "kind": "clarify",
-        "state": None,
-        "prompt_to_user": (
-            "Replacement requires both new and old items.\n"
-            "Use 'use <new item> instead of <old item>' with non-empty values."
         ),
     }
 
@@ -302,11 +284,6 @@ def test_import_json_accepts_valid_policy_key_and_normalizes_it() -> None:
     )
 
     assert engine.state == {"premise": None, "policies": {"docker": "use"}, "version": 2}
-
-
-def test_normalize_confirmation_collapses_unicode_spacing_and_trailing_punctuation() -> None:
-    assert _normalize_confirmation("  YES!!  ") == "yes"
-    assert _normalize_confirmation("No\t\tthanks...\n") == "no thanks"
 
 
 def test_replace_use_clarifies_when_old_policy_is_not_use_in_invalid_internal_state() -> None:
@@ -1199,9 +1176,7 @@ def test_directive_like_substrings_inside_larger_words_do_not_trigger_compound_r
 
     decision = engine.step(user_input)
 
-    assert not (
-        decision["kind"] == "clarify" and decision["prompt_to_user"] == COMPOUND_DIRECTIVE_PROMPT
-    )
+    assert decision["kind"] != "clarify"
     assert decision["kind"] == expected_decision_kind
     assert engine.state == expected_state
 
@@ -1290,9 +1265,7 @@ def test_all_canonical_directive_starts_remain_single_directive_when_valid(
 
     decision = engine.step(directive_start)
 
-    assert not (
-        decision["kind"] == "clarify" and decision["prompt_to_user"] == COMPOUND_DIRECTIVE_PROMPT
-    )
+    assert decision["kind"] != "passthrough"
 
 
 def test_compound_passthrough_after_prior_missing_source_replacement_update() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -744,7 +744,7 @@ def test_replace_use_identity_is_noop_update() -> None:
     assert engine.state == before
 
 
-def test_replace_use_missing_source_applies_as_use_update_without_pending() -> None:
+def test_replace_use_missing_source_applies_as_use_update() -> None:
     engine = create_engine()
 
     d1 = engine.step("use kubectl instead of docker")
@@ -756,7 +756,7 @@ def test_replace_use_missing_source_applies_as_use_update_without_pending() -> N
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
 
-def test_replace_use_missing_source_yes_confirmation_is_passthrough() -> None:
+def test_replace_use_missing_source_yes_followup_is_passthrough() -> None:
     engine = create_engine()
 
     first = engine.step("use kubectl instead of docker")
@@ -772,7 +772,7 @@ def test_replace_use_missing_source_yes_confirmation_is_passthrough() -> None:
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
 
-def test_replace_use_missing_source_no_confirmation_has_no_mutation() -> None:
+def test_replace_use_missing_source_no_followup_has_no_mutation() -> None:
     engine = create_engine()
     engine.step("use kubectl instead of docker")
     before = engine.state
@@ -835,7 +835,7 @@ def test_replace_use_missing_source_with_empty_probe_uses_invalid_prompt() -> No
     }
 
 
-def test_replace_use_ky_prohibit_returns_non_pending_clarify() -> None:
+def test_replace_use_ky_prohibit_returns_clarify_without_mutation() -> None:
     engine = create_engine()
     engine.step("prohibit docker")
     engine.step("use pytest")
@@ -866,7 +866,7 @@ def test_replace_use_ky_prohibit_yes_does_not_authorize_mutation() -> None:
     assert engine.state == before
 
 
-def test_replace_use_kx_prohibit_returns_non_pending_clarify() -> None:
+def test_replace_use_kx_prohibit_returns_clarify_without_mutation() -> None:
     engine = create_engine()
     engine.step("use docker")
     engine.step("prohibit kubectl")
@@ -920,7 +920,7 @@ def test_replace_use_invalid_source_state_prohibit_clarifies_without_mutation() 
     assert engine.state == before
 
 
-def test_replace_use_kx_prohibit_no_confirmation_has_no_mutation() -> None:
+def test_replace_use_kx_prohibit_no_followup_has_no_mutation() -> None:
     engine = create_engine()
     engine.step("use docker")
     engine.step("prohibit kubectl")
@@ -973,7 +973,7 @@ def test_missing_source_replacement_negative_followup_is_passthrough() -> None:
     assert engine.state["policies"] == {"kubectl": "use"}
 
 
-def test_missing_source_replacement_confirmation_tokens_are_not_consumed() -> None:
+def test_missing_source_replacement_affirmative_followup_tokens_are_passthrough() -> None:
     engine = create_engine()
     engine.step("use kubectl instead of docker")
 
@@ -1059,7 +1059,7 @@ def test_prohibited_replacement_yes_cannot_override_conflicting_target_polarity(
     assert engine.state["policies"] == {"docker": "use", "kubectl": "prohibit"}
 
 
-def test_import_json_clears_pending_clarification_yes_no_not_confirmation() -> None:
+def test_import_json_does_not_change_independent_yes_no_followup_behavior() -> None:
     engine = create_engine()
     first = engine.step("use kubectl instead of docker")
     assert first["kind"] == "update"

--- a/tests/test_examples_behavior.py
+++ b/tests/test_examples_behavior.py
@@ -51,7 +51,7 @@ def test_example_03_clarify_gate_blocks_llm_and_allows_later_update(
     output = capsys.readouterr().out
 
     assert decision_kinds == ["update", "clarify", "update"]
-    assert "Host behavior: clarification pending, do NOT call LLM." in output
+    assert "Host behavior: clarification returned, do NOT call LLM." in output
     assert llm_calls == []
 
 

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.contract
         (
             "03_ambiguity_with_clarification.py",
             (
-                "Host behavior: clarification pending, do NOT call LLM.",
+                "Host behavior: clarification returned, do NOT call LLM.",
                 "Remove or replace it before using it.",
             ),
         ),

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -612,7 +612,7 @@ def test_repl_non_interactive_json_multi_command_chunk_error() -> None:
     ]
 
 
-def test_repl_non_interactive_json_step_pending_confirmation_error() -> None:
+def test_repl_non_interactive_json_step_runs_normally_after_replace_update() -> None:
     rows = _run_non_interactive_json_lines(
         "use kubectl instead of docker\nstep set premise concise\nyes\nquit\n"
     )
@@ -722,7 +722,7 @@ def test_repl_step_command_runs_normally_after_invalid_replacement() -> None:
     assert lines[-1] == "passthrough"
 
 
-def test_repl_step_command_confirmation_token_is_passthrough_without_pending() -> None:
+def test_repl_step_command_affirmative_followup_is_passthrough() -> None:
     out = StringIO()
     run_repl(StringIO("use kubectl instead of docker\nstep yes\nquit\n"), out)
     lines = [line for line in out.getvalue().splitlines() if line.strip()]
@@ -734,7 +734,7 @@ def test_repl_step_command_confirmation_token_is_passthrough_without_pending() -
     assert lines[-1] == "passthrough"
 
 
-def test_repl_step_command_negative_confirmation_is_passthrough_without_pending() -> None:
+def test_repl_step_command_negative_followup_is_passthrough() -> None:
     out = StringIO()
     run_repl(StringIO("use kubectl instead of docker\nstep no\nquit\n"), out)
     lines = [line for line in out.getvalue().splitlines() if line.strip()]
@@ -876,7 +876,7 @@ def test_repl_non_interactive_remove_policy_flow() -> None:
     assert lines.count("policies: (none)") == 2
 
 
-def test_repl_contradiction_clarify_is_not_pending_confirmable() -> None:
+def test_repl_contradiction_clarify_does_not_reserve_followup_tokens() -> None:
     lines = _run_non_interactive_lines("use docker\nprohibit docker\nno\nquit\n")
     assert _contains_subsequence(lines, ["updated", "premise: (none)", "policies:", "- use docker"])
     assert _contains_subsequence(

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -167,7 +167,7 @@ def test_main_with_json_flag_runs_repl_with_json_mode(monkeypatch: pytest.Monkey
     assert called["json_mode"] is True
 
 
-def test_render_decision_lines_uses_confirm_prefix_for_question_prompts() -> None:
+def test_render_decision_lines_uses_error_prefix_for_all_clarify_prompts() -> None:
     lines = repl_module._render_decision_lines(
         {
             "kind": "clarify",
@@ -176,7 +176,7 @@ def test_render_decision_lines_uses_confirm_prefix_for_question_prompts() -> Non
         }
     )
 
-    assert lines == ["confirm: Proceed?"]
+    assert lines == ["error: Proceed?"]
 
 
 def test_render_diff_lines_includes_added_policy_entries() -> None:
@@ -198,20 +198,6 @@ def test_render_diff_lines_includes_added_policy_entries() -> None:
         "diff:",
         "- + use docker",
     ]
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        ("yes", True),
-        (" no! ", True),
-        ("maybe", False),
-    ],
-)
-def test_is_confirmation_input_recognizes_affirmative_and_negative_tokens(
-    value: str, expected: bool
-) -> None:
-    assert repl_module._is_confirmation_input(value) is expected
 
 
 def test_main_json_requires_non_interactive_stdio(
@@ -498,8 +484,7 @@ def test_repl_interactive_help_commands() -> None:
         "  clear state",
         "Bare input behavior remains unchanged.",
         "preview is a deterministic dry-run and never mutates live state.",
-        "Only question prompts accept yes/no confirmations",
-        "Other clarify prompts are errors and do not accept yes/no",
+        "clarify results are immediate messages and do not reserve later input.",
     ]
     assert lines[0] == "Context Compiler REPL (0.5). Type help for commands."
     assert lines[1] == "Non-directive input is passthrough."
@@ -947,17 +932,12 @@ def test_repl_replacement_invalid_followups_are_passthrough() -> None:
     assert lines[-2:] == ["passthrough", "passthrough"]
 
 
-def test_repl_interactive_prints_confirm_and_error_for_clarify_types() -> None:
+def test_repl_interactive_prints_error_for_clarify_output() -> None:
     error_out = _TTYStringIO()
     run_repl(_TTYStringIO("use docker\nprohibit docker\nquit\n"), error_out)
     error_lines = error_out.getvalue().splitlines()
     assert 'error: "docker" is currently in use.' in error_lines
     assert "Remove or replace it before prohibiting it." in error_lines
-
-    confirm_out = _TTYStringIO()
-    run_repl(_TTYStringIO("use podman instead of docker\nquit\n"), confirm_out)
-    confirm_lines = confirm_out.getvalue().splitlines()
-    assert "updated" in confirm_lines
 
 
 def test_repl_prohibited_replacement_followup_tokens_remain_passthrough() -> None:
@@ -1045,7 +1025,7 @@ def test_repl_interactive_admin_idempotency_outputs_updated_with_unchanged_state
     assert lines.count("policies: (none)") == 3
 
 
-def test_repl_interactive_confirm_vs_error_alignment_for_actual_clarify_behaviors() -> None:
+def test_repl_interactive_clarify_output_alignment_for_actual_behaviors() -> None:
     lines = _run_interactive_lines(
         "set premise concise\n"
         "set premise verbose\n"

--- a/tests/test_repl_coverage.py
+++ b/tests/test_repl_coverage.py
@@ -1,7 +1,6 @@
 from io import StringIO
 
 from context_compiler.repl import (
-    _normalize_confirmation_token,
     _print_command_error,
     _render_diff_lines,
     run_repl,
@@ -46,10 +45,6 @@ def test_print_command_error_leading_blank_line() -> None:
     out = StringIO()
     _print_command_error(out, leading_blank=True, message="boom")
     assert out.getvalue().splitlines() == ["", "error: boom"]
-
-
-def test_normalize_confirmation_token_strips_trailing_punctuation() -> None:
-    assert _normalize_confirmation_token(" YES PLEASE!! ") == "yes please"
 
 
 def test_interactive_state_step_and_preview_command_error_paths() -> None:

--- a/tests/test_repl_properties.py
+++ b/tests/test_repl_properties.py
@@ -40,8 +40,6 @@ def _oracle_render_decision(decision: dict[str, object]) -> list[str]:
         prompt_obj = decision["prompt_to_user"]
         prompt = prompt_obj if isinstance(prompt_obj, str) else ""
         prompt_lines = prompt.splitlines() if prompt else [""]
-        if prompt.endswith("?"):
-            return [f"confirm: {prompt_lines[0]}", *prompt_lines[1:]]
         return [f"error: {prompt_lines[0]}", *prompt_lines[1:]]
 
     state_obj = decision["state"]


### PR DESCRIPTION
## What changed

- removed stale pending/continuation terminology from conformance fixtures, controller fixtures, and tests so they describe the current clarify-result model instead of nonexistent reserved follow-up state
- removed dead core and REPL confirmation artifacts that were left behind after pending-continuation ownership was deleted from the engine
- updated REPL/help-facing wording and related examples to stop implying that later yes/no input resumes an earlier engine operation

## Why

- the engine no longer owns pending confirmation or continuation state, so the remaining terminology and dead helpers were incorrectly suggesting a runtime contract that no longer exists
- cleaning up those artifacts keeps the public behavior, tests, and fixtures aligned before adding new consumers such as Directive Drafter

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
