### PR TITLE
fix: export public policy typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.9.0dev"
+version = "0.9.0dev1"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/context_compiler/__init__.py
+++ b/src/context_compiler/__init__.py
@@ -30,7 +30,9 @@ from .decision_helpers import (
 )
 from .engine import (
     Decision,
+    DecisionKind,
     Engine,
+    PolicyValue,
     State,
     create_engine,
 )
@@ -40,6 +42,7 @@ __version__ = version("context-compiler")
 
 __all__ = [
     "Decision",
+    "DecisionKind",
     "DECISION_CLARIFY",
     "DECISION_PASSTHROUGH",
     "DECISION_UPDATE",
@@ -47,6 +50,7 @@ __all__ = [
     "Engine",
     "POLICY_PROHIBIT",
     "POLICY_USE",
+    "PolicyValue",
     "PreviewResult",
     "State",
     "StepResult",

--- a/tests/fixtures/conformance/api/public-api-v1.json
+++ b/tests/fixtures/conformance/api/public-api-v1.json
@@ -4,8 +4,6 @@
   "target": "context-compiler-ports",
   "module": "context_compiler",
   "forbidden_exports": [
-    "DecisionKind",
-    "PolicyValue",
     "CheckpointPending",
     "CheckpointPendingReplacement",
     "PendingReplacement",
@@ -15,6 +13,7 @@
     "mode": "exact",
     "names": [
       "Decision",
+      "DecisionKind",
       "DECISION_CLARIFY",
       "DECISION_PASSTHROUGH",
       "DECISION_UPDATE",
@@ -22,6 +21,7 @@
       "Engine",
       "POLICY_PROHIBIT",
       "POLICY_USE",
+      "PolicyValue",
       "PreviewResult",
       "State",
       "StepResult",
@@ -49,6 +49,9 @@
       "Decision": {
         "kind": "type"
       },
+      "DecisionKind": {
+        "kind": "class"
+      },
       "DECISION_CLARIFY": {
         "kind": "constant",
         "value": "clarify"
@@ -74,6 +77,9 @@
       "POLICY_USE": {
         "kind": "constant",
         "value": "use"
+      },
+      "PolicyValue": {
+        "kind": "type_alias"
       },
       "PreviewResult": {
         "kind": "type"

--- a/tests/test_api_contract_fixture.py
+++ b/tests/test_api_contract_fixture.py
@@ -150,6 +150,11 @@ def test_api_contract_fixture_forbidden_exports_are_not_present() -> None:
         assert not hasattr(context_compiler, name), name
 
 
+def test_public_annotation_dependencies_are_importable_from_root() -> None:
+    assert context_compiler.PolicyValue is not None
+    assert context_compiler.DecisionKind is not None
+
+
 def test_api_contract_fixture_has_unique_entries() -> None:
     contract = _load_contract()
     export_names = contract["exports"]["names"]

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.9.0.dev0"
+version = "0.9.0.dev1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- exported `PolicyValue` and `DecisionKind` from the root `context_compiler` public API
- updated the public API conformance fixture to reflect the intended root export surface
- added regression coverage that verifies the public annotation dependency imports work from the package root
- bumped the package dev release version in `pyproject.toml` and refreshed `uv.lock`

## Why

- `PolicyValue` is used in exported API annotations, and `DecisionKind` is referenced by the exported `Decision` type, so the root public API needed to expose those symbols consistently
- the public API contract fixture needed to match the intended root export surface before the next dev release
- the package metadata and lockfile needed a new dev release version for publishing the updated branch state

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
