### PR TITLE
chore: prepare 0.9.0 dev release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.8.3"
+version = "0.9.0dev"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.8.3"
+version = "0.9.0.dev0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- bumped the package version for the next drafter development release
- refreshed `uv.lock` so the locked package metadata matches the release version

## Why

- GitHub releases publish this package to PyPI, so the upcoming development release needs the package metadata and lockfile updated before future drafter work continues

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
