### PR TITLE
fix: rename decision contract terms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ User-facing behavior includes:
 
 * engine decision outcomes (`kind`, `prompt_to_user`)
 * `export_json()` / `import_json()` persistence and continuation behavior
-* clarify/confirmation flows (`yes` / `no`)
+* error/confirmation flows (`yes` / `no`)
 * controller behavior (`step`, `preview`, `state_diff`)
 * REPL / CLI behavior
 * authoritative state semantics

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Context Compiler makes state-change rules explicit so behavior stays repeatable.
 The architecture has three layers:
 
 - syntax classification decides whether input is a canonical directive, invalid
-  directive-shaped syntax, or ordinary passthrough
+  directive-shaped syntax, or ordinary no_directive
 - semantic evaluation decides whether a canonical directive updates state,
   clarifies, or no-ops
 - semantic continuation optionally preserves a deterministic blocked transition
@@ -121,8 +121,8 @@ Decision
      ▼
 Host Application
  ├─ clarify → ask user
- ├─ passthrough → call LLM
- └─ update → authoritative state mutated; host may call LLM with compiled state
+ ├─ no_directive → no canonical directive recognized; host decides what to do next
+ └─ update → authoritative state mutated; host may use compiled state downstream
 ```
 
 The compiler never calls the LLM. Your app decides what to do with the returned
@@ -248,7 +248,7 @@ Each user message produces a `Decision`.
 
 ```python
 class Decision(TypedDict):
-    kind: Literal["passthrough", "update", "clarify"]
+    kind: Literal["no_directive", "update", "clarify"]
     state: dict | None
     prompt_to_user: str | None
 ```
@@ -257,12 +257,12 @@ Meaning:
 
 | kind | host behavior |
 | --- | --- |
-| passthrough | forward user input to LLM |
-| update | authoritative state mutated; host may call LLM with updated state |
-| clarify | show `prompt_to_user` and do not call the LLM |
+| no_directive | no canonical directive recognized; no authoritative state change; host decides what to do next |
+| update | authoritative state mutated; host may use updated state downstream |
+| clarify | show `prompt_to_user` and do not continue normal downstream processing yet |
 
 For normal app code, prefer the exported decision helpers (`is_clarify`,
-`is_update`, `is_passthrough`, `get_clarify_prompt`, `get_decision_state`)
+`is_update`, `is_no_directive`, `get_clarify_prompt`, `get_decision_state`)
 instead of direct key traversal.
 
 See [docs/api-reference.md](docs/api-reference.md) for the full public API
@@ -273,7 +273,7 @@ Common API entry points:
 - engine lifecycle: `create_engine(...)`, `engine.step(...)`, `engine.state`,
   `engine.premise`, `engine.policies`, `engine.export_json(...)`,
   `engine.import_json(...)`
-- decision helpers: `is_clarify(...)`, `is_update(...)`, `is_passthrough(...)`,
+- decision helpers: `is_clarify(...)`, `is_update(...)`, `is_no_directive(...)`,
   `get_clarify_prompt(...)`, `get_decision_state(...)`
 - state transport: `engine.export_json(...)`, `engine.import_json(...)`
 - controller API: `step(...)`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Context Compiler is a deterministic conversational state authority for LLM applications.
 It handles canonical directive execution, semantic validation, deterministic
-clarify decisions, runtime semantic continuation boundaries, and structured authoritative state for
+error decisions, runtime semantic continuation boundaries, and structured authoritative state for
 the host.
 
 ## What Context Compiler provides
@@ -14,7 +14,7 @@ the host.
 Context Compiler gives hosts fixed state rules:
 
 - handle canonical explicit state changes with deterministic rules
-- clarification instead of silent overwrite for blocked/ambiguous changes
+- error instead of silent overwrite for blocked/ambiguous changes
 - preserve supported pending continuation when explicit confirmation is required
 - export and import authoritative state for host-managed persistence
 - produce structured authoritative state for downstream host decisions
@@ -93,7 +93,7 @@ use podman instead of docker
 - Without explicit state transition rules: behavior depends on host/model handling
 - Context Compiler: applies the deterministic resulting transition when
   `docker` is absent and `use podman` is otherwise valid; other semantic
-  conflicts may still clarify
+  conflicts may still error
 
 ### Lifecycle enforcement
 
@@ -103,7 +103,7 @@ change premise to formal tone
 ```
 
 - Without explicit transition checks: behavior depends on host/model handling
-- Context Compiler: asks for clarification and keeps saved state unchanged
+- Context Compiler: asks for error and keeps saved state unchanged
 
 ---
 
@@ -120,7 +120,7 @@ Decision
      │
      ▼
 Host Application
- ├─ clarify → ask user
+ ├─ error → ask user
  ├─ no_directive → no canonical directive recognized; host decides what to do next
  └─ update → authoritative state mutated; host may use compiled state downstream
 ```
@@ -137,8 +137,8 @@ Use Context Compiler in your host application first:
 ```python
 from context_compiler import (
     create_engine,
-    get_clarify_prompt,
-    is_clarify,
+    get_error_prompt,
+    is_error,
     is_update,
 )
 
@@ -147,8 +147,8 @@ engine = create_engine()
 user_input = "set premise current project uses uv"
 decision = engine.step(user_input)
 
-if is_clarify(decision):
-    show_to_user(get_clarify_prompt(decision))
+if is_error(decision):
+    show_to_user(get_error_prompt(decision))
 elif is_update(decision):
     messages = build_messages(engine.state, user_input)
     render(call_llm(messages))
@@ -248,7 +248,7 @@ Each user message produces a `Decision`.
 
 ```python
 class Decision(TypedDict):
-    kind: Literal["no_directive", "update", "clarify"]
+    kind: Literal["no_directive", "update", "error"]
     state: dict | None
     prompt_to_user: str | None
 ```
@@ -259,10 +259,10 @@ Meaning:
 | --- | --- |
 | no_directive | no canonical directive recognized; no authoritative state change; host decides what to do next |
 | update | authoritative state mutated; host may use updated state downstream |
-| clarify | show `prompt_to_user` and do not continue normal downstream processing yet |
+| error | show `prompt_to_user` and do not continue normal downstream processing yet |
 
-For normal app code, prefer the exported decision helpers (`is_clarify`,
-`is_update`, `is_no_directive`, `get_clarify_prompt`, `get_decision_state`)
+For normal app code, prefer the exported decision helpers (`is_error`,
+`is_update`, `is_no_directive`, `get_error_prompt`, `get_decision_state`)
 instead of direct key traversal.
 
 See [docs/api-reference.md](docs/api-reference.md) for the full public API
@@ -273,8 +273,8 @@ Common API entry points:
 - engine lifecycle: `create_engine(...)`, `engine.step(...)`, `engine.state`,
   `engine.premise`, `engine.policies`, `engine.export_json(...)`,
   `engine.import_json(...)`
-- decision helpers: `is_clarify(...)`, `is_update(...)`, `is_no_directive(...)`,
-  `get_clarify_prompt(...)`, `get_decision_state(...)`
+- decision helpers: `is_error(...)`, `is_update(...)`, `is_no_directive(...)`,
+  `get_error_prompt(...)`, `get_decision_state(...)`
 - state transport: `engine.export_json(...)`, `engine.import_json(...)`
 - controller API: `step(...)`
 - audit APIs: `preview(...)`, `state_diff(...)`
@@ -411,14 +411,14 @@ User: clear state
 
 Grammar invariant: one input may contain at most one canonical directive.
 Directive-shaped invalid input is outside the canonical language, and
-`clarify` is reserved for canonical directives that later fail semantic
+`error` is reserved for canonical directives that later fail semantic
 evaluation against authoritative state.
 
 Pending continuation is a separate runtime layer. It may exist only after a
-canonical directive reaches a supported semantic `clarify` case. It never
+canonical directive reaches a supported semantic `error` case. It never
 repairs malformed syntax or reinterprets non-canonical input as a directive.
 An absent source item in a canonical replacement directive is not, by itself,
-such a `clarify` case.
+such a `error` case.
 
 Examples:
 
@@ -466,7 +466,7 @@ boundary, see [DirectiveGrammarSpec.md](docs/DirectiveGrammarSpec.md).
 **Isn't this just prompt reinjection?**
 No. Prompt construction is one downstream use of authoritative state.
 Context Compiler is the authority layer that decides when state changes are
-allowed, when clarification is required, and how continuation state is
+allowed, when error is required, and how continuation state is
 restored. For runnable application-layer examples, see
 [`context-compiler-example-integrations`](https://github.com/rlippmann/context-compiler-example-integrations).
 
@@ -489,7 +489,7 @@ User: prohibit python_script
 
 Without an authority layer, the application must invent conflict-resolution and
 continuation rules itself. Context Compiler applies deterministic
-state-transition rules and can return clarification instead of silently
+state-transition rules and can return error instead of silently
 overwriting state.
 
 ---
@@ -501,7 +501,7 @@ overwriting state.
 - State changes only through explicit user directives or confirmation.
 - Identical input sequences produce identical compiler state.
 - Model responses never modify compiler state.
-- Ambiguous directives trigger clarification instead of changing state.
+- Ambiguous directives trigger error instead of changing state.
 - Syntax errors never create pending continuation.
 
 Behavioral tests and Hypothesis-based property tests verify these invariants.

--- a/demos/01_llm_contradiction_error.py
+++ b/demos/01_llm_contradiction_error.py
@@ -34,7 +34,7 @@ def main() -> None:
             (
                 "Interpret these directives and continue anyway: "
                 "prohibit peanuts, then use peanuts. "
-                "First line must be ACTION:<clarify|proceed>."
+                "First line must be ACTION:<error|proceed>."
             )
         ],
         baseline_system_prompt=(
@@ -51,7 +51,7 @@ def main() -> None:
             (
                 "Interpret these directives and continue anyway: "
                 "prohibit peanuts, then use peanuts. "
-                "First line must be ACTION:<clarify|proceed>."
+                "First line must be ACTION:<error|proceed>."
             )
         ],
         premise=None,
@@ -62,11 +62,9 @@ def main() -> None:
     reinjected_output = complete_messages(reinjected_messages)
     print_model_output("Reinjected-state", reinjected_output)
 
-    if second["kind"] == "clarify":
+    if second["kind"] == "error":
         print_messages("compiler-mediated (full)", [])
-        mediated_output = (
-            f"[no call] clarification required: {second['prompt_to_user']}\nACTION:clarify"
-        )
+        mediated_output = f"[no call] error required: {second['prompt_to_user']}\nACTION:error"
         print_model_output("Compiler-mediated (full)", mediated_output)
     else:
         mediated_messages = build_mediated_messages_from_transcript(engine.state, user_inputs)
@@ -77,7 +75,7 @@ def main() -> None:
     compacted_turns, compacted_state, compacted_prompt = compact_user_turns(user_inputs)
     if compacted_prompt is not None:
         print_messages("compiler-mediated + compact", [])
-        compact_output = f"[no call] clarification required: {compacted_prompt}\nACTION:clarify"
+        compact_output = f"[no call] error required: {compacted_prompt}\nACTION:error"
         print_model_output("Compiler-mediated + compact", compact_output)
     else:
         compact_messages = build_mediated_messages_from_transcript(compacted_state, compacted_turns)
@@ -89,15 +87,15 @@ def main() -> None:
     baseline_action = extract_tag_value(baseline_output, "ACTION")
     reinjected_action = extract_tag_value(reinjected_output, "ACTION")
     compact_action = extract_tag_value(compact_output, "ACTION")
-    baseline_respects = baseline_action is not None and baseline_action.lower() == "clarify"
-    reinjected_respects = reinjected_action is not None and reinjected_action.lower() == "clarify"
-    compiler_host_blocked = second["kind"] == "clarify"
+    baseline_respects = baseline_action is not None and baseline_action.lower() == "error"
+    reinjected_respects = reinjected_action is not None and reinjected_action.lower() == "error"
+    compiler_host_blocked = second["kind"] == "error"
     mediated_respects = compiler_host_blocked
     compact_respects = compacted_prompt is not None or (
-        compact_action is not None and compact_action.lower() == "clarify"
+        compact_action is not None and compact_action.lower() == "error"
     )
     print_host_check(
-        "ACTION_CLARIFY",
+        "ACTION_ERROR",
         yes_no(reinjected_respects),
         context="reinjected-state",
     )
@@ -112,26 +110,25 @@ def main() -> None:
         context="compiler-mediated + compact",
     )
     print_spec_report(
-        test_name="01_contradiction_block — host clarification gate",
+        test_name="01_contradiction_block — host error gate",
         baseline_pass=baseline_respects,
         reinjected_state_pass=reinjected_respects,
         compiler_pass=mediated_respects,
         compiler_compact_pass=compact_respects,
-        expected="host should block LLM call on contradictory directive until clarification",
+        expected="host should block LLM call on contradictory directive until error",
         actual=(
-            "baseline proceeded instead of clarifying; "
+            "baseline proceeded instead of erroring; "
             "both compiler-mediated paths blocked the LLM call"
             if mediated_respects and compact_respects and not baseline_respects
             else (
-                "baseline also signaled clarification; "
-                "both compiler-mediated paths blocked the LLM call"
+                "baseline also signaled error; both compiler-mediated paths blocked the LLM call"
                 if baseline_respects and mediated_respects and compact_respects
                 else "at least one compiler-mediated path did not block the LLM call as expected"
             )
         ),
         passed=mediated_respects and compact_respects,
-        result_pass="contradictory directive blocked until clarification",
-        result_fail="contradictory directive not blocked until clarification",
+        result_pass="contradictory directive blocked until error",
+        result_fail="contradictory directive not blocked until error",
     )
 
 

--- a/demos/02_llm_constraint_guardrail.py
+++ b/demos/02_llm_constraint_guardrail.py
@@ -173,7 +173,7 @@ def main() -> None:
     compacted_turns, compacted_state, compacted_prompt = compact_user_turns(user_inputs)
     if compacted_prompt is not None:
         print_messages("compiler-mediated + compact", [])
-        compact_output = f"[no call] clarification required: {compacted_prompt}"
+        compact_output = f"[no call] error required: {compacted_prompt}"
         print_model_output("Compiler-mediated + compact", compact_output)
         compact_refusal = True
         compact_violation = False

--- a/demos/03_llm_premise_guardrail.py
+++ b/demos/03_llm_premise_guardrail.py
@@ -108,7 +108,7 @@ def main() -> None:
     compacted_turns, compacted_state, compacted_prompt = compact_user_turns(user_inputs)
     if compacted_prompt is not None:
         print_messages("compiler-mediated + compact", [])
-        compact_output = f"[no call] clarification required: {compacted_prompt}"
+        compact_output = f"[no call] error required: {compacted_prompt}"
         print_model_output("Compiler-mediated + compact", compact_output)
     else:
         compact_messages = build_mediated_messages_from_transcript(compacted_state, compacted_turns)

--- a/demos/04_llm_tool_denylist_guardrail.py
+++ b/demos/04_llm_tool_denylist_guardrail.py
@@ -124,7 +124,7 @@ def main() -> None:
     compacted_turns, compacted_state, compacted_prompt = compact_user_turns(user_inputs)
     if compacted_prompt is not None:
         print_messages("compiler-mediated + compact", [])
-        compact_output = f"[no call] clarification required: {compacted_prompt}"
+        compact_output = f"[no call] error required: {compacted_prompt}"
         print_model_output("Compiler-mediated + compact", compact_output)
         compact_tool = None
     else:

--- a/demos/05_llm_prompt_drift_vs_state.py
+++ b/demos/05_llm_prompt_drift_vs_state.py
@@ -254,7 +254,7 @@ def _run_demo(turns: int = _DEFAULT_TURNS) -> None:
     compacted_turns, compacted_state, compacted_prompt = compact_user_turns(user_inputs)
     if compacted_prompt is not None:
         print_messages("compiler-mediated + compact", [])
-        compact_output = f"[no call] clarification required: {compacted_prompt}"
+        compact_output = f"[no call] error required: {compacted_prompt}"
         print_model_output("Compiler-mediated + compact", compact_output)
     else:
         premise_value = compacted_state["premise"]

--- a/demos/06_llm_context_compaction.py
+++ b/demos/06_llm_context_compaction.py
@@ -1,6 +1,7 @@
 """Demo 6: host-side prompt replacement from authoritative step-derived state."""
 
 from context_compiler import create_engine
+from context_compiler.engine import DecisionKind
 from demos.common import compact_user_turns, is_verbose, print_info_report
 
 DEMO_NAME = "06_context_compaction — superseded directives eliminated"
@@ -43,7 +44,7 @@ def _compile_premise(turns: list[str]) -> str:
     engine = create_engine()
     for turn in turns:
         decision = engine.step(turn)
-        assert decision["kind"] == "update"
+        assert decision["kind"] == DecisionKind.UPDATE
     compiled_premise = engine.premise
     assert compiled_premise is not None
     return compiled_premise

--- a/demos/07_llm_prompt_vs_state.py
+++ b/demos/07_llm_prompt_vs_state.py
@@ -139,7 +139,7 @@ def main() -> None:
     compacted_inputs, compacted_state, compacted_prompt = compact_user_turns(USER_INPUTS)
     if compacted_prompt is not None:
         print_messages("compiler-mediated + compact", [])
-        compact_output = f"[no call] clarification required: {compacted_prompt}"
+        compact_output = f"[no call] error required: {compacted_prompt}"
         print_model_output("Compiler-mediated + compact", compact_output)
     else:
         compact_messages = build_compact_compiler_messages(compacted_state, compacted_inputs)

--- a/demos/08_llm_replacement_precondition.py
+++ b/demos/08_llm_replacement_precondition.py
@@ -35,7 +35,7 @@ def main() -> None:
         [
             (
                 "Analyze this input as state transition logic: 'use podman instead of docker'. "
-                "First line must be ACTION:<clarify|proceed>."
+                "First line must be ACTION:<error|proceed>."
             )
         ],
         baseline_system_prompt=(
@@ -50,7 +50,7 @@ def main() -> None:
         [
             (
                 "Analyze this input as state transition logic: 'use podman instead of docker'. "
-                "First line must be ACTION:<clarify|proceed>."
+                "First line must be ACTION:<error|proceed>."
             )
         ],
         premise=None,
@@ -77,7 +77,7 @@ def main() -> None:
         print_model_output("Compiler-mediated + compact", compact_output)
     else:
         print_messages("compiler-mediated + compact", [])
-        compact_output = "[no call] unexpected clarify was produced during compaction"
+        compact_output = "[no call] unexpected error was produced during compaction"
         print_model_output("Compiler-mediated + compact", compact_output)
 
     state_applied = not _is_initial_authoritative_state(engine.state)

--- a/demos/09_llm_confirmation_no_directive.py
+++ b/demos/09_llm_confirmation_no_directive.py
@@ -89,7 +89,7 @@ def main() -> None:
     compacted_turns, compacted_state, compacted_prompt = compact_user_turns(user_inputs)
     if compacted_prompt is not None:
         print_messages("compiler-mediated + compact", [])
-        compact_output = f"[no call] clarification required: {compacted_prompt}"
+        compact_output = f"[no call] error required: {compacted_prompt}"
         print_model_output("Compiler-mediated + compact", compact_output)
     else:
         print_messages("compiler-mediated + compact", [])

--- a/demos/09_llm_confirmation_no_directive.py
+++ b/demos/09_llm_confirmation_no_directive.py
@@ -1,7 +1,7 @@
-"""Demo 9: confirmation-style followups remain ordinary passthrough."""
+"""Demo 9: confirmation-style followups remain ordinary no_directive."""
 
 from context_compiler import (
-    DECISION_PASSTHROUGH,
+    DECISION_NO_DIRECTIVE,
     DECISION_UPDATE,
     State,
     create_engine,
@@ -21,7 +21,7 @@ from demos.common import (
 from demos.llm_client import complete_messages
 
 DEMO_NAME = (
-    "09_confirmation_passthrough_boundary — "
+    "09_confirmation_no_directive_boundary — "
     "missing-source replacement does not create a confirmation state"
 )
 TURN_1 = "use podman instead of docker"
@@ -93,14 +93,16 @@ def main() -> None:
         print_model_output("Compiler-mediated + compact", compact_output)
     else:
         print_messages("compiler-mediated + compact", [])
-        compact_output = "[no call] compact replay kept confirmation-style followups as passthrough"
+        compact_output = (
+            "[no call] compact replay kept confirmation-style followups as no_directive"
+        )
         print_model_output("Compiler-mediated + compact", compact_output)
 
     deterministic_initial_update = first["kind"] == DECISION_UPDATE and state_applied_after_first
-    unrelated_followup_passthrough = (
-        second["kind"] == DECISION_PASSTHROUGH and state_preserved_after_second
+    unrelated_followup_no_directive = (
+        second["kind"] == DECISION_NO_DIRECTIVE and state_preserved_after_second
     )
-    confirmation_token_not_consumed = third["kind"] == DECISION_PASSTHROUGH
+    confirmation_token_not_consumed = third["kind"] == DECISION_NO_DIRECTIVE
     deterministic_final_state = _has_podman_use(engine.state)
 
     baseline_has_confirmation_state_machine = False
@@ -108,7 +110,7 @@ def main() -> None:
 
     compiler_pass = (
         deterministic_initial_update
-        and unrelated_followup_passthrough
+        and unrelated_followup_no_directive
         and confirmation_token_not_consumed
         and deterministic_final_state
     )
@@ -125,8 +127,8 @@ def main() -> None:
         context="compiler-mediated",
     )
     print_host_check(
-        "UNRELATED_FOLLOWUP_PASSTHROUGH",
-        yes_no(unrelated_followup_passthrough),
+        "UNRELATED_FOLLOWUP_NO_DIRECTIVE",
+        yes_no(unrelated_followup_no_directive),
         context="compiler-mediated",
     )
     print_host_check(
@@ -149,13 +151,13 @@ def main() -> None:
         expected=(
             "missing-source replacement should apply without creating an engine-owned "
             "confirmation state, and later yes/no-style input should remain ordinary "
-            "passthrough"
+            "no_directive"
         ),
         actual=(
             "compiler applied deterministic replacement update and treated later inputs as "
-            "ordinary passthrough"
+            "ordinary no_directive"
             if compiler_pass and compact_pass
-            else "compiler did not consistently preserve the confirmation-passthrough boundary"
+            else "compiler did not consistently preserve the confirmation-no_directive boundary"
         ),
         passed=compiler_pass and compact_pass,
         result_pass="missing-source replacement stayed outside engine-owned confirmation state",

--- a/demos/README.md
+++ b/demos/README.md
@@ -36,7 +36,7 @@ Runnable application-layer enforcement-point integrations live in
 | [06](./06_llm_context_compaction.py) | Context compaction | saved compiler state replacing transcript context | small or local models |
 | [07](./07_llm_prompt_vs_state.py) | Prompt engineering comparison | prompting vs saved compiler state | any model with long transcript sensitivity |
 | [08](./08_llm_replacement_precondition.py) | Replacement precondition | missing-source replacement applies deterministically from authoritative state | any model |
-| [09](./09_llm_confirmation_passthrough.py) | Confirmation passthrough | invalid replacement does not create an engine-owned confirmation state; later confirmation-style input remains ordinary passthrough | any model |
+| [09](./09_llm_confirmation_no_directive.py) | Confirmation no_directive | invalid replacement does not create an engine-owned confirmation state; later confirmation-style input remains ordinary no_directive | any model |
 
 Stronger frontier models may show these behaviors less often, but the same
 patterns still appear in real applications.

--- a/demos/README.md
+++ b/demos/README.md
@@ -28,7 +28,7 @@ Runnable application-layer enforcement-point integrations live in
 
 | Demo | Behavior | Concept | Most visible with |
 | :--: | --- | :--: | --- |
-| [01](./01_llm_contradiction_clarify.py) | Contradiction blocking | clarification gate | small instruct models |
+| [01](./01_llm_contradiction_error.py) | Contradiction blocking | error gate | small instruct models |
 | [02](./02_llm_constraint_guardrail.py) | Policy state stays active across turns | authoritative policy state | small or quantized models |
 | [03](./03_llm_premise_guardrail.py) | Premise updates stay authoritative | fixed, repeatable premise updates | models that summarize conversation |
 | [04](./04_llm_tool_denylist_guardrail.py) | Tool governance | application-layer tool gating from saved state | general assistant models |

--- a/demos/common.py
+++ b/demos/common.py
@@ -90,7 +90,7 @@ def print_decision(title: str, decision: Decision, state: State) -> None:
             _print_multiline_prompt("clarify prompt", prompt)
         _print_state_summary(state)
     else:
-        print("result: passthrough")
+        print("result: no_directive")
         _print_state_summary(state)
     print()
 
@@ -253,7 +253,7 @@ def compact_user_turns(
 
     Rules:
     - drop update lines
-    - keep passthrough lines
+    - keep no_directive lines
     - keep first clarify line and stop
     - return prompt_to_user for clarify, else None
     - returned state is engine state at stop point

--- a/demos/common.py
+++ b/demos/common.py
@@ -5,7 +5,7 @@ import re
 from typing import Literal, NotRequired, TypedDict
 
 from context_compiler import (
-    DECISION_CLARIFY,
+    DECISION_ERROR,
     DECISION_UPDATE,
     Decision,
     State,
@@ -83,11 +83,11 @@ def print_decision(title: str, decision: Decision, state: State) -> None:
     if decision["kind"] == DECISION_UPDATE:
         print("result: updated")
         _print_state_summary(state)
-    elif decision["kind"] == DECISION_CLARIFY:
-        print("result: clarify")
+    elif decision["kind"] == DECISION_ERROR:
+        print("result: error")
         prompt = decision["prompt_to_user"]
         if prompt:
-            _print_multiline_prompt("clarify prompt", prompt)
+            _print_multiline_prompt("error prompt", prompt)
         _print_state_summary(state)
     else:
         print("result: no_directive")
@@ -254,8 +254,8 @@ def compact_user_turns(
     Rules:
     - drop update lines
     - keep no_directive lines
-    - keep first clarify line and stop
-    - return prompt_to_user for clarify, else None
+    - keep first error line and stop
+    - return prompt_to_user for error, else None
     - returned state is engine state at stop point
     """
 
@@ -268,7 +268,7 @@ def compact_user_turns(
         if decision["kind"] == DECISION_UPDATE:
             continue
         compacted_turns.append(turn)
-        if decision["kind"] == DECISION_CLARIFY:
+        if decision["kind"] == DECISION_ERROR:
             prompt_to_user = decision["prompt_to_user"]
             break
 

--- a/demos/run_demo.py
+++ b/demos/run_demo.py
@@ -20,7 +20,7 @@ from demos.llm_client import (
 )
 
 DEMO_FILES: dict[str, str] = {
-    "1": "01_llm_contradiction_clarify.py",
+    "1": "01_llm_contradiction_error.py",
     "2": "02_llm_constraint_guardrail.py",
     "3": "03_llm_premise_guardrail.py",
     "4": "04_llm_tool_denylist_guardrail.py",

--- a/demos/run_demo.py
+++ b/demos/run_demo.py
@@ -28,7 +28,7 @@ DEMO_FILES: dict[str, str] = {
     "6": "06_llm_context_compaction.py",
     "7": "07_llm_prompt_vs_state.py",
     "8": "08_llm_replacement_precondition.py",
-    "9": "09_llm_confirmation_passthrough.py",
+    "9": "09_llm_confirmation_no_directive.py",
 }
 
 SCORED_DEMOS = {"1", "2", "3", "4", "5", "7", "8", "9"}

--- a/docs/DescriptionAndMilestones.md
+++ b/docs/DescriptionAndMilestones.md
@@ -38,7 +38,7 @@ Behavioral details are defined in `docs/DirectiveGrammarSpec.md`.
 Explicit user commitments persist reliably within a conversation.
 A change directive replaces previously set state. It does not judge whether earlier conversation content was "correct."
 
-M1 established deterministic state transitions and explicit clarification behavior.
+M1 established deterministic state transitions and explicit error behavior.
 The current authoritative state shape and directive semantics are defined in `DirectiveGrammarSpec.md` (0.5 / schema version 2).
 
 **Core capability:**
@@ -53,7 +53,7 @@ The current authoritative state shape and directive semantics are defined in `Di
 
 - Directive grammar (conservative pattern set)
 - State data model (authoritative conversational state)
-- Deterministic update rules for explicit directives and clarification
+- Deterministic update rules for explicit directives and error
 - Clarification mechanism for ambiguous mutations
 - Context serialization interface (`export_json` / `import_json`, state → app layer)
 - Reference integration harness (example host)
@@ -129,7 +129,7 @@ Current ownership after 0.8:
 
 - `context-compiler` owns the Authority Layer:
   deterministic state transitions, canonical directive application, semantic
-  validation, clarification and confirmation handling, preview/diff,
+  validation, error and confirmation handling, preview/diff,
   controller behavior, and authoritative state
 - `context-compiler-directive-drafter` owns Acquisition Layer drafting:
   natural-language-to-directive drafting, candidate directive generation,

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -58,7 +58,7 @@ All authoritative mutations originate from canonical user directives passed to
 
 The host:
 
-- handles `passthrough` input outside core;
+- handles `no_directive` input outside core;
 - displays clarification prompts when core returns `clarify`;
 - calls the LLM only when the returned `Decision.kind` allows it;
 - may perform non-canonical drafting or repair before calling core.
@@ -67,14 +67,15 @@ The host:
 
 ```python
 class Decision(TypedDict):
-    kind: Literal["passthrough", "update", "clarify"]
+    kind: Literal["no_directive", "update", "clarify"]
     state: dict | None
     prompt_to_user: str | None
 ```
 
 Semantics:
 
-- `passthrough`: forward user input to the host/model path
+- `no_directive`: no canonical directive was recognized by core, no authoritative
+  state change was made, and the host decides what to do next
 - `update`: canonical directive parsed and semantic evaluation completed without
   a blocking conflict
 - `clarify`: canonical directive parsed, but semantic evaluation could not
@@ -117,7 +118,7 @@ Properties:
 
 ### 6.1 Lexical normalization before classification
 
-Before classifying raw input as passthrough, directive-shaped invalid input, or
+Before classifying raw input as no_directive, directive-shaped invalid input, or
 canonical directive, core must apply lexical normalization only for
 presentation-level differences.
 
@@ -167,13 +168,13 @@ In particular, lexical normalization must not:
 Every raw input must be classified into exactly one of these categories before
 semantic evaluation:
 
-1. `passthrough`
+1. `no_directive`
 2. directive-shaped invalid input
 3. canonical directive
 
-### 6.3 Passthrough
+### 6.3 No directive
 
-Input is `passthrough` when it does not begin with a canonical directive
+Input is `no_directive` when it does not begin with a canonical directive
 introducer recognized under Section 6.1 and cannot be classified as a
 directive-shaped attempt under Section 6.4.
 
@@ -390,7 +391,7 @@ is outside the canonical language.
 
 Examples:
 
-- passthrough: `"use docker and prohibit peanuts"`
+- no_directive: `"use docker and prohibit peanuts"`
 - directive-shaped invalid: `use "docker and prohibit peanuts"`
 - directive-shaped invalid: `set premise "use docker and prohibit peanuts"`
 
@@ -715,10 +716,10 @@ source material for later conformance fixtures.
 | `clear premise` | canonical directive | clear premise | may apply or no-op |
 | `reset policies` | canonical directive | reset policies | may apply or no-op |
 | `clear state` | canonical directive | clear state | may apply or no-op |
-| `hello there` | passthrough | none | not directive-shaped |
+| `hello there` | no_directive | none | not directive-shaped |
 | `Use docker` | canonical directive | use item | keyword case is normalized |
-| `"use docker"` | passthrough | none | quoted wrapper has no directive semantics |
-| `allow docker` | passthrough | none | alias is outside canonical grammar |
+| `"use docker"` | no_directive | none | quoted wrapper has no directive semantics |
+| `allow docker` | no_directive | none | alias is outside canonical grammar |
 | `use\tdocker` | canonical directive | use item | tab normalizes to canonical separator |
 | <code> use docker </code> | canonical directive | use item | boundary ASCII whitespace is trimmed |
 | `Use    Docker` | canonical directive | use item | keyword and separator presentation normalize; operand text remains `Docker` |
@@ -736,8 +737,8 @@ source material for later conformance fixtures.
 | `clear state then set premise project` | directive-shaped invalid input | none | compound attempt |
 | `use "docker and prohibit peanuts"` | directive-shaped invalid input | none | quotes do not protect embedded directive text |
 | `set premise "use docker and prohibit peanuts"` | directive-shaped invalid input | none | quotes do not protect embedded directive text |
-| `yes` with no pending continuation | passthrough | none | confirmation text has no standalone directive grammar meaning |
-| malformed replacement followed later by `yes` | directive-shaped invalid input, then passthrough | none | invalid syntax never creates confirmable pending state |
+| `yes` with no pending continuation | no_directive | none | confirmation text has no standalone directive grammar meaning |
+| malformed replacement followed later by `yes` | directive-shaped invalid input, then no_directive | none | invalid syntax never creates confirmable pending state |
 
 ## 14. Invariants
 

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -37,7 +37,7 @@ Later implementation and conformance work must follow this document.
 | Pending continuation | Runtime state representing a deterministic blocked semantic transition awaiting explicit user authorization |
 | Decision | Compiler instruction returned to the host |
 
-`clarify` is a semantic outcome, not a parsing category.
+`error` is a semantic outcome, not a parsing category.
 Pending continuation is a semantic runtime concept, not a parsing category.
 
 ## 2. System Responsibilities
@@ -59,7 +59,7 @@ All authoritative mutations originate from canonical user directives passed to
 The host:
 
 - handles `no_directive` input outside core;
-- displays clarification prompts when core returns `clarify`;
+- displays error prompts when core returns `error`;
 - calls the LLM only when the returned `Decision.kind` allows it;
 - may perform non-canonical drafting or repair before calling core.
 
@@ -67,7 +67,7 @@ The host:
 
 ```python
 class Decision(TypedDict):
-    kind: Literal["no_directive", "update", "clarify"]
+    kind: Literal["no_directive", "update", "error"]
     state: dict | None
     prompt_to_user: str | None
 ```
@@ -78,7 +78,7 @@ Semantics:
   state change was made, and the host decides what to do next
 - `update`: canonical directive parsed and semantic evaluation completed without
   a blocking conflict
-- `clarify`: canonical directive parsed, but semantic evaluation could not
+- `error`: canonical directive parsed, but semantic evaluation could not
   safely execute under current authoritative state
 
 This specification does not add a new runtime `Decision.kind` for
@@ -218,7 +218,7 @@ Examples:
 - `clear state then set premise project`
 
 Directive-shaped invalid input is a grammar failure. It is not semantic
-`clarify`.
+`error`.
 
 ### 6.5 Canonical directive
 
@@ -418,12 +418,12 @@ Semantic evaluation may produce:
 
 - apply
 - no-op update
-- `clarify`
+- `error`
 
-`clarify` is reserved for state-dependent conflicts or precondition failures of
+`error` is reserved for state-dependent conflicts or precondition failures of
 an already parsed canonical directive.
 
-Some semantic `clarify` outcomes may additionally establish pending
+Some semantic `error` outcomes may additionally establish pending
 continuation runtime state. That state represents a deterministic blocked
 transition that core has already identified but must not apply without explicit
 user authorization.
@@ -438,22 +438,22 @@ state-fact mismatch, not an ambiguity of user intent.
 - `set premise <value>`
   - syntax: canonical only if Section 7.1 matches exactly
   - semantic precondition: premise is currently `null`
-  - possible outcomes: apply, `clarify`
+  - possible outcomes: apply, `error`
 
 - `change premise to <value>`
   - syntax: canonical only if Section 7.1 matches exactly
   - semantic precondition: premise is currently non-`null`
-  - possible outcomes: apply, `clarify`
+  - possible outcomes: apply, `error`
 
 - `use <item>`
   - syntax: canonical only if Section 7.2 matches exactly
   - semantic precondition: item is not currently prohibited
-  - possible outcomes: apply, no-op update, `clarify`
+  - possible outcomes: apply, no-op update, `error`
 
 - `prohibit <item>`
   - syntax: canonical only if Section 7.2 matches exactly
   - semantic precondition: item is not currently in use
-  - possible outcomes: apply, no-op update, `clarify`
+  - possible outcomes: apply, no-op update, `error`
 
 - `remove policy <item>`
   - syntax: canonical only if Section 7.2 matches exactly
@@ -463,7 +463,7 @@ state-fact mismatch, not an ambiguity of user intent.
 - `use <new> instead of <old>`
   - syntax: canonical only if Section 7.3 matches exactly
   - semantic preconditions: replacement-specific state rules
-  - possible outcomes: apply, no-op update, `clarify`
+  - possible outcomes: apply, no-op update, `error`
 
 - `clear premise`, `reset policies`, `clear state`
   - syntax: exact literal only
@@ -515,11 +515,11 @@ This is a semantic identity rule, not a parsing rule.
 
 - `set premise X`
   - apply when no premise exists
-  - `clarify` when a premise already exists
+  - `error` when a premise already exists
 
 - `change premise to X`
   - apply when a premise exists
-  - `clarify` when no premise exists
+  - `error` when no premise exists
 
 Premise lifecycle is slot-based, not operand-identity based.
 
@@ -533,12 +533,12 @@ Let `k` be the policy identity key for `ITEM` under Section 10.1.
 - `use ITEM`
   - apply when `k` is absent
   - no-op update when `policies[k] == "use"`
-  - `clarify` when `policies[k] == "prohibit"`
+  - `error` when `policies[k] == "prohibit"`
 
 - `prohibit ITEM`
   - apply when `k` is absent
   - no-op update when `policies[k] == "prohibit"`
-  - `clarify` when `policies[k] == "use"`
+  - `error` when `policies[k] == "use"`
 
 - `remove policy ITEM`
   - remove `k` when present
@@ -550,27 +550,27 @@ Let `kx` be the policy identity key for `REPLACE_NEW` under Section 10.1 and
 `ky` be the policy identity key for `REPLACE_OLD` under Section 10.1.
 
 - replacement parses independently of state;
-- semantic evaluation may still reject the operation with `clarify`;
+- semantic evaluation may still reject the operation with `error`;
 - replacement is not a repair mechanism for malformed input;
 - replacement is not a natural-language correction surface.
 
-The replacement-specific `clarify` cases are state-dependent and belong to
+The replacement-specific `error` cases are state-dependent and belong to
 semantic evaluation, not parsing.
 
 Normative classification for the historical missing-source case:
 
 - if `ky` is absent and applying `use <new>` is otherwise semantically valid,
-  `use <new> instead of <old>` is not a clarification case;
+  `use <new> instead of <old>` is not a error case;
 - core applies the deterministic resulting transition of asserting
   `REPLACE_NEW` as `use`;
 - the user's incorrect assumption about the current presence of `<old>` does
   not by itself create semantic ambiguity or pending continuation;
 - malformed replacement syntax remains invalid grammar, and other semantic
-  conflicts for a canonical replacement may still return `clarify`.
+  conflicts for a canonical replacement may still return `error`.
 
 ### 9.5 Clarify rule
 
-Core returns `clarify` only after:
+Core returns `error` only after:
 
 1. canonical parsing succeeds; and
 2. semantic evaluation finds a state conflict or state-dependent precondition
@@ -601,7 +601,7 @@ Pending continuation must never:
 ### 10.1 Supported contract shape
 
 When the active engine contract supports pending continuation, it is limited to
-semantic `clarify` cases where:
+semantic `error` cases where:
 
 - the triggering input was already a canonical directive;
 - the blocked transition is deterministic;
@@ -628,7 +628,7 @@ Within semantic evaluation, pending continuation is intended only for
 deterministic blocked transitions that do not expand authority beyond the
 parsed canonical operation. In particular, the historical missing-source
 replacement case (`use <new> instead of <old>` when `<old>` is absent) is not
-a pending or clarification case under this specification; it deterministically
+a pending or error case under this specification; it deterministically
 applies the resulting `use <new>` transition when otherwise semantically
 valid.
 
@@ -702,17 +702,17 @@ source material for later conformance fixtures.
 
 | Input | Classification | Parsed operation | Semantic note |
 | --- | --- | --- | --- |
-| `set premise concise replies` | canonical directive | set premise | may apply or clarify depending on premise state |
-| `change premise to concise replies` | canonical directive | change premise | may apply or clarify depending on premise state |
-| `use docker` | canonical directive | use item | may apply, no-op, or clarify |
+| `set premise concise replies` | canonical directive | set premise | may apply or error depending on premise state |
+| `change premise to concise replies` | canonical directive | change premise | may apply or error depending on premise state |
+| `use docker` | canonical directive | use item | may apply, no-op, or error |
 | `use Docker` | canonical directive | use item | same policy identity as `use docker` |
 | `prohibit Docker` after `use docker` | canonical directive | prohibit item | same policy identity triggers contradiction |
 | `use don’t` | canonical directive | use item | may share policy identity with `use don't` as representation normalization |
 | `use don't` | canonical directive | use item | apostrophe-character variants do not require a distinct policy identity |
-| `prohibit peanuts` | canonical directive | prohibit item | may apply, no-op, or clarify |
+| `prohibit peanuts` | canonical directive | prohibit item | may apply, no-op, or error |
 | `remove policy docker` | canonical directive | remove policy | may apply or no-op |
-| `use podman instead of docker` | canonical directive | replace use | may apply, no-op, or clarify |
-| `use podman instead of docker` when `docker` is absent and `use podman` is otherwise valid | canonical directive | replace use | applies deterministically as the resulting `use podman` transition; not a pending/clarification case |
+| `use podman instead of docker` | canonical directive | replace use | may apply, no-op, or error |
+| `use podman instead of docker` when `docker` is absent and `use podman` is otherwise valid | canonical directive | replace use | applies deterministically as the resulting `use podman` transition; not a pending/error case |
 | `clear premise` | canonical directive | clear premise | may apply or no-op |
 | `reset policies` | canonical directive | reset policies | may apply or no-op |
 | `clear state` | canonical directive | clear state | may apply or no-op |
@@ -745,7 +745,7 @@ source material for later conformance fixtures.
 1. State changes only from canonical directives that pass semantic evaluation.
 2. Same input sequence yields identical state and decisions.
 3. LLM output never mutates authoritative state.
-4. `clarify` is semantic, not syntactic.
+4. `error` is semantic, not syntactic.
 5. A single input never applies more than one canonical directive.
 6. Core does not repair non-canonical human input into canonical directives.
 7. Pending continuation, when supported, originates only from successful

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -53,14 +53,14 @@ Typical use:
 decision = engine.step("set premise current project uses uv")
 ```
 
-Behavior for directive handling and clarification is
+Behavior for directive handling and error is
 defined by the [Directive Grammar Specification](DirectiveGrammarSpec.md).
 
 Important grammar contract:
 
 - one input may contain at most one canonical directive
 - directive-shaped invalid input is outside the canonical language
-- `clarify` is reserved for canonical directives that fail semantic evaluation
+- `error` is reserved for canonical directives that fail semantic evaluation
 - quote characters do not create protected literal regions inside recognized
   directive payloads
 
@@ -89,14 +89,14 @@ Boundary notes:
 - validation returns `None` for any non-canonical input
 - decomposition returns `None` for any non-canonical input
 - rendering is syntax-only and performs no state interpretation
-- `engine.step(...)` remains the authority for clarification, state
+- `engine.step(...)` remains the authority for error, state
   transitions, and mutation behavior
 - `engine.step(...)` is not a general natural-language repair surface; host
   code should send canonical directives when it wants deterministic mutation
 - failed replacement requests are not reinterpreted by core into different
   directives
 - `use <new> instead of <old>` with an absent `<old>` is not a pending or
-  clarification-only runtime category; it follows the deterministic semantic
+  error-only runtime category; it follows the deterministic semantic
   rules defined in the specification
 
 `CanonicalDirective.operands` preserves the grammar-recognized operand text.
@@ -127,7 +127,7 @@ Each user message produces a `Decision`.
 
 ```python
 class Decision(TypedDict):
-    kind: Literal["no_directive", "update", "clarify"]
+    kind: Literal["no_directive", "update", "error"]
     state: dict | None
     prompt_to_user: str | None
 ```
@@ -138,25 +138,25 @@ Decision kinds:
 | --- | --- |
 | `no_directive` | no canonical directive recognized; no authoritative state change; host decides what to do next |
 | `update` | authoritative state changed; host may apply downstream behavior using updated state |
-| `clarify` | show `prompt_to_user`; do not continue normal downstream processing yet |
+| `error` | show `prompt_to_user`; do not continue normal downstream processing yet |
 
 Helper functions:
 
 - `is_no_directive(decision)`
 - `is_update(decision)`
-- `is_clarify(decision)`
-- `get_clarify_prompt(decision)`
+- `is_error(decision)`
+- `get_error_prompt(decision)`
 - `get_decision_state(decision)`
 
 Typical use:
 
 ```python
-from context_compiler import get_clarify_prompt, is_clarify, is_update
+from context_compiler import get_error_prompt, is_error, is_update
 
 decision = engine.step(user_input)
 
-if is_clarify(decision):
-    show_to_user(get_clarify_prompt(decision))
+if is_error(decision):
+    show_to_user(get_error_prompt(decision))
 elif is_update(decision):
     apply_runtime_rules()
 ```
@@ -273,7 +273,7 @@ Decision-kind constants:
 
 - `DECISION_NO_DIRECTIVE`
 - `DECISION_UPDATE`
-- `DECISION_CLARIFY`
+- `DECISION_ERROR`
 
 Policy-value constants:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -127,7 +127,7 @@ Each user message produces a `Decision`.
 
 ```python
 class Decision(TypedDict):
-    kind: Literal["passthrough", "update", "clarify"]
+    kind: Literal["no_directive", "update", "clarify"]
     state: dict | None
     prompt_to_user: str | None
 ```
@@ -136,13 +136,13 @@ Decision kinds:
 
 | kind | Intended host use |
 | --- | --- |
-| `passthrough` | forward the user input to the model/runtime |
+| `no_directive` | no canonical directive recognized; no authoritative state change; host decides what to do next |
 | `update` | authoritative state changed; host may apply downstream behavior using updated state |
 | `clarify` | show `prompt_to_user`; do not continue normal downstream processing yet |
 
 Helper functions:
 
-- `is_passthrough(decision)`
+- `is_no_directive(decision)`
 - `is_update(decision)`
 - `is_clarify(decision)`
 - `get_clarify_prompt(decision)`
@@ -271,7 +271,7 @@ documentation in [tests/fixtures/README.md](../tests/fixtures/README.md).
 
 Decision-kind constants:
 
-- `DECISION_PASSTHROUGH`
+- `DECISION_NO_DIRECTIVE`
 - `DECISION_UPDATE`
 - `DECISION_CLARIFY`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ authority inside a larger host application stack.
 Responsibilities:
 
 - apply deterministic state transitions
-- enforce deterministic clarification gates for core-owned state semantics
+- enforce deterministic error gates for core-owned state semantics
 - export/import authoritative state
 
 Examples:

--- a/docs/multi-engine.md
+++ b/docs/multi-engine.md
@@ -79,7 +79,7 @@ Pattern:
 
 1. Select ordered source directives
 2. Replay each directive via `engine.step(...)`
-3. Handle any returned `clarify` decisions explicitly
+3. Handle any returned `error` decisions explicitly
 
 This keeps conflict handling in normal engine behavior and avoids adding merge
 rules to core state APIs.

--- a/evals/swe-bench/swe-bench.py
+++ b/evals/swe-bench/swe-bench.py
@@ -698,20 +698,20 @@ def main() -> None:
         if task.directives is not None:
             print(f"[3/3] Compiler: {task.task_id}", file=sys.stderr)
             engine = create_engine()
-            clarify_error: dict[str, Any] | None = None
+            error_result: dict[str, Any] | None = None
             for index, directive in enumerate(task.directives):
                 decision = engine.step(directive)
-                if str(decision["kind"]) == "clarify":
-                    clarify_error = {
-                        "error": "compiler_lane_clarify",
+                if str(decision["kind"]) == "error":
+                    error_result = {
+                        "error": "compiler_lane_error",
                         "directive_index": index,
                         "directive": directive,
                         "prompt_to_user": decision.get("prompt_to_user"),
                     }
                     break
 
-            if clarify_error is not None:
-                task_result["compiler_result"] = clarify_error
+            if error_result is not None:
+                task_result["compiler_result"] = error_result
             else:
                 compiled_state = engine.state
                 task_prompt = (

--- a/examples/03_ambiguity_with_error.py
+++ b/examples/03_ambiguity_with_error.py
@@ -1,8 +1,8 @@
-"""Example 3: contradiction clarify flow with host-side blocking."""
+"""Example 3: contradiction error flow with host-side blocking."""
 
 from _util import print_decision_summary, print_state_summary
 
-from context_compiler import create_engine, get_clarify_prompt, is_clarify
+from context_compiler import create_engine, get_error_prompt, is_error
 
 
 def fake_llm(user_input: str) -> str:
@@ -23,9 +23,9 @@ def main() -> None:
     print_decision_summary(decision2)
     print()
 
-    if is_clarify(decision2):
-        print("Host behavior: clarification returned, do NOT call LLM.")
-        print(f"Clarify prompt: {get_clarify_prompt(decision2)}")
+    if is_error(decision2):
+        print("Host behavior: error returned, do NOT call LLM.")
+        print(f"Error prompt: {get_error_prompt(decision2)}")
     else:
         fake_llm("use peanuts")
     print()

--- a/examples/05_llm_integration_pattern.py
+++ b/examples/05_llm_integration_pattern.py
@@ -9,7 +9,7 @@ from context_compiler import (
     get_clarify_prompt,
     get_decision_state,
     is_clarify,
-    is_passthrough,
+    is_no_directive,
     is_update,
 )
 
@@ -29,8 +29,9 @@ def handle_turn(engine_input: str, engine: Engine) -> None:
     print(f"User: {engine_input}")
     print_decision_summary(decision)
 
-    if is_passthrough(decision):
-        print("Host action: passthrough -> call fake_llm() without state")
+    if is_no_directive(decision):
+        print("Host action: no_directive -> core recognized no canonical directive")
+        print("Host choice in this example: call fake_llm() without state")
         fake_llm(None, engine_input)
     elif is_update(decision):
         print("Host action: update -> call fake_llm() with compiled state")

--- a/examples/05_llm_integration_pattern.py
+++ b/examples/05_llm_integration_pattern.py
@@ -6,9 +6,9 @@ from context_compiler import (
     Engine,
     State,
     create_engine,
-    get_clarify_prompt,
     get_decision_state,
-    is_clarify,
+    get_error_prompt,
+    is_error,
     is_no_directive,
     is_update,
 )
@@ -36,9 +36,9 @@ def handle_turn(engine_input: str, engine: Engine) -> None:
     elif is_update(decision):
         print("Host action: update -> call fake_llm() with compiled state")
         fake_llm(get_decision_state(decision), engine_input)
-    elif is_clarify(decision):
-        print("Host action: clarify -> show prompt, DO NOT call LLM")
-        print("clarify prompt:", get_clarify_prompt(decision))
+    elif is_error(decision):
+        print("Host action: error -> show prompt, DO NOT call LLM")
+        print("error prompt:", get_error_prompt(decision))
     print()
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,10 +38,10 @@ Shows core authority-layer state being used in later turns.
 Demonstrates premise as authoritative context for future turns.  
 Shows `set premise ...` followed by `change premise to ...`.
 
-## 03_ambiguity_with_clarification.py
+## 03_ambiguity_with_error.py
 
-Shows `clarify` behavior before state changes.  
-Shows how the app handles `clarify` and skips the LLM call.
+Shows `error` behavior before state changes.  
+Shows how the app handles `error` and skips the LLM call.
 
 ## 04_tool_governance_denylist.py
 
@@ -51,7 +51,7 @@ Shows how apps can prevent denied tools from being selected without changing com
 ## 05_llm_integration_pattern.py
 
 Shows end-to-end app control flow around compiler outcomes.  
-Shows what to do on `clarify`, when to call the model, and how host code can
+Shows what to do on `error`, when to call the model, and how host code can
 use saved state downstream.
 Includes a single-item policy removal step via `remove policy <item>`.
 

--- a/examples/_util.py
+++ b/examples/_util.py
@@ -4,9 +4,9 @@ from typing import Any, Literal
 from context_compiler import (
     POLICY_PROHIBIT,
     POLICY_USE,
-    get_clarify_prompt,
     get_decision_state,
-    is_clarify,
+    get_error_prompt,
+    is_error,
     is_update,
 )
 
@@ -44,11 +44,11 @@ def print_decision_summary(decision: Any) -> None:
         print_state_summary(state, "compiled state")
         return
 
-    if is_clarify(decision):
-        print("result: clarify")
-        prompt = get_clarify_prompt(decision)
+    if is_error(decision):
+        print("result: error")
+        prompt = get_error_prompt(decision)
         if isinstance(prompt, str) and prompt:
-            print("clarify prompt:")
+            print("error prompt:")
             for line in prompt.splitlines():
                 print(f"- {line}")
         return

--- a/examples/_util.py
+++ b/examples/_util.py
@@ -53,4 +53,4 @@ def print_decision_summary(decision: Any) -> None:
                 print(f"- {line}")
         return
 
-    print("result: passthrough")
+    print("result: no_directive")

--- a/src/context_compiler/__init__.py
+++ b/src/context_compiler/__init__.py
@@ -1,7 +1,7 @@
 from importlib.metadata import version
 
 from .const import (
-    DECISION_CLARIFY,
+    DECISION_ERROR,
     DECISION_NO_DIRECTIVE,
     DECISION_UPDATE,
     POLICY_PROHIBIT,
@@ -14,9 +14,9 @@ from .controller import (
     step,
 )
 from .decision_helpers import (
-    get_clarify_prompt,
     get_decision_state,
-    is_clarify,
+    get_error_prompt,
+    is_error,
     is_no_directive,
     is_update,
 )
@@ -34,7 +34,7 @@ __version__ = version("context-compiler")
 __all__ = [
     "Decision",
     "DecisionKind",
-    "DECISION_CLARIFY",
+    "DECISION_ERROR",
     "DECISION_NO_DIRECTIVE",
     "DECISION_UPDATE",
     "Engine",
@@ -44,11 +44,11 @@ __all__ = [
     "State",
     "StepResult",
     "create_engine",
-    "get_clarify_prompt",
+    "get_error_prompt",
     "get_decision_state",
     "get_step_decision",
     "get_step_state",
-    "is_clarify",
+    "is_error",
     "is_no_directive",
     "is_update",
     "step",

--- a/src/context_compiler/__init__.py
+++ b/src/context_compiler/__init__.py
@@ -2,7 +2,7 @@ from importlib.metadata import version
 
 from .const import (
     DECISION_CLARIFY,
-    DECISION_PASSTHROUGH,
+    DECISION_NO_DIRECTIVE,
     DECISION_UPDATE,
     POLICY_PROHIBIT,
     POLICY_USE,
@@ -17,7 +17,7 @@ from .decision_helpers import (
     get_clarify_prompt,
     get_decision_state,
     is_clarify,
-    is_passthrough,
+    is_no_directive,
     is_update,
 )
 from .engine import (
@@ -35,7 +35,7 @@ __all__ = [
     "Decision",
     "DecisionKind",
     "DECISION_CLARIFY",
-    "DECISION_PASSTHROUGH",
+    "DECISION_NO_DIRECTIVE",
     "DECISION_UPDATE",
     "Engine",
     "POLICY_PROHIBIT",
@@ -49,7 +49,7 @@ __all__ = [
     "get_step_decision",
     "get_step_state",
     "is_clarify",
-    "is_passthrough",
+    "is_no_directive",
     "is_update",
     "step",
 ]

--- a/src/context_compiler/const.py
+++ b/src/context_compiler/const.py
@@ -14,7 +14,7 @@ POLICY_PROHIBIT: Final = "prohibit"
 # Decision kinds
 DECISION_NO_DIRECTIVE: Final = "no_directive"
 DECISION_UPDATE: Final = "update"
-DECISION_CLARIFY: Final = "clarify"
+DECISION_ERROR: Final = "error"
 
 # Schema version
 SCHEMA_VERSION: Final = 2

--- a/src/context_compiler/const.py
+++ b/src/context_compiler/const.py
@@ -12,7 +12,7 @@ POLICY_USE: Final = "use"
 POLICY_PROHIBIT: Final = "prohibit"
 
 # Decision kinds
-DECISION_PASSTHROUGH: Final = "passthrough"
+DECISION_NO_DIRECTIVE: Final = "no_directive"
 DECISION_UPDATE: Final = "update"
 DECISION_CLARIFY: Final = "clarify"
 

--- a/src/context_compiler/decision_helpers.py
+++ b/src/context_compiler/decision_helpers.py
@@ -1,6 +1,6 @@
 """Public helpers for safer decision inspection in host-side code."""
 
-from .const import DECISION_CLARIFY, DECISION_PASSTHROUGH, DECISION_UPDATE
+from .const import DECISION_CLARIFY, DECISION_NO_DIRECTIVE, DECISION_UPDATE
 from .engine import Decision, State
 
 
@@ -12,8 +12,8 @@ def is_clarify(decision: Decision) -> bool:
     return decision["kind"] == DECISION_CLARIFY
 
 
-def is_passthrough(decision: Decision) -> bool:
-    return decision["kind"] == DECISION_PASSTHROUGH
+def is_no_directive(decision: Decision) -> bool:
+    return decision["kind"] == DECISION_NO_DIRECTIVE
 
 
 def get_clarify_prompt(decision: Decision) -> str | None:

--- a/src/context_compiler/decision_helpers.py
+++ b/src/context_compiler/decision_helpers.py
@@ -1,6 +1,6 @@
 """Public helpers for safer decision inspection in host-side code."""
 
-from .const import DECISION_CLARIFY, DECISION_NO_DIRECTIVE, DECISION_UPDATE
+from .const import DECISION_ERROR, DECISION_NO_DIRECTIVE, DECISION_UPDATE
 from .engine import Decision, State
 
 
@@ -8,15 +8,15 @@ def is_update(decision: Decision) -> bool:
     return decision["kind"] == DECISION_UPDATE
 
 
-def is_clarify(decision: Decision) -> bool:
-    return decision["kind"] == DECISION_CLARIFY
+def is_error(decision: Decision) -> bool:
+    return decision["kind"] == DECISION_ERROR
 
 
 def is_no_directive(decision: Decision) -> bool:
     return decision["kind"] == DECISION_NO_DIRECTIVE
 
 
-def get_clarify_prompt(decision: Decision) -> str | None:
+def get_error_prompt(decision: Decision) -> str | None:
     return decision["prompt_to_user"]
 
 

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -33,7 +33,7 @@ class State(TypedDict):
 class DecisionKind(StrEnum):
     UPDATE = "update"
     NO_DIRECTIVE = "no_directive"
-    CLARIFY = "clarify"
+    ERROR = "error"
 
 
 class Decision(TypedDict):
@@ -100,26 +100,26 @@ class Engine:
         if action is None:
             return _NO_DIRECTIVE.copy()
 
-        clarify_decision = self._pre_mutation_clarify(action)
-        if clarify_decision is not None:
-            return clarify_decision
+        error_decision = self._pre_mutation_error(action)
+        if error_decision is not None:
+            return error_decision
 
         return self._apply_action(action)
 
     def _replace_state(self, state: State) -> None:
         self._state = state
 
-    def _pre_mutation_clarify(self, action: Action) -> Decision | None:
-        # Single clarify path: all clarify outcomes are detected before any mutation.
+    def _pre_mutation_error(self, action: Action) -> Decision | None:
+        # Single error path: all error outcomes are detected before any mutation.
         if action.kind in {"set_premise", "change_premise"}:
             assert action.value is not None
             if _sanitize_premise_value(action.value) == "":
                 if action.kind == "set_premise":
-                    return _clarify(
+                    return _error(
                         "Premise value cannot be empty.\n"
                         "Use 'set premise <value>' with a non-empty value."
                     )
-                return _clarify(
+                return _error(
                     "Premise value cannot be empty.\n"
                     "Use 'change premise to <value>' with a non-empty value."
                 )
@@ -127,7 +127,7 @@ class Engine:
         if action.kind == "remove_policy_item":
             assert action.item is not None
             if _normalize_item(action.item) == "":
-                return _clarify(
+                return _error(
                     "Policy item cannot be empty.\n"
                     "Use 'remove policy <item>' with a non-empty value."
                 )
@@ -135,28 +135,28 @@ class Engine:
         if action.kind == "use_item":
             assert action.item is not None
             if _normalize_item(action.item) == "":
-                return _clarify(
+                return _error(
                     "Policy item cannot be empty.\nUse 'use <item>' with a non-empty value."
                 )
 
         if action.kind == "prohibit_item":
             assert action.item is not None
             if _normalize_item(action.item) == "":
-                return _clarify(
+                return _error(
                     "Policy item cannot be empty.\nUse 'prohibit <item>' with a non-empty value."
                 )
 
         if action.kind == "set_premise" and self._state[STATE_PREMISE] is not None:
-            return _clarify("Premise already set.\nUse 'change premise to <value>' to modify it.")
+            return _error("Premise already set.\nUse 'change premise to <value>' to modify it.")
 
         if action.kind == "change_premise" and self._state[STATE_PREMISE] is None:
-            return _clarify("No premise is set.\nUse 'set premise <value>' to define one.")
+            return _error("No premise is set.\nUse 'set premise <value>' to define one.")
 
         if action.kind == "use_item":
             assert action.item is not None
             item_key = _normalize_item(action.item)
             if self._state[STATE_POLICIES].get(item_key) == POLICY_PROHIBIT:
-                return _clarify(
+                return _error(
                     f'"{item_key}" is currently prohibited.\nRemove or replace it before using it.'
                 )
 
@@ -164,7 +164,7 @@ class Engine:
             assert action.item is not None
             item_key = _normalize_item(action.item)
             if self._state[STATE_POLICIES].get(item_key) == POLICY_USE:
-                return _clarify(
+                return _error(
                     f'"{item_key}" is currently in use.\n'
                     "Remove or replace it before prohibiting it."
                 )
@@ -180,17 +180,17 @@ class Engine:
             old_state = self._state[STATE_POLICIES].get(old_key)
             new_state = self._state[STATE_POLICIES].get(new_key)
             if old_state == POLICY_PROHIBIT:
-                return _clarify(
+                return _error(
                     f'"{action.old_item}" is currently prohibited.\n'
                     "Submit explicit directive(s) to remove it or use a different item."
                 )
             if new_state == POLICY_PROHIBIT:
-                return _clarify(
+                return _error(
                     f'"{action.new_item}" is currently prohibited.\n'
                     "Submit explicit directive(s) to remove it or use a different item."
                 )
             if old_state not in {None, POLICY_USE}:
-                return _clarify(
+                return _error(
                     f'"{action.old_item}" is not currently in use.\n'
                     "Replacement requires an active 'use' policy."
                 )
@@ -355,9 +355,9 @@ def _normalize_item(value: str) -> str:
     return normalized.strip()
 
 
-def _clarify(prompt: str) -> Decision:
+def _error(prompt: str) -> Decision:
     return {
-        "kind": DecisionKind.CLARIFY,
+        "kind": DecisionKind.ERROR,
         "state": None,
         "prompt_to_user": prompt,
     }

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -32,7 +32,7 @@ class State(TypedDict):
 
 class DecisionKind(StrEnum):
     UPDATE = "update"
-    PASSTHROUGH = "passthrough"
+    NO_DIRECTIVE = "no_directive"
     CLARIFY = "clarify"
 
 
@@ -61,8 +61,8 @@ class Action:
     old_item: str | None = None
 
 
-_PASSTHROUGH: Decision = {
-    "kind": DecisionKind.PASSTHROUGH,
+_NO_DIRECTIVE: Decision = {
+    "kind": DecisionKind.NO_DIRECTIVE,
     "state": None,
     "prompt_to_user": None,
 }
@@ -98,7 +98,7 @@ class Engine:
     def step(self, user_input: str) -> Decision:
         action = _parse_directive(user_input)
         if action is None:
-            return _PASSTHROUGH.copy()
+            return _NO_DIRECTIVE.copy()
 
         clarify_decision = self._pre_mutation_clarify(action)
         if clarify_decision is not None:

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -3,7 +3,7 @@ import sys
 from typing import TextIO
 
 from . import __version__, create_engine
-from .const import DECISION_CLARIFY, DECISION_NO_DIRECTIVE
+from .const import DECISION_ERROR, DECISION_NO_DIRECTIVE
 from .controller import (
     OUTPUT_VERSION,
     PreviewResult,
@@ -45,7 +45,7 @@ def _has_embedded_newline(raw_line: str) -> bool:
 
 def _multi_command_decision() -> Decision:
     return {
-        "kind": DecisionKind.CLARIFY,
+        "kind": DecisionKind.ERROR,
         "state": None,
         "prompt_to_user": _MULTI_COMMAND_PROMPT,
     }
@@ -69,7 +69,7 @@ def _print_interactive_help(out_stream: TextIO) -> None:
     print("  clear state", file=out_stream)
     print("Bare input behavior remains unchanged.", file=out_stream)
     print("preview is a deterministic dry-run and never mutates live state.", file=out_stream)
-    print("clarify results are immediate messages and do not reserve later input.", file=out_stream)
+    print("error results are immediate messages and do not reserve later input.", file=out_stream)
 
 
 def _render_state_lines(state: State) -> list[str]:
@@ -92,7 +92,7 @@ def _render_decision_lines(decision: Decision) -> list[str]:
     kind = decision["kind"]
     if kind == DECISION_NO_DIRECTIVE:
         return ["no_directive"]
-    if kind == DECISION_CLARIFY:
+    if kind == DECISION_ERROR:
         prompt = decision["prompt_to_user"] or ""
         prompt_lines = prompt.splitlines() if prompt else [""]
         return [f"error: {prompt_lines[0]}", *prompt_lines[1:]]

--- a/src/context_compiler/repl.py
+++ b/src/context_compiler/repl.py
@@ -3,7 +3,7 @@ import sys
 from typing import TextIO
 
 from . import __version__, create_engine
-from .const import DECISION_CLARIFY, DECISION_PASSTHROUGH
+from .const import DECISION_CLARIFY, DECISION_NO_DIRECTIVE
 from .controller import (
     OUTPUT_VERSION,
     PreviewResult,
@@ -90,8 +90,8 @@ def _render_state_lines(state: State) -> list[str]:
 
 def _render_decision_lines(decision: Decision) -> list[str]:
     kind = decision["kind"]
-    if kind == DECISION_PASSTHROUGH:
-        return ["passthrough"]
+    if kind == DECISION_NO_DIRECTIVE:
+        return ["no_directive"]
     if kind == DECISION_CLARIFY:
         prompt = decision["prompt_to_user"] or ""
         prompt_lines = prompt.splitlines() if prompt else [""]
@@ -253,7 +253,7 @@ def run_repl(
 
     if _is_interactive(in_stream, out_stream):
         print("Context Compiler REPL (0.5). Type help for commands.", file=out_stream)
-        print("Non-directive input is passthrough.", file=out_stream)
+        print("Non-directive input is no_directive.", file=out_stream)
 
         while True:
             line = in_stream.readline()

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -155,7 +155,7 @@ They validate:
 
 * per-turn input handling
 * `Decision.kind` outcomes
-* clarification prompt behavior
+* error prompt behavior
 * authoritative state parity against expected snapshots
 
 The current conformance corpus assumes the engine owns authoritative state only.

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -68,7 +68,7 @@ Unknown top-level and documented nested fields are rejected.
 `prelude` simulates prior user inputs to reach states through the public engine
 surface before the main fixture input runs.
 
-Shared `step` fixtures intentionally cover representative parser and passthrough
+Shared `step` fixtures intentionally cover representative parser and no_directive
 boundaries. They do not attempt to freeze every ambiguous natural-language edge
 case as part of the cross-language contract.
 

--- a/tests/fixtures/conformance/api/public-api-v1.json
+++ b/tests/fixtures/conformance/api/public-api-v1.json
@@ -14,7 +14,7 @@
     "names": [
       "Decision",
       "DecisionKind",
-      "DECISION_CLARIFY",
+      "DECISION_ERROR",
       "DECISION_NO_DIRECTIVE",
       "DECISION_UPDATE",
       "Engine",
@@ -24,11 +24,11 @@
       "State",
       "StepResult",
       "create_engine",
-      "get_clarify_prompt",
+      "get_error_prompt",
       "get_decision_state",
       "get_step_decision",
       "get_step_state",
-      "is_clarify",
+      "is_error",
       "is_no_directive",
       "is_update",
       "step"
@@ -40,9 +40,9 @@
       "DecisionKind": {
         "kind": "class"
       },
-      "DECISION_CLARIFY": {
+      "DECISION_ERROR": {
         "kind": "constant",
-        "value": "clarify"
+        "value": "error"
       },
       "DECISION_NO_DIRECTIVE": {
         "kind": "constant",
@@ -92,7 +92,7 @@
           }
         ]
       },
-      "get_clarify_prompt": {
+      "get_error_prompt": {
         "kind": "callable",
         "signature": {
           "params": [
@@ -107,7 +107,7 @@
           {
             "kwargs": {
               "decision": {
-                "kind": "clarify",
+                "kind": "error",
                 "state": null,
                 "prompt_to_user": "confirm?"
               }
@@ -185,7 +185,7 @@
           ]
         }
       },
-      "is_clarify": {
+      "is_error": {
         "kind": "callable",
         "signature": {
           "params": [
@@ -200,7 +200,7 @@
           {
             "kwargs": {
               "decision": {
-                "kind": "clarify",
+                "kind": "error",
                 "state": null,
                 "prompt_to_user": "confirm?"
               }

--- a/tests/fixtures/conformance/api/public-api-v1.json
+++ b/tests/fixtures/conformance/api/public-api-v1.json
@@ -7,7 +7,7 @@
     "CheckpointPending",
     "CheckpointPendingReplacement",
     "PendingReplacement",
-    "_PASSTHROUGH"
+    "_NO_DIRECTIVE"
   ],
   "exports": {
     "mode": "exact",
@@ -15,7 +15,7 @@
       "Decision",
       "DecisionKind",
       "DECISION_CLARIFY",
-      "DECISION_PASSTHROUGH",
+      "DECISION_NO_DIRECTIVE",
       "DECISION_UPDATE",
       "Engine",
       "POLICY_PROHIBIT",
@@ -29,7 +29,7 @@
       "get_step_decision",
       "get_step_state",
       "is_clarify",
-      "is_passthrough",
+      "is_no_directive",
       "is_update",
       "step"
     ],
@@ -44,9 +44,9 @@
         "kind": "constant",
         "value": "clarify"
       },
-      "DECISION_PASSTHROUGH": {
+      "DECISION_NO_DIRECTIVE": {
         "kind": "constant",
-        "value": "passthrough"
+        "value": "no_directive"
       },
       "DECISION_UPDATE": {
         "kind": "constant",
@@ -212,7 +212,7 @@
           }
         ]
       },
-      "is_passthrough": {
+      "is_no_directive": {
         "kind": "callable",
         "signature": {
           "params": [
@@ -227,7 +227,7 @@
           {
             "kwargs": {
               "decision": {
-                "kind": "passthrough",
+                "kind": "no_directive",
                 "state": null,
                 "prompt_to_user": null
               }

--- a/tests/fixtures/conformance/controller/controller_preview_affirmative_followup_no_directive_after_replace_update.json
+++ b/tests/fixtures/conformance/controller/controller_preview_affirmative_followup_no_directive_after_replace_update.json
@@ -1,5 +1,5 @@
 {
-  "id": "controller_preview_affirmative_followup_passthrough_after_replace_update",
+  "id": "controller_preview_affirmative_followup_no_directive_after_replace_update",
   "kind": "controller",
   "initial_state": {
     "premise": null,
@@ -18,7 +18,7 @@
       "output_version": 1,
       "mode": "preview",
       "decision": {
-        "kind": "passthrough",
+        "kind": "no_directive",
         "state": null,
         "prompt_to_user": null
       },

--- a/tests/fixtures/conformance/controller/controller_preview_error_reports_non_mutating_and_restores_live_state.json
+++ b/tests/fixtures/conformance/controller/controller_preview_error_reports_non_mutating_and_restores_live_state.json
@@ -1,5 +1,5 @@
 {
-  "id": "controller_preview_clarify_reports_non_mutating_and_restores_live_state",
+  "id": "controller_preview_error_reports_non_mutating_and_restores_live_state",
   "kind": "controller",
   "initial_state": {
     "premise": null,

--- a/tests/fixtures/conformance/controller/controller_preview_replace_prohibited_old_matches_execution_without_mutation.json
+++ b/tests/fixtures/conformance/controller/controller_preview_replace_prohibited_old_matches_execution_without_mutation.json
@@ -19,7 +19,7 @@
       "output_version": 1,
       "mode": "preview",
       "decision": {
-        "kind": "clarify",
+        "kind": "error",
         "state": null,
         "prompt_to_user": "\"docker\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item."
       },

--- a/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_normalized_token.json
+++ b/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_normalized_token.json
@@ -1,21 +1,26 @@
 {
-  "id": "step_non_directive_input_passthrough",
+  "id": "step_affirmative_followup_no_directive_normalized_token",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "input": "hello there",
+  "prelude": [
+    "use kubectl instead of docker"
+  ],
+  "input": "  YES!!!  ",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },
     "state": {
       "premise": null,
-      "policies": {},
+      "policies": {
+        "kubectl": "use"
+      },
       "version": 2
     }
   }

--- a/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_punctuation_token.json
+++ b/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_punctuation_token.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_affirmative_followup_passthrough_punctuation_token",
+  "id": "step_affirmative_followup_no_directive_punctuation_token",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -12,7 +12,7 @@
   "input": " okay!!! ",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_change_premise_missing_error.json
+++ b/tests/fixtures/conformance/step/step_change_premise_missing_error.json
@@ -1,25 +1,21 @@
 {
-  "id": "step_conflict_prohibit_clarify",
+  "id": "step_change_premise_missing_error",
   "kind": "step",
   "initial_state": {
     "premise": null,
-    "policies": {
-      "docker": "use"
-    },
+    "policies": {},
     "version": 2
   },
-  "input": "prohibit docker",
+  "input": "change premise to concise replies",
   "expected": {
     "decision": {
-      "kind": "clarify",
+      "kind": "error",
       "prompt_to_user": null,
       "state": null
     },
     "state": {
       "premise": null,
-      "policies": {
-        "docker": "use"
-      },
+      "policies": {},
       "version": 2
     }
   }

--- a/tests/fixtures/conformance/step/step_compound_clear_state_then_set_premise_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_clear_state_then_set_premise_invalid_boundary.json
@@ -11,7 +11,7 @@
   "input": "clear state then set premise project",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_compound_remove_policy_and_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_remove_policy_and_prohibit_invalid_boundary.json
@@ -11,7 +11,7 @@
   "input": "remove policy docker and prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_compound_set_premise_and_use_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_set_premise_and_use_invalid_boundary.json
@@ -9,7 +9,7 @@
   "input": "set premise vegetarian and use docker",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_compound_use_and_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_use_and_prohibit_invalid_boundary.json
@@ -9,7 +9,7 @@
   "input": "use docker and prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_compound_use_or_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_use_or_prohibit_invalid_boundary.json
@@ -9,7 +9,7 @@
   "input": "use docker or prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_compound_use_punctuation_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_use_punctuation_prohibit_invalid_boundary.json
@@ -9,7 +9,7 @@
   "input": "use docker. prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_compound_use_xor_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_use_xor_prohibit_invalid_boundary.json
@@ -9,7 +9,7 @@
   "input": "use docker xor prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_conflict_prohibit_error.json
+++ b/tests/fixtures/conformance/step/step_conflict_prohibit_error.json
@@ -1,25 +1,24 @@
 {
-  "id": "step_policy_identity_apostrophe_variant_clarify",
+  "id": "step_conflict_prohibit_error",
   "kind": "step",
   "initial_state": {
     "premise": null,
-    "policies": {},
+    "policies": {
+      "docker": "use"
+    },
     "version": 2
   },
-  "prelude": [
-    "use don't"
-  ],
-  "input": "prohibit don’t",
+  "input": "prohibit docker",
   "expected": {
     "decision": {
-      "kind": "clarify",
+      "kind": "error",
       "prompt_to_user": null,
       "state": null
     },
     "state": {
       "premise": null,
       "policies": {
-        "don't": "use"
+        "docker": "use"
       },
       "version": 2
     }

--- a/tests/fixtures/conformance/step/step_exact_prefix_no_directive_leading_space.json
+++ b/tests/fixtures/conformance/step/step_exact_prefix_no_directive_leading_space.json
@@ -1,20 +1,24 @@
 {
-  "id": "step_quoted_leading_directive_text_passthrough",
+  "id": "step_exact_prefix_no_directive_leading_space",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "input": "\"use docker and prohibit peanuts\"",
+  "input": " set premise concise",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "update",
       "prompt_to_user": null,
-      "state": null
+      "state": {
+        "premise": "concise",
+        "policies": {},
+        "version": 2
+      }
     },
     "state": {
-      "premise": null,
+      "premise": "concise",
       "policies": {},
       "version": 2
     }

--- a/tests/fixtures/conformance/step/step_independent_followup_no_directive_after_replace_update.json
+++ b/tests/fixtures/conformance/step/step_independent_followup_no_directive_after_replace_update.json
@@ -1,21 +1,26 @@
 {
-  "id": "step_natural_language_request_passthrough",
+  "id": "step_independent_followup_no_directive_after_replace_update",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "input": "please use docker",
+  "prelude": [
+    "use kubectl instead of docker"
+  ],
+  "input": "sounds good",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },
     "state": {
       "premise": null,
-      "policies": {},
+      "policies": {
+        "kubectl": "use"
+      },
       "version": 2
     }
   }

--- a/tests/fixtures/conformance/step/step_natural_language_request_no_directive.json
+++ b/tests/fixtures/conformance/step/step_natural_language_request_no_directive.json
@@ -1,26 +1,21 @@
 {
-  "id": "step_negative_followup_passthrough_punctuation_token",
+  "id": "step_natural_language_request_no_directive",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "prelude": [
-    "use kubectl instead of docker"
-  ],
-  "input": " NOPE?? ",
+  "input": "please use docker",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },
     "state": {
       "premise": null,
-      "policies": {
-        "kubectl": "use"
-      },
+      "policies": {},
       "version": 2
     }
   }

--- a/tests/fixtures/conformance/step/step_near_miss_change_premise_missing_to.json
+++ b/tests/fixtures/conformance/step/step_near_miss_change_premise_missing_to.json
@@ -9,7 +9,7 @@
   "input": "change premise concise",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_near_miss_set_premise_to.json
+++ b/tests/fixtures/conformance/step/step_near_miss_set_premise_to.json
@@ -9,7 +9,7 @@
   "input": "set premise to concise",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_negative_followup_no_directive_normalized_token.json
+++ b/tests/fixtures/conformance/step/step_negative_followup_no_directive_normalized_token.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_negative_followup_passthrough_normalized_token",
+  "id": "step_negative_followup_no_directive_normalized_token",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -12,7 +12,7 @@
   "input": "no thanks.",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_negative_followup_no_directive_punctuation_token.json
+++ b/tests/fixtures/conformance/step/step_negative_followup_no_directive_punctuation_token.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_independent_followup_passthrough_after_replace_update",
+  "id": "step_negative_followup_no_directive_punctuation_token",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -9,10 +9,10 @@
   "prelude": [
     "use kubectl instead of docker"
   ],
-  "input": "sounds good",
+  "input": " NOPE?? ",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_non_directive_input_no_directive.json
+++ b/tests/fixtures/conformance/step/step_non_directive_input_no_directive.json
@@ -1,24 +1,20 @@
 {
-  "id": "step_exact_prefix_passthrough_leading_space",
+  "id": "step_non_directive_input_no_directive",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "input": " set premise concise",
+  "input": "hello there",
   "expected": {
     "decision": {
-      "kind": "update",
+      "kind": "no_directive",
       "prompt_to_user": null,
-      "state": {
-        "premise": "concise",
-        "policies": {},
-        "version": 2
-      }
+      "state": null
     },
     "state": {
-      "premise": "concise",
+      "premise": null,
       "policies": {},
       "version": 2
     }

--- a/tests/fixtures/conformance/step/step_policy_identity_apostrophe_variant_error.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_apostrophe_variant_error.json
@@ -1,21 +1,26 @@
 {
-  "id": "step_change_premise_missing_clarify",
+  "id": "step_policy_identity_apostrophe_variant_error",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "input": "change premise to concise replies",
+  "prelude": [
+    "use don't"
+  ],
+  "input": "prohibit don’t",
   "expected": {
     "decision": {
-      "kind": "clarify",
+      "kind": "error",
       "prompt_to_user": null,
       "state": null
     },
     "state": {
       "premise": null,
-      "policies": {},
+      "policies": {
+        "don't": "use"
+      },
       "version": 2
     }
   }

--- a/tests/fixtures/conformance/step/step_quoted_leading_directive_text_no_directive.json
+++ b/tests/fixtures/conformance/step/step_quoted_leading_directive_text_no_directive.json
@@ -1,26 +1,21 @@
 {
-  "id": "step_affirmative_followup_passthrough_normalized_token",
+  "id": "step_quoted_leading_directive_text_no_directive",
   "kind": "step",
   "initial_state": {
     "premise": null,
     "policies": {},
     "version": 2
   },
-  "prelude": [
-    "use kubectl instead of docker"
-  ],
-  "input": "  YES!!!  ",
+  "input": "\"use docker and prohibit peanuts\"",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },
     "state": {
       "premise": null,
-      "policies": {
-        "kubectl": "use"
-      },
+      "policies": {},
       "version": 2
     }
   }

--- a/tests/fixtures/conformance/step/step_quoted_payload_compound_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_quoted_payload_compound_invalid_boundary.json
@@ -9,7 +9,7 @@
   "input": "use \"docker and prohibit peanuts\"",
   "expected": {
     "decision": {
-      "kind": "passthrough",
+      "kind": "no_directive",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_replace_missing_source_error_prompt.json
+++ b/tests/fixtures/conformance/step/step_replace_missing_source_error_prompt.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_replace_missing_source_clarify_prompt",
+  "id": "step_replace_missing_source_error_prompt",
   "kind": "step",
   "initial_state": {
     "premise": null,

--- a/tests/fixtures/conformance/step/step_replace_prohibited_new_error_without_mutation.json
+++ b/tests/fixtures/conformance/step/step_replace_prohibited_new_error_without_mutation.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_replace_prohibited_new_clarify_without_mutation",
+  "id": "step_replace_prohibited_new_error_without_mutation",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -13,7 +13,7 @@
   "input": "use kubectl instead of docker",
   "expected": {
     "decision": {
-      "kind": "clarify",
+      "kind": "error",
       "prompt_to_user": "\"kubectl\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item.",
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_replace_prohibited_old_error_without_mutation.json
+++ b/tests/fixtures/conformance/step/step_replace_prohibited_old_error_without_mutation.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_replace_prohibited_old_clarify_without_mutation",
+  "id": "step_replace_prohibited_old_error_without_mutation",
   "kind": "step",
   "initial_state": {
     "premise": null,
@@ -13,7 +13,7 @@
   "input": "use kubectl instead of docker",
   "expected": {
     "decision": {
-      "kind": "clarify",
+      "kind": "error",
       "prompt_to_user": "\"docker\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item.",
       "state": null
     },

--- a/tests/fixtures/conformance/step/step_set_premise_existing_error.json
+++ b/tests/fixtures/conformance/step/step_set_premise_existing_error.json
@@ -1,5 +1,5 @@
 {
-  "id": "step_set_premise_existing_clarify",
+  "id": "step_set_premise_existing_error",
   "kind": "step",
   "initial_state": {
     "premise": "existing premise",
@@ -9,7 +9,7 @@
   "input": "set premise concise replies",
   "expected": {
     "decision": {
-      "kind": "clarify",
+      "kind": "error",
       "prompt_to_user": null,
       "state": null
     },

--- a/tests/fixtures/controller/preview_error_no_mutation.json
+++ b/tests/fixtures/controller/preview_error_no_mutation.json
@@ -1,5 +1,5 @@
 {
-  "id": "controller_preview_clarify_no_mutation",
+  "id": "controller_preview_error_no_mutation",
   "kind": "controller_preview",
   "input": "use kubectl instead of docker",
   "expected": {

--- a/tests/fixtures/engine-regression/structured/README.md
+++ b/tests/fixtures/engine-regression/structured/README.md
@@ -43,7 +43,7 @@ regressions are visible in:
 
 ## Prompt Matching
 
-`decision.prompt_to_user` is matched exactly, including clarify text.
+`decision.prompt_to_user` is matched exactly, including error text.
 
 ## Adding a Scenario
 

--- a/tests/fixtures/engine-regression/structured/expected/contradiction_error.json
+++ b/tests/fixtures/engine-regression/structured/expected/contradiction_error.json
@@ -1,5 +1,5 @@
 {
-  "id": "contradiction_clarify",
+  "id": "contradiction_error",
   "turns": [
     {
       "state": {
@@ -24,7 +24,7 @@
         "version": 2
       },
       "decision": {
-        "kind": "clarify",
+        "kind": "error",
         "prompt_to_user": "\"docker\" is currently in use.\nRemove or replace it before prohibiting it."
       },
       "input": "prohibit docker"

--- a/tests/fixtures/engine-regression/structured/expected/premise_lifecycle.json
+++ b/tests/fixtures/engine-regression/structured/expected/premise_lifecycle.json
@@ -20,7 +20,7 @@
         "version": 2
       },
       "decision": {
-        "kind": "clarify",
+        "kind": "error",
         "prompt_to_user": "Premise already set.\nUse 'change premise to <value>' to modify it."
       },
       "input": "set premise formal replies"
@@ -56,7 +56,7 @@
         "version": 2
       },
       "decision": {
-        "kind": "clarify",
+        "kind": "error",
         "prompt_to_user": "No premise is set.\nUse 'set premise <value>' to define one."
       },
       "input": "change premise to formal tone"

--- a/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_new_clarify.json
+++ b/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_new_clarify.json
@@ -55,7 +55,7 @@
         "version": 2
       },
       "decision": {
-        "kind": "passthrough",
+        "kind": "no_directive",
         "prompt_to_user": null
       },
       "input": "no"

--- a/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_new_error.json
+++ b/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_new_error.json
@@ -1,10 +1,10 @@
 {
-  "id": "prohibited_replacement_old_clarify",
+  "id": "prohibited_replacement_new_error",
   "turns": [
     {
       "state": {
         "policies": {
-          "docker": "prohibit"
+          "docker": "use"
         },
         "premise": null,
         "version": 2
@@ -13,13 +13,13 @@
         "kind": "update",
         "prompt_to_user": null
       },
-      "input": "prohibit docker"
+      "input": "use docker"
     },
     {
       "state": {
         "policies": {
-          "docker": "prohibit",
-          "pytest": "use"
+          "docker": "use",
+          "kubectl": "prohibit"
         },
         "premise": null,
         "version": 2
@@ -28,28 +28,28 @@
         "kind": "update",
         "prompt_to_user": null
       },
-      "input": "use pytest"
+      "input": "prohibit kubectl"
     },
     {
       "state": {
         "policies": {
-          "docker": "prohibit",
-          "pytest": "use"
+          "docker": "use",
+          "kubectl": "prohibit"
         },
         "premise": null,
         "version": 2
       },
       "decision": {
-        "kind": "clarify",
-        "prompt_to_user": "\"docker\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item."
+        "kind": "error",
+        "prompt_to_user": "\"kubectl\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item."
       },
       "input": "use kubectl instead of docker"
     },
     {
       "state": {
         "policies": {
-          "docker": "prohibit",
-          "pytest": "use"
+          "docker": "use",
+          "kubectl": "prohibit"
         },
         "premise": null,
         "version": 2
@@ -58,7 +58,7 @@
         "kind": "no_directive",
         "prompt_to_user": null
       },
-      "input": "yes"
+      "input": "no"
     }
   ]
 }

--- a/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_old_clarify.json
+++ b/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_old_clarify.json
@@ -55,7 +55,7 @@
         "version": 2
       },
       "decision": {
-        "kind": "passthrough",
+        "kind": "no_directive",
         "prompt_to_user": null
       },
       "input": "yes"

--- a/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_old_error.json
+++ b/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_old_error.json
@@ -1,10 +1,10 @@
 {
-  "id": "prohibited_replacement_new_clarify",
+  "id": "prohibited_replacement_old_error",
   "turns": [
     {
       "state": {
         "policies": {
-          "docker": "use"
+          "docker": "prohibit"
         },
         "premise": null,
         "version": 2
@@ -13,13 +13,13 @@
         "kind": "update",
         "prompt_to_user": null
       },
-      "input": "use docker"
+      "input": "prohibit docker"
     },
     {
       "state": {
         "policies": {
-          "docker": "use",
-          "kubectl": "prohibit"
+          "docker": "prohibit",
+          "pytest": "use"
         },
         "premise": null,
         "version": 2
@@ -28,28 +28,28 @@
         "kind": "update",
         "prompt_to_user": null
       },
-      "input": "prohibit kubectl"
+      "input": "use pytest"
     },
     {
       "state": {
         "policies": {
-          "docker": "use",
-          "kubectl": "prohibit"
+          "docker": "prohibit",
+          "pytest": "use"
         },
         "premise": null,
         "version": 2
       },
       "decision": {
-        "kind": "clarify",
-        "prompt_to_user": "\"kubectl\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item."
+        "kind": "error",
+        "prompt_to_user": "\"docker\" is currently prohibited.\nSubmit explicit directive(s) to remove it or use a different item."
       },
       "input": "use kubectl instead of docker"
     },
     {
       "state": {
         "policies": {
-          "docker": "use",
-          "kubectl": "prohibit"
+          "docker": "prohibit",
+          "pytest": "use"
         },
         "premise": null,
         "version": 2
@@ -58,7 +58,7 @@
         "kind": "no_directive",
         "prompt_to_user": null
       },
-      "input": "no"
+      "input": "yes"
     }
   ]
 }

--- a/tests/fixtures/engine-regression/structured/expected/replacement_error.json
+++ b/tests/fixtures/engine-regression/structured/expected/replacement_error.json
@@ -1,5 +1,5 @@
 {
-  "id": "replacement_clarify",
+  "id": "replacement_error",
   "turns": [
     {
       "state": {

--- a/tests/fixtures/engine-regression/structured/scenarios/contradiction_clarify.json
+++ b/tests/fixtures/engine-regression/structured/scenarios/contradiction_clarify.json
@@ -1,9 +1,0 @@
-{
-  "description": "Policy contradiction yields clarify with no mutation",
-  "id": "contradiction_clarify",
-  "initial_state": null,
-  "inputs": [
-    "use docker",
-    "prohibit docker"
-  ]
-}

--- a/tests/fixtures/engine-regression/structured/scenarios/contradiction_error.json
+++ b/tests/fixtures/engine-regression/structured/scenarios/contradiction_error.json
@@ -1,0 +1,9 @@
+{
+  "description": "Policy contradiction yields error with no mutation",
+  "id": "contradiction_error",
+  "initial_state": null,
+  "inputs": [
+    "use docker",
+    "prohibit docker"
+  ]
+}

--- a/tests/fixtures/engine-regression/structured/scenarios/premise_lifecycle.json
+++ b/tests/fixtures/engine-regression/structured/scenarios/premise_lifecycle.json
@@ -1,5 +1,5 @@
 {
-  "description": "Premise lifecycle updates and clarify gates",
+  "description": "Premise lifecycle updates and error gates",
   "id": "premise_lifecycle",
   "initial_state": null,
   "inputs": [

--- a/tests/fixtures/engine-regression/structured/scenarios/prohibited_replacement_new_error.json
+++ b/tests/fixtures/engine-regression/structured/scenarios/prohibited_replacement_new_error.json
@@ -1,6 +1,6 @@
 {
-  "description": "Replacement to a prohibited new item stays an ordinary clarify",
-  "id": "prohibited_replacement_new_clarify",
+  "description": "Replacement to a prohibited new item stays an ordinary error",
+  "id": "prohibited_replacement_new_error",
   "initial_state": null,
   "inputs": [
     "use docker",

--- a/tests/fixtures/engine-regression/structured/scenarios/prohibited_replacement_old_error.json
+++ b/tests/fixtures/engine-regression/structured/scenarios/prohibited_replacement_old_error.json
@@ -1,6 +1,6 @@
 {
-  "description": "Replacement from a prohibited old item stays an ordinary clarify",
-  "id": "prohibited_replacement_old_clarify",
+  "description": "Replacement from a prohibited old item stays an ordinary error",
+  "id": "prohibited_replacement_old_error",
   "initial_state": null,
   "inputs": [
     "prohibit docker",

--- a/tests/fixtures/engine-regression/structured/scenarios/replacement_error.json
+++ b/tests/fixtures/engine-regression/structured/scenarios/replacement_error.json
@@ -1,6 +1,6 @@
 {
   "description": "Replacement from missing old item applies as deterministic use update",
-  "id": "replacement_clarify",
+  "id": "replacement_error",
   "initial_state": null,
   "inputs": [
     "use podman instead of docker"

--- a/tests/test_04_grammar_edge_cases.py
+++ b/tests/test_04_grammar_edge_cases.py
@@ -1,4 +1,5 @@
 from context_compiler import create_engine
+from context_compiler.engine import DecisionKind
 
 
 def test_parser_trims_leading_space_for_canonical_directive() -> None:
@@ -7,7 +8,7 @@ def test_parser_trims_leading_space_for_canonical_directive() -> None:
     decision = engine.step(" set premise concise")
 
     assert decision == {
-        "kind": "update",
+        "kind": DecisionKind.UPDATE,
         "state": {"premise": "concise", "policies": {}, "version": 2},
         "prompt_to_user": None,
     }
@@ -28,7 +29,7 @@ def test_parser_does_not_accept_conversational_aliases() -> None:
         "set docker",
     ]:
         decision = engine.step(text)
-        assert decision["kind"] == "no_directive"
+        assert decision["kind"] == DecisionKind.NO_DIRECTIVE
 
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
@@ -38,11 +39,19 @@ def test_empty_policy_payloads_and_incomplete_replacement_remain_no_directive() 
     before = engine.state
 
     for text in ["use", "use ", "use    "]:
-        assert engine.step(text) == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+        assert engine.step(text) == {
+            "kind": DecisionKind.NO_DIRECTIVE,
+            "state": None,
+            "prompt_to_user": None,
+        }
         assert engine.state == before
 
     for text in ["prohibit", "prohibit ", "prohibit    "]:
-        assert engine.step(text) == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+        assert engine.step(text) == {
+            "kind": DecisionKind.NO_DIRECTIVE,
+            "state": None,
+            "prompt_to_user": None,
+        }
         assert engine.state == before
 
     for text in [
@@ -52,23 +61,27 @@ def test_empty_policy_payloads_and_incomplete_replacement_remain_no_directive() 
         "use   instead of y",
         "use instead of y",
     ]:
-        assert engine.step(text) == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+        assert engine.step(text) == {
+            "kind": DecisionKind.NO_DIRECTIVE,
+            "state": None,
+            "prompt_to_user": None,
+        }
         assert engine.state == before
 
-    assert engine.step("remove policy\tdocker")["kind"] == "update"
+    assert engine.step("remove policy\tdocker")["kind"] == DecisionKind.UPDATE
     assert engine.state == before
 
 
 def test_lexical_normalization_and_non_directive_near_misses() -> None:
     engine = create_engine()
-    assert engine.step("clear premise ")["kind"] == "update"
-    assert engine.step("reset policies ")["kind"] == "update"
-    assert engine.step("clear state ")["kind"] == "update"
-    assert engine.step("remove policy\tdocker")["kind"] == "update"
-    assert engine.step("Use docker")["kind"] == "update"
-    assert engine.step("use\tdocker")["kind"] == "update"
-    assert engine.step("don't Use docker")["kind"] == "no_directive"
-    assert engine.step("don't use")["kind"] == "no_directive"
+    assert engine.step("clear premise ")["kind"] == DecisionKind.UPDATE
+    assert engine.step("reset policies ")["kind"] == DecisionKind.UPDATE
+    assert engine.step("clear state ")["kind"] == DecisionKind.UPDATE
+    assert engine.step("remove policy\tdocker")["kind"] == DecisionKind.UPDATE
+    assert engine.step("Use docker")["kind"] == DecisionKind.UPDATE
+    assert engine.step("use\tdocker")["kind"] == DecisionKind.UPDATE
+    assert engine.step("don't Use docker")["kind"] == DecisionKind.NO_DIRECTIVE
+    assert engine.step("don't use")["kind"] == DecisionKind.NO_DIRECTIVE
 
     assert engine.state == {"premise": None, "policies": {"docker": "use"}, "version": 2}
 
@@ -80,8 +93,12 @@ def test_premise_to_variant_near_misses_remain_no_directive() -> None:
     set_variant = engine.step("set premise to concise")
     change_variant = engine.step("change premise concise")
 
-    assert set_variant == {"kind": "no_directive", "state": None, "prompt_to_user": None}
-    assert change_variant == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert set_variant == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
+    assert change_variant == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert before == engine.state
 
 
@@ -92,19 +109,23 @@ def test_remove_policy_missing_or_whitespace_payload_remains_no_directive() -> N
     first = engine.step("remove policy")
     second = engine.step("remove policy   ")
 
-    assert first == {"kind": "no_directive", "state": None, "prompt_to_user": None}
-    assert second == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert first == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
+    assert second == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert engine.state == before
 
 
 def test_invalid_replacement_does_not_block_following_directives() -> None:
     engine = create_engine()
     first = engine.step("use kubectl instead of docker")
-    assert first["kind"] == "update"
+    assert first["kind"] == DecisionKind.UPDATE
 
     second = engine.step("set premise concise")
     assert second == {
-        "kind": "update",
+        "kind": DecisionKind.UPDATE,
         "state": {"premise": "concise", "policies": {"kubectl": "use"}, "version": 2},
         "prompt_to_user": None,
     }
@@ -120,5 +141,9 @@ def test_replace_update_independent_followup_is_no_directive() -> None:
     first = engine.step("use kubectl instead of docker")
     second = engine.step("sounds good")
 
-    assert first["kind"] == "update"
-    assert second == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert first["kind"] == DecisionKind.UPDATE
+    assert second == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }

--- a/tests/test_04_grammar_edge_cases.py
+++ b/tests/test_04_grammar_edge_cases.py
@@ -28,21 +28,21 @@ def test_parser_does_not_accept_conversational_aliases() -> None:
         "set docker",
     ]:
         decision = engine.step(text)
-        assert decision["kind"] == "passthrough"
+        assert decision["kind"] == "no_directive"
 
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
-def test_empty_policy_payloads_and_incomplete_replacement_remain_passthrough() -> None:
+def test_empty_policy_payloads_and_incomplete_replacement_remain_no_directive() -> None:
     engine = create_engine()
     before = engine.state
 
     for text in ["use", "use ", "use    "]:
-        assert engine.step(text) == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+        assert engine.step(text) == {"kind": "no_directive", "state": None, "prompt_to_user": None}
         assert engine.state == before
 
     for text in ["prohibit", "prohibit ", "prohibit    "]:
-        assert engine.step(text) == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+        assert engine.step(text) == {"kind": "no_directive", "state": None, "prompt_to_user": None}
         assert engine.state == before
 
     for text in [
@@ -52,7 +52,7 @@ def test_empty_policy_payloads_and_incomplete_replacement_remain_passthrough() -
         "use   instead of y",
         "use instead of y",
     ]:
-        assert engine.step(text) == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+        assert engine.step(text) == {"kind": "no_directive", "state": None, "prompt_to_user": None}
         assert engine.state == before
 
     assert engine.step("remove policy\tdocker")["kind"] == "update"
@@ -67,33 +67,33 @@ def test_lexical_normalization_and_non_directive_near_misses() -> None:
     assert engine.step("remove policy\tdocker")["kind"] == "update"
     assert engine.step("Use docker")["kind"] == "update"
     assert engine.step("use\tdocker")["kind"] == "update"
-    assert engine.step("don't Use docker")["kind"] == "passthrough"
-    assert engine.step("don't use")["kind"] == "passthrough"
+    assert engine.step("don't Use docker")["kind"] == "no_directive"
+    assert engine.step("don't use")["kind"] == "no_directive"
 
     assert engine.state == {"premise": None, "policies": {"docker": "use"}, "version": 2}
 
 
-def test_premise_to_variant_near_misses_remain_passthrough() -> None:
+def test_premise_to_variant_near_misses_remain_no_directive() -> None:
     engine = create_engine()
     before = engine.state
 
     set_variant = engine.step("set premise to concise")
     change_variant = engine.step("change premise concise")
 
-    assert set_variant == {"kind": "passthrough", "state": None, "prompt_to_user": None}
-    assert change_variant == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert set_variant == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert change_variant == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert before == engine.state
 
 
-def test_remove_policy_missing_or_whitespace_payload_remains_passthrough() -> None:
+def test_remove_policy_missing_or_whitespace_payload_remains_no_directive() -> None:
     engine = create_engine()
     before = engine.state
 
     first = engine.step("remove policy")
     second = engine.step("remove policy   ")
 
-    assert first == {"kind": "passthrough", "state": None, "prompt_to_user": None}
-    assert second == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert first == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert second == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -115,10 +115,10 @@ def test_invalid_replacement_does_not_block_following_directives() -> None:
     }
 
 
-def test_replace_update_independent_followup_is_passthrough() -> None:
+def test_replace_update_independent_followup_is_no_directive() -> None:
     engine = create_engine()
     first = engine.step("use kubectl instead of docker")
     second = engine.step("sounds good")
 
     assert first["kind"] == "update"
-    assert second == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert second == {"kind": "no_directive", "state": None, "prompt_to_user": None}

--- a/tests/test_compound_directive_properties.py
+++ b/tests/test_compound_directive_properties.py
@@ -4,6 +4,7 @@ from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 from context_compiler import create_engine
+from context_compiler.engine import DecisionKind
 
 CANONICAL_SECOND_DIRECTIVES = [
     "set premise concise",
@@ -38,7 +39,7 @@ def _assert_compound_no_directive(user_input: str) -> None:
 
     decision = engine.step(user_input)
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -82,8 +83,8 @@ def test_embedded_canonical_tokens_do_not_trigger_compound_detection(
 
     decision = engine.step(f"use docker {prefix}{token}{suffix}")
 
-    assert decision["prompt_to_user"] is not None or decision["kind"] != "clarify"
-    assert decision["kind"] == "update"
+    assert decision["prompt_to_user"] is not None or decision["kind"] != DecisionKind.CLARIFY
+    assert decision["kind"] == DecisionKind.UPDATE
     assert engine.state != before
 
 
@@ -103,7 +104,7 @@ def test_leading_non_directive_text_disables_compound_detection(prefix: str, sec
     before = engine.state
     decision = engine.step(f"{prefix} use docker {second}")
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -124,7 +125,7 @@ def test_case_mutated_second_directive_does_not_trigger_compound_detection(
 
     decision = engine.step(f"use docker {second_start}")
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -156,5 +157,5 @@ def test_fully_quoted_input_remains_no_directive(quote: str, second: str) -> Non
 
     decision = engine.step(f"{quote}use docker {second}{quote}")
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before

--- a/tests/test_compound_directive_properties.py
+++ b/tests/test_compound_directive_properties.py
@@ -83,7 +83,7 @@ def test_embedded_canonical_tokens_do_not_trigger_compound_detection(
 
     decision = engine.step(f"use docker {prefix}{token}{suffix}")
 
-    assert decision["prompt_to_user"] is not None or decision["kind"] != DecisionKind.CLARIFY
+    assert decision["prompt_to_user"] is not None or decision["kind"] != DecisionKind.ERROR
     assert decision["kind"] == DecisionKind.UPDATE
     assert engine.state != before
 

--- a/tests/test_compound_directive_properties.py
+++ b/tests/test_compound_directive_properties.py
@@ -32,13 +32,13 @@ SEPARATOR_CHARS = " \t\n\r,.;:!?-/()[]"
 LETTER_CHARS = string.ascii_lowercase
 
 
-def _assert_compound_passthrough(user_input: str) -> None:
+def _assert_compound_no_directive(user_input: str) -> None:
     engine = create_engine()
     before = engine.state
 
     decision = engine.step(user_input)
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -48,7 +48,7 @@ def _assert_compound_passthrough(user_input: str) -> None:
     second=st.sampled_from(CANONICAL_SECOND_DIRECTIVES),
 )
 def test_compound_separator_robustness(separator: str, second: str) -> None:
-    _assert_compound_passthrough(f"use docker{separator}{second}")
+    _assert_compound_no_directive(f"use docker{separator}{second}")
 
 
 @settings(max_examples=50)
@@ -65,7 +65,7 @@ def test_compound_arbitrary_intervening_text(chunks: list[str], second: str) -> 
     lowered = intervening.lower()
     assume(all(token not in lowered for token in CANONICAL_STARTS))
 
-    _assert_compound_passthrough(f"use docker {intervening} {second}")
+    _assert_compound_no_directive(f"use docker {intervening} {second}")
 
 
 @settings(max_examples=50)
@@ -103,7 +103,7 @@ def test_leading_non_directive_text_disables_compound_detection(prefix: str, sec
     before = engine.state
     decision = engine.step(f"{prefix} use docker {second}")
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -124,7 +124,7 @@ def test_case_mutated_second_directive_does_not_trigger_compound_detection(
 
     decision = engine.step(f"use docker {second_start}")
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -142,7 +142,7 @@ def test_case_mutated_second_directive_does_not_trigger_compound_detection(
 def test_quotes_do_not_create_protected_region_after_first_directive(
     quote: str, payload: str, closing: str, second: str
 ) -> None:
-    _assert_compound_passthrough(f"use {quote}{payload}{closing} {second}")
+    _assert_compound_no_directive(f"use {quote}{payload}{closing} {second}")
 
 
 @settings(max_examples=20)
@@ -150,11 +150,11 @@ def test_quotes_do_not_create_protected_region_after_first_directive(
     quote=st.sampled_from(['"', "'"]),
     second=st.sampled_from(CANONICAL_SECOND_DIRECTIVES),
 )
-def test_fully_quoted_input_remains_passthrough(quote: str, second: str) -> None:
+def test_fully_quoted_input_remains_no_directive(quote: str, second: str) -> None:
     engine = create_engine()
     before = engine.state
 
     decision = engine.step(f"{quote}use docker {second}{quote}")
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -78,7 +78,7 @@ def test_preview_missing_source_replacement_reports_update_without_live_mutation
     assert yes["kind"] == DecisionKind.NO_DIRECTIVE
 
 
-def test_preview_prohibited_replacement_clarify_matches_execution_without_mutation() -> None:
+def test_preview_prohibited_replacement_error_matches_execution_without_mutation() -> None:
     engine = create_engine()
     engine.step("use docker")
     engine.step("prohibit kubectl")
@@ -86,7 +86,7 @@ def test_preview_prohibited_replacement_clarify_matches_execution_without_mutati
     result = preview(engine, "use kubectl instead of docker")
 
     assert result["decision"] == {
-        "kind": DecisionKind.CLARIFY,
+        "kind": DecisionKind.ERROR,
         "state": None,
         "prompt_to_user": (
             '"kubectl" is currently prohibited.\n'

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -74,7 +74,7 @@ def test_preview_missing_source_replacement_reports_update_without_live_mutation
     assert result["would_mutate"] is True
 
     yes = engine.step("yes")
-    assert yes["kind"] == "passthrough"
+    assert yes["kind"] == "no_directive"
 
 
 def test_preview_prohibited_replacement_clarify_matches_execution_without_mutation() -> None:
@@ -247,7 +247,7 @@ def test_controller_helpers_are_importable_from_package_root() -> None:
 
 
 @pytest.mark.parametrize("followup_token", ["yes", "no"])
-def test_preview_followup_tokens_after_replace_update_are_passthrough(
+def test_preview_followup_tokens_after_replace_update_are_no_directive(
     followup_token: str,
 ) -> None:
     engine = create_engine()
@@ -260,7 +260,7 @@ def test_preview_followup_tokens_after_replace_update_are_passthrough(
 
     preview_result = preview(engine, followup_token)
     assert preview_result["decision"] == {
-        "kind": "passthrough",
+        "kind": "no_directive",
         "state": None,
         "prompt_to_user": None,
     }
@@ -274,5 +274,5 @@ def test_preview_followup_tokens_after_replace_update_are_passthrough(
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
     final = step(engine, followup_token)
-    assert final["decision"] == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert final["decision"] == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert final["state"] == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -17,6 +17,7 @@ from context_compiler.audit import (
     state_diff,
 )
 from context_compiler.controller import step
+from context_compiler.engine import DecisionKind
 
 _CONTROLLER_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "controller"
 
@@ -27,7 +28,7 @@ def test_step_wrapper_returns_state_snapshot_and_contract_shape() -> None:
 
     assert result["output_version"] == 1
     assert result["mode"] == "step"
-    assert result["decision"]["kind"] == "update"
+    assert result["decision"]["kind"] == DecisionKind.UPDATE
     assert result["state"] == engine.state
     assert result["state"] == {
         "premise": "concise replies",
@@ -43,7 +44,7 @@ def test_preview_update_does_not_mutate_engine_state() -> None:
     result = preview(engine, "set premise concise replies")
 
     assert result["mode"] == "preview"
-    assert result["decision"]["kind"] == "update"
+    assert result["decision"]["kind"] == DecisionKind.UPDATE
     assert result["state_before"] == before
     assert result["state_after"] == {
         "premise": "concise replies",
@@ -60,7 +61,7 @@ def test_preview_missing_source_replacement_reports_update_without_live_mutation
     result = preview(engine, "use kubectl instead of docker")
 
     assert result["decision"] == {
-        "kind": "update",
+        "kind": DecisionKind.UPDATE,
         "state": {"premise": None, "policies": {"kubectl": "use"}, "version": 2},
         "prompt_to_user": None,
     }
@@ -74,7 +75,7 @@ def test_preview_missing_source_replacement_reports_update_without_live_mutation
     assert result["would_mutate"] is True
 
     yes = engine.step("yes")
-    assert yes["kind"] == "no_directive"
+    assert yes["kind"] == DecisionKind.NO_DIRECTIVE
 
 
 def test_preview_prohibited_replacement_clarify_matches_execution_without_mutation() -> None:
@@ -85,7 +86,7 @@ def test_preview_prohibited_replacement_clarify_matches_execution_without_mutati
     result = preview(engine, "use kubectl instead of docker")
 
     assert result["decision"] == {
-        "kind": "clarify",
+        "kind": DecisionKind.CLARIFY,
         "state": None,
         "prompt_to_user": (
             '"kubectl" is currently prohibited.\n'
@@ -103,7 +104,7 @@ def test_preview_idempotent_update_is_not_a_mutation() -> None:
 
     result = preview(engine, "use docker")
 
-    assert result["decision"]["kind"] == "update"
+    assert result["decision"]["kind"] == DecisionKind.UPDATE
     assert result["state_before"] == result["state_after"]
     assert result["diff"]["changed"] is False
     assert result["would_mutate"] is False
@@ -253,14 +254,14 @@ def test_preview_followup_tokens_after_replace_update_are_no_directive(
     engine = create_engine()
     initial = engine.step("use kubectl instead of docker")
     assert initial == {
-        "kind": "update",
+        "kind": DecisionKind.UPDATE,
         "state": {"premise": None, "policies": {"kubectl": "use"}, "version": 2},
         "prompt_to_user": None,
     }
 
     preview_result = preview(engine, followup_token)
     assert preview_result["decision"] == {
-        "kind": "no_directive",
+        "kind": DecisionKind.NO_DIRECTIVE,
         "state": None,
         "prompt_to_user": None,
     }
@@ -274,5 +275,9 @@ def test_preview_followup_tokens_after_replace_update_are_no_directive(
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
     final = step(engine, followup_token)
-    assert final["decision"] == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert final["decision"] == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert final["state"] == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}

--- a/tests/test_decision_constants.py
+++ b/tests/test_decision_constants.py
@@ -1,20 +1,20 @@
 from context_compiler import (
     DECISION_CLARIFY,
-    DECISION_PASSTHROUGH,
+    DECISION_NO_DIRECTIVE,
     DECISION_UPDATE,
     POLICY_PROHIBIT,
     POLICY_USE,
     get_clarify_prompt,
     get_decision_state,
     is_clarify,
-    is_passthrough,
+    is_no_directive,
     is_update,
 )
 from context_compiler.engine import Decision
 
 
 def test_decision_constants_match_decision_kind_literals() -> None:
-    assert DECISION_PASSTHROUGH == "passthrough"
+    assert DECISION_NO_DIRECTIVE == "no_directive"
     assert DECISION_UPDATE == "update"
     assert DECISION_CLARIFY == "clarify"
 
@@ -33,7 +33,7 @@ def test_decision_helpers_for_update_decision() -> None:
 
     assert is_update(decision) is True
     assert is_clarify(decision) is False
-    assert is_passthrough(decision) is False
+    assert is_no_directive(decision) is False
     assert get_clarify_prompt(decision) is None
     assert get_decision_state(decision) == {
         "premise": "concise replies",
@@ -51,20 +51,20 @@ def test_decision_helpers_for_clarify_decision() -> None:
 
     assert is_update(decision) is False
     assert is_clarify(decision) is True
-    assert is_passthrough(decision) is False
+    assert is_no_directive(decision) is False
     assert get_clarify_prompt(decision) == "Use what item?"
     assert get_decision_state(decision) is None
 
 
-def test_decision_helpers_for_passthrough_decision() -> None:
+def test_decision_helpers_for_no_directive_decision() -> None:
     decision: Decision = {
-        "kind": DECISION_PASSTHROUGH,
+        "kind": DECISION_NO_DIRECTIVE,
         "state": None,
         "prompt_to_user": None,
     }
 
     assert is_update(decision) is False
     assert is_clarify(decision) is False
-    assert is_passthrough(decision) is True
+    assert is_no_directive(decision) is True
     assert get_clarify_prompt(decision) is None
     assert get_decision_state(decision) is None

--- a/tests/test_decision_constants.py
+++ b/tests/test_decision_constants.py
@@ -1,12 +1,12 @@
 from context_compiler import (
-    DECISION_CLARIFY,
+    DECISION_ERROR,
     DECISION_NO_DIRECTIVE,
     DECISION_UPDATE,
     POLICY_PROHIBIT,
     POLICY_USE,
-    get_clarify_prompt,
     get_decision_state,
-    is_clarify,
+    get_error_prompt,
+    is_error,
     is_no_directive,
     is_update,
 )
@@ -16,7 +16,7 @@ from context_compiler.engine import Decision
 def test_decision_constants_match_decision_kind_literals() -> None:
     assert DECISION_NO_DIRECTIVE == "no_directive"
     assert DECISION_UPDATE == "update"
-    assert DECISION_CLARIFY == "clarify"
+    assert DECISION_ERROR == "error"
 
 
 def test_policy_constants_match_policy_literals() -> None:
@@ -32,9 +32,9 @@ def test_decision_helpers_for_update_decision() -> None:
     }
 
     assert is_update(decision) is True
-    assert is_clarify(decision) is False
+    assert is_error(decision) is False
     assert is_no_directive(decision) is False
-    assert get_clarify_prompt(decision) is None
+    assert get_error_prompt(decision) is None
     assert get_decision_state(decision) == {
         "premise": "concise replies",
         "policies": {},
@@ -42,17 +42,17 @@ def test_decision_helpers_for_update_decision() -> None:
     }
 
 
-def test_decision_helpers_for_clarify_decision() -> None:
+def test_decision_helpers_for_error_decision() -> None:
     decision: Decision = {
-        "kind": DECISION_CLARIFY,
+        "kind": DECISION_ERROR,
         "state": None,
         "prompt_to_user": "Use what item?",
     }
 
     assert is_update(decision) is False
-    assert is_clarify(decision) is True
+    assert is_error(decision) is True
     assert is_no_directive(decision) is False
-    assert get_clarify_prompt(decision) == "Use what item?"
+    assert get_error_prompt(decision) == "Use what item?"
     assert get_decision_state(decision) is None
 
 
@@ -64,7 +64,7 @@ def test_decision_helpers_for_no_directive_decision() -> None:
     }
 
     assert is_update(decision) is False
-    assert is_clarify(decision) is False
+    assert is_error(decision) is False
     assert is_no_directive(decision) is True
-    assert get_clarify_prompt(decision) is None
+    assert get_error_prompt(decision) is None
     assert get_decision_state(decision) is None

--- a/tests/test_demo_01_04_behavior.py
+++ b/tests/test_demo_01_04_behavior.py
@@ -82,7 +82,7 @@ def test_demo_01_calls_llm_when_second_turn_is_not_clarify(
             self._step_count += 1
             if self._step_count == 1:
                 return {"kind": "update"}
-            return {"kind": "passthrough"}
+            return {"kind": "no_directive"}
 
     def fake_complete_messages(_messages: object) -> str:
         nonlocal call_count
@@ -118,7 +118,7 @@ def test_demo_01_baseline_and_compiler_use_intentionally_different_gates(
             self._step_count += 1
             if self._step_count == 1:
                 return {"kind": "update"}
-            return {"kind": "passthrough"}
+            return {"kind": "no_directive"}
 
     monkeypatch.setattr(module, "create_engine", _FakeEngine)
     monkeypatch.setattr(

--- a/tests/test_demo_01_04_behavior.py
+++ b/tests/test_demo_01_04_behavior.py
@@ -6,6 +6,8 @@ from types import ModuleType
 
 import pytest
 
+from context_compiler.engine import DecisionKind
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -81,8 +83,8 @@ def test_demo_01_calls_llm_when_second_turn_is_not_clarify(
         def step(self, _text: str) -> dict[str, str]:
             self._step_count += 1
             if self._step_count == 1:
-                return {"kind": "update"}
-            return {"kind": "no_directive"}
+                return {"kind": DecisionKind.UPDATE}
+            return {"kind": DecisionKind.NO_DIRECTIVE}
 
     def fake_complete_messages(_messages: object) -> str:
         nonlocal call_count
@@ -117,8 +119,8 @@ def test_demo_01_baseline_and_compiler_use_intentionally_different_gates(
         def step(self, _text: str) -> dict[str, str]:
             self._step_count += 1
             if self._step_count == 1:
-                return {"kind": "update"}
-            return {"kind": "no_directive"}
+                return {"kind": DecisionKind.UPDATE}
+            return {"kind": DecisionKind.NO_DIRECTIVE}
 
     monkeypatch.setattr(module, "create_engine", _FakeEngine)
     monkeypatch.setattr(

--- a/tests/test_demo_01_04_behavior.py
+++ b/tests/test_demo_01_04_behavior.py
@@ -37,17 +37,17 @@ def _sequenced_outputs(outputs: list[str]) -> Callable[[object], str]:
     return _fake_complete_messages
 
 
-def test_demo_01_reports_host_clarification_gate(
+def test_demo_01_reports_host_error_gate(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    module = _load_demo_module("01_llm_contradiction_clarify.py")
+    module = _load_demo_module("01_llm_contradiction_error.py")
     monkeypatch.setattr(
         module,
         "complete_messages",
         _sequenced_outputs(
             [
                 "ACTION:proceed\nI will continue.",
-                "ACTION:clarify\nNeed clarification.",
+                "ACTION:error\nNeed error.",
             ]
         ),
     )
@@ -69,10 +69,10 @@ def test_demo_01_reports_host_clarification_gate(
     assert "reinjected-state: PASS" in output
 
 
-def test_demo_01_calls_llm_when_second_turn_is_not_clarify(
+def test_demo_01_calls_llm_when_second_turn_is_not_error(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    module = _load_demo_module("01_llm_contradiction_clarify.py")
+    module = _load_demo_module("01_llm_contradiction_error.py")
     call_count = 0
 
     class _FakeEngine:
@@ -91,7 +91,7 @@ def test_demo_01_calls_llm_when_second_turn_is_not_clarify(
         call_count += 1
         if call_count == 1:
             return "ACTION:proceed"
-        return "ACTION:clarify"
+        return "ACTION:error"
 
     monkeypatch.setattr(module, "create_engine", _FakeEngine)
     monkeypatch.setattr(module, "complete_messages", fake_complete_messages)
@@ -109,7 +109,7 @@ def test_demo_01_calls_llm_when_second_turn_is_not_clarify(
 def test_demo_01_baseline_and_compiler_use_intentionally_different_gates(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    module = _load_demo_module("01_llm_contradiction_clarify.py")
+    module = _load_demo_module("01_llm_contradiction_error.py")
 
     class _FakeEngine:
         def __init__(self) -> None:
@@ -128,7 +128,7 @@ def test_demo_01_baseline_and_compiler_use_intentionally_different_gates(
         "complete_messages",
         _sequenced_outputs(
             [
-                "ACTION:clarify",
+                "ACTION:error",
                 "ACTION:proceed",
                 "ACTION:proceed",
                 "ACTION:proceed",
@@ -247,7 +247,7 @@ def test_demo_02_uses_same_prohibited_content_check_for_baseline_and_compiler(
     assert "compiler: PASS" in output
 
 
-def test_demo_02_compact_clarify_branch_skips_compact_llm_call(
+def test_demo_02_compact_error_branch_skips_compact_llm_call(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     module = _load_demo_module("02_llm_constraint_guardrail.py")
@@ -263,7 +263,7 @@ def test_demo_02_compact_clarify_branch_skips_compact_llm_call(
     monkeypatch.setattr(
         module,
         "compact_user_turns",
-        lambda turns: ([], {"premise": None, "policies": {}, "version": 2}, "Need clarification."),
+        lambda turns: ([], {"premise": None, "policies": {}, "version": 2}, "Need error."),
     )
 
     module.main()
@@ -309,7 +309,7 @@ def test_demo_03_reports_explicit_premise_change(
     assert "compiler+compact: PASS" in output
 
 
-def test_demo_03_compact_clarify_branch_reports_compact_fail(
+def test_demo_03_compact_error_branch_reports_compact_fail(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     module = _load_demo_module("03_llm_premise_guardrail.py")
@@ -325,7 +325,7 @@ def test_demo_03_compact_clarify_branch_reports_compact_fail(
     monkeypatch.setattr(
         module,
         "compact_user_turns",
-        lambda turns: ([], {"premise": None, "policies": {}, "version": 2}, "Need clarification."),
+        lambda turns: ([], {"premise": None, "policies": {}, "version": 2}, "Need error."),
     )
 
     module.main()
@@ -372,7 +372,7 @@ def test_demo_04_reports_denylisted_tool_avoidance(
     assert "compiler+compact: PASS" in output
 
 
-def test_demo_04_compact_clarify_branch_skips_compact_tool_call(
+def test_demo_04_compact_error_branch_skips_compact_tool_call(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     module = _load_demo_module("04_llm_tool_denylist_guardrail.py")
@@ -388,7 +388,7 @@ def test_demo_04_compact_clarify_branch_skips_compact_tool_call(
     monkeypatch.setattr(
         module,
         "compact_user_turns",
-        lambda turns: ([], {"premise": None, "policies": {}, "version": 2}, "Need clarification."),
+        lambda turns: ([], {"premise": None, "policies": {}, "version": 2}, "Need error."),
     )
 
     module.main()

--- a/tests/test_demo_08_09_behavior.py
+++ b/tests/test_demo_08_09_behavior.py
@@ -108,10 +108,10 @@ def test_demo_08_reinjected_path_does_not_instantiate_engine(
     assert report["reinjected_state_pass"] is False
 
 
-def test_demo_09_reports_independent_followup_passthrough_boundary(
+def test_demo_09_reports_independent_followup_no_directive_boundary(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    module = _load_demo_module("09_llm_confirmation_passthrough.py")
+    module = _load_demo_module("09_llm_confirmation_no_directive.py")
     monkeypatch.setattr(
         module,
         "complete_messages",
@@ -128,7 +128,7 @@ def test_demo_09_reports_independent_followup_passthrough_boundary(
     report = consume_last_report()
 
     assert report is not None
-    assert report["name"].startswith("09_confirmation_passthrough_boundary")
+    assert report["name"].startswith("09_confirmation_no_directive_boundary")
     assert report["baseline_pass"] is False
     assert report["reinjected_state_pass"] is False
     assert report["compiler_pass"] is True
@@ -141,7 +141,7 @@ def test_demo_09_reports_independent_followup_passthrough_boundary(
 def test_demo_09_reinjected_path_does_not_call_create_engine(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = _load_demo_module("09_llm_confirmation_passthrough.py")
+    module = _load_demo_module("09_llm_confirmation_no_directive.py")
 
     original_create_engine = module.create_engine
     create_engine_calls = 0

--- a/tests/test_demo_compaction.py
+++ b/tests/test_demo_compaction.py
@@ -11,7 +11,7 @@ def test_compaction_drops_only_update_lines_and_keeps_no_directive_lines() -> No
     assert state == {"premise": "concise", "policies": {"docker": "use"}, "version": 2}
 
 
-def test_compaction_keeps_first_clarify_line_and_stops_replay() -> None:
+def test_compaction_keeps_first_error_line_and_stops_replay() -> None:
     compacted, state, prompt = compact_user_turns(
         ["use docker", "prohibit docker", "set premise ignored", "hello"]
     )

--- a/tests/test_demo_compaction.py
+++ b/tests/test_demo_compaction.py
@@ -1,7 +1,7 @@
 from demos.common import compact_user_turns
 
 
-def test_compaction_drops_only_update_lines_and_keeps_passthrough_lines() -> None:
+def test_compaction_drops_only_update_lines_and_keeps_no_directive_lines() -> None:
     compacted, state, prompt = compact_user_turns(
         ["hello", "set premise concise", "world", "use docker"]
     )

--- a/tests/test_demo_oracle_properties.py
+++ b/tests/test_demo_oracle_properties.py
@@ -231,7 +231,7 @@ def test_demo05_non_veg_detection_ignores_inflected_or_freeform_negation(line: s
 
 @given(
     tag=st.sampled_from(["ACTION", "action", " Action "]),
-    value=st.sampled_from(["clarify", "proceed"]),
+    value=st.sampled_from(["error", "proceed"]),
     pre=st.sampled_from(["", " ", "\t"]),
     post=st.sampled_from(["", " ", "\t"]),
 )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -57,7 +57,7 @@ def test_engine_parse_directive_matches_public_decomposition_boundary() -> None:
     )
 
 
-def test_parse_directive_returns_none_for_invalid_syntax_and_passthrough_inputs() -> None:
+def test_parse_directive_returns_none_for_invalid_syntax_and_no_directive_inputs() -> None:
     assert _parse_directive("set premise") is None
     assert _parse_directive("change premise to") is None
     assert _parse_directive("use") is None
@@ -390,7 +390,7 @@ def test_state_property_is_read_only() -> None:
         engine.state = {"premise": None, "policies": {}, "version": 2}
 
 
-def test_non_matching_input_is_passthrough() -> None:
+def test_non_matching_input_is_no_directive() -> None:
     engine = create_engine()
     before = engine.state
 
@@ -404,7 +404,7 @@ def test_non_matching_input_is_passthrough() -> None:
         "don't use docker",
     ]:
         decision = engine.step(text)
-        assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
 
     assert engine.state == before
 
@@ -455,36 +455,36 @@ def test_set_premise_lifecycle_rules() -> None:
     assert engine.state == before
 
 
-def test_set_premise_empty_payload_remains_passthrough() -> None:
+def test_set_premise_empty_payload_remains_no_directive() -> None:
     engine = create_engine()
     before = engine.state
     d1 = engine.step("set premise")
-    assert d1 == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert d1 == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_set_premise_whitespace_payload_remains_passthrough() -> None:
+def test_set_premise_whitespace_payload_remains_no_directive() -> None:
     engine = create_engine()
     before = engine.state
     d1 = engine.step("set premise    ")
-    assert d1 == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert d1 == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_set_premise_to_variant_remains_passthrough() -> None:
+def test_set_premise_to_variant_remains_no_directive() -> None:
     engine = create_engine()
 
     decision = engine.step("set premise to concise replies")
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
-def test_set_premise_to_with_whitespace_payload_remains_passthrough() -> None:
+def test_set_premise_to_with_whitespace_payload_remains_no_directive() -> None:
     engine = create_engine()
 
     decision = engine.step("set premise to   ")
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
@@ -505,54 +505,54 @@ def test_change_premise_requires_existing_premise() -> None:
     assert engine.state["premise"] == "second"
 
 
-def test_change_premise_to_empty_payload_remains_passthrough() -> None:
+def test_change_premise_to_empty_payload_remains_no_directive() -> None:
     engine = create_engine()
     engine.step("set premise baseline")
     before = engine.state
 
     d1 = engine.step("change premise to")
-    assert d1 == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert d1 == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_change_premise_to_without_space_payload_and_empty_variant_remain_passthrough() -> None:
+def test_change_premise_to_without_space_payload_and_empty_variant_remain_no_directive() -> None:
     engine = create_engine()
     engine.step("set premise baseline")
     before = engine.state
 
     near_miss = engine.step("change premise baseline")
-    assert near_miss == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert near_miss == {"kind": "no_directive", "state": None, "prompt_to_user": None}
 
     decision = engine.step("change premise to")
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_change_premise_to_whitespace_payload_remains_passthrough() -> None:
+def test_change_premise_to_whitespace_payload_remains_no_directive() -> None:
     engine = create_engine()
     engine.step("set premise baseline")
     before = engine.state
 
     d1 = engine.step("change premise to    ")
-    assert d1 == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert d1 == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_change_premise_missing_to_variant_is_passthrough() -> None:
+def test_change_premise_missing_to_variant_is_no_directive() -> None:
     engine = create_engine()
     before = engine.state
 
     decision = engine.step("change premise concise replies")
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_change_premise_with_whitespace_after_prefix_remains_passthrough() -> None:
+def test_change_premise_with_whitespace_after_prefix_remains_no_directive() -> None:
     engine = create_engine(state={"premise": "baseline", "policies": {}, "version": 2})
 
     decision = engine.step("change premise   ")
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": "baseline", "policies": {}, "version": 2}
 
 
@@ -613,27 +613,27 @@ def test_policy_directives_and_idempotent_update() -> None:
     assert engine2.state["policies"] == {"docker": "prohibit"}
 
 
-def test_use_empty_payload_remains_passthrough() -> None:
+def test_use_empty_payload_remains_no_directive() -> None:
     engine = create_engine()
     before = engine.state
 
     for text in ["use", "use ", "use    "]:
         decision = engine.step(text)
-        assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
         assert engine.state == before
 
 
-def test_prohibit_empty_payload_remains_passthrough() -> None:
+def test_prohibit_empty_payload_remains_no_directive() -> None:
     engine = create_engine()
     before = engine.state
 
     for text in ["prohibit", "prohibit ", "prohibit    "]:
         decision = engine.step(text)
-        assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
         assert engine.state == before
 
 
-def test_replace_use_incomplete_payload_remains_passthrough() -> None:
+def test_replace_use_incomplete_payload_remains_no_directive() -> None:
     engine = create_engine()
     before = engine.state
 
@@ -645,7 +645,7 @@ def test_replace_use_incomplete_payload_remains_passthrough() -> None:
         "use instead of y",
     ]:
         decision = engine.step(text)
-        assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
         assert engine.state == before
 
 
@@ -692,23 +692,23 @@ def test_remove_policy_missing_item_is_idempotent_update() -> None:
     assert engine.state == before
 
 
-def test_remove_policy_empty_payload_remains_passthrough() -> None:
+def test_remove_policy_empty_payload_remains_no_directive() -> None:
     engine = create_engine()
     before = engine.state
 
     decision = engine.step("remove policy")
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_remove_policy_whitespace_payload_remains_passthrough() -> None:
+def test_remove_policy_whitespace_payload_remains_no_directive() -> None:
     engine = create_engine()
     before = engine.state
 
     decision = engine.step("remove policy    ")
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -745,7 +745,7 @@ def test_replace_use_missing_source_applies_as_use_update() -> None:
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
 
-def test_replace_use_missing_source_yes_followup_is_passthrough() -> None:
+def test_replace_use_missing_source_yes_followup_is_no_directive() -> None:
     engine = create_engine()
 
     first = engine.step("use kubectl instead of docker")
@@ -757,7 +757,7 @@ def test_replace_use_missing_source_yes_followup_is_passthrough() -> None:
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
     second = engine.step("yes")
-    assert second == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert second == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
 
@@ -767,7 +767,7 @@ def test_replace_use_missing_source_no_followup_has_no_mutation() -> None:
     before = engine.state
 
     decision = engine.step("no")
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -851,7 +851,7 @@ def test_replace_use_ky_prohibit_yes_does_not_authorize_mutation() -> None:
 
     assert first["kind"] == "clarify"
     decision = engine.step("yes")
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -918,7 +918,7 @@ def test_replace_use_kx_prohibit_no_followup_has_no_mutation() -> None:
 
     assert first["kind"] == "clarify"
     decision = engine.step("no")
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -932,7 +932,7 @@ def test_missing_source_replacement_does_not_block_following_directives() -> Non
     assert engine.state["policies"] == {"docker": "use", "kubectl": "use"}
 
     third = engine.step("yes")
-    assert third == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert third == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state["policies"] == {"docker": "use", "kubectl": "use"}
 
 
@@ -948,86 +948,86 @@ def test_missing_source_replacement_does_not_suspend_admin_commands() -> None:
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
     resolved = engine.step("yes")
-    assert resolved == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert resolved == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state["policies"] == {}
 
 
-def test_missing_source_replacement_negative_followup_is_passthrough() -> None:
+def test_missing_source_replacement_negative_followup_is_no_directive() -> None:
     engine = create_engine()
     engine.step("use kubectl instead of docker")
 
     decision = engine.step("no")
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state["policies"] == {"kubectl": "use"}
 
 
-def test_missing_source_replacement_affirmative_followup_tokens_are_passthrough() -> None:
+def test_missing_source_replacement_affirmative_followup_tokens_are_no_directive() -> None:
     engine = create_engine()
     engine.step("use kubectl instead of docker")
 
     decision = engine.step("  YES!!!  ")
-    assert decision["kind"] == "passthrough"
+    assert decision["kind"] == "no_directive"
     assert engine.state["policies"] == {"kubectl": "use"}
 
 
-def test_missing_source_replacement_affirmative_token_variants_are_passthrough() -> None:
+def test_missing_source_replacement_affirmative_token_variants_are_no_directive() -> None:
     for token in ["yes please", "Yep", "yeah", "ok", "  OKAY...  ", "sure!"]:
         engine = create_engine()
         engine.step("use kubectl instead of docker")
         decision = engine.step(token)
-        assert decision["kind"] == "passthrough"
+        assert decision["kind"] == "no_directive"
         assert engine.state["policies"] == {"kubectl": "use"}
 
 
-def test_missing_source_replacement_negative_tokens_are_passthrough() -> None:
+def test_missing_source_replacement_negative_tokens_are_no_directive() -> None:
     engine = create_engine()
     engine.step("use kubectl instead of docker")
     before = engine.state
 
     decision = engine.step("  NO!!!  ")
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_missing_source_replacement_no_thanks_is_passthrough() -> None:
+def test_missing_source_replacement_no_thanks_is_no_directive() -> None:
     engine = create_engine()
     engine.step("use kubectl instead of docker")
     before = engine.state
 
     decision = engine.step("no thanks.")
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_missing_source_replacement_negative_token_variants_are_passthrough() -> None:
+def test_missing_source_replacement_negative_token_variants_are_no_directive() -> None:
     for token in ["nope", "Nope??", " no ", "NO THANKS!"]:
         engine = create_engine()
         engine.step("use kubectl instead of docker")
         before = engine.state
         decision = engine.step(token)
-        assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
         assert engine.state == before
 
 
-def test_missing_source_replacement_unmatched_followup_is_passthrough() -> None:
+def test_missing_source_replacement_unmatched_followup_is_no_directive() -> None:
     engine = create_engine()
     engine.step("use kubectl instead of docker")
     before = engine.state
 
     second = engine.step("maybe")
-    assert second == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert second == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_missing_source_replacement_unmatched_followups_remain_passthrough() -> None:
+def test_missing_source_replacement_unmatched_followups_remain_no_directive() -> None:
     engine = create_engine()
     engine.step("use kubectl instead of docker")
     before = engine.state
 
-    assert engine.step("later") == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert engine.step("later") == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.step("still later") == {
-        "kind": "passthrough",
+        "kind": "no_directive",
         "state": None,
         "prompt_to_user": None,
     }
@@ -1044,7 +1044,7 @@ def test_prohibited_replacement_yes_cannot_override_conflicting_target_polarity(
     assert engine.state["policies"] == {"docker": "use", "kubectl": "prohibit"}
 
     second = engine.step("yes")
-    assert second["kind"] == "passthrough"
+    assert second["kind"] == "no_directive"
     assert engine.state["policies"] == {"docker": "use", "kubectl": "prohibit"}
 
 
@@ -1057,11 +1057,11 @@ def test_import_json_does_not_change_independent_yes_no_followup_behavior() -> N
     engine.import_json(json.dumps(imported))
 
     yes_decision = engine.step("yes")
-    assert yes_decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert yes_decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == imported
 
     no_decision = engine.step("no")
-    assert no_decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert no_decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
 
 
 def test_remove_policy_uses_normalized_item_matching() -> None:
@@ -1124,7 +1124,7 @@ def test_remove_policy_uses_normalized_item_matching() -> None:
         ),
     ],
 )
-def test_compound_directives_remain_passthrough_without_mutation(
+def test_compound_directives_remain_no_directive_without_mutation(
     user_input: str, initial_state: dict[str, object]
 ) -> None:
     engine = create_engine(state=initial_state)
@@ -1132,16 +1132,16 @@ def test_compound_directives_remain_passthrough_without_mutation(
 
     decision = engine.step(user_input)
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_quoted_non_directive_leading_input_remains_passthrough() -> None:
+def test_quoted_non_directive_leading_input_remains_no_directive() -> None:
     engine = create_engine()
 
     decision = engine.step('"use docker and prohibit peanuts"')
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
@@ -1277,10 +1277,10 @@ def test_all_canonical_directive_starts_remain_single_directive_when_valid(
 
     decision = engine.step(directive_start)
 
-    assert decision["kind"] != "passthrough"
+    assert decision["kind"] != "no_directive"
 
 
-def test_compound_passthrough_after_prior_missing_source_replacement_update() -> None:
+def test_compound_no_directive_after_prior_missing_source_replacement_update() -> None:
     engine = create_engine()
     first = engine.step("use kubectl instead of docker")
     assert first == {
@@ -1291,7 +1291,7 @@ def test_compound_passthrough_after_prior_missing_source_replacement_update() ->
 
     decision = engine.step("use docker and prohibit peanuts")
 
-    assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -68,38 +68,38 @@ def test_parse_directive_returns_none_for_invalid_syntax_and_no_directive_inputs
     assert _parse_directive("hello there") is None
 
 
-def test_pre_mutation_clarify_empty_operand_branches_remain_stable() -> None:
+def test_pre_mutation_error_empty_operand_branches_remain_stable() -> None:
     engine = create_engine()
 
-    assert engine._pre_mutation_clarify(Action(kind="set_premise", value="")) == {
-        "kind": "clarify",
+    assert engine._pre_mutation_error(Action(kind="set_premise", value="")) == {
+        "kind": "error",
         "state": None,
         "prompt_to_user": (
             "Premise value cannot be empty.\nUse 'set premise <value>' with a non-empty value."
         ),
     }
-    assert engine._pre_mutation_clarify(Action(kind="change_premise", value="")) == {
-        "kind": "clarify",
+    assert engine._pre_mutation_error(Action(kind="change_premise", value="")) == {
+        "kind": "error",
         "state": None,
         "prompt_to_user": (
             "Premise value cannot be empty.\n"
             "Use 'change premise to <value>' with a non-empty value."
         ),
     }
-    assert engine._pre_mutation_clarify(Action(kind="remove_policy_item", item="")) == {
-        "kind": "clarify",
+    assert engine._pre_mutation_error(Action(kind="remove_policy_item", item="")) == {
+        "kind": "error",
         "state": None,
         "prompt_to_user": (
             "Policy item cannot be empty.\nUse 'remove policy <item>' with a non-empty value."
         ),
     }
-    assert engine._pre_mutation_clarify(Action(kind="use_item", item="")) == {
-        "kind": "clarify",
+    assert engine._pre_mutation_error(Action(kind="use_item", item="")) == {
+        "kind": "error",
         "state": None,
         "prompt_to_user": "Policy item cannot be empty.\nUse 'use <item>' with a non-empty value.",
     }
-    assert engine._pre_mutation_clarify(Action(kind="prohibit_item", item="")) == {
-        "kind": "clarify",
+    assert engine._pre_mutation_error(Action(kind="prohibit_item", item="")) == {
+        "kind": "error",
         "state": None,
         "prompt_to_user": (
             "Policy item cannot be empty.\nUse 'prohibit <item>' with a non-empty value."
@@ -306,7 +306,7 @@ def test_replace_use_clarifies_when_old_policy_is_not_use_in_invalid_internal_st
     decision = engine.step("use kubectl instead of docker")
 
     assert decision == {
-        "kind": "clarify",
+        "kind": "error",
         "state": None,
         "prompt_to_user": (
             "\"docker\" is not currently in use.\nReplacement requires an active 'use' policy."
@@ -421,7 +421,7 @@ def test_lexical_normalization_accepts_canonical_directives() -> None:
     assert engine.step("clear state\t")["kind"] == DecisionKind.UPDATE
     assert engine.step("Use docker")["kind"] == DecisionKind.UPDATE
     assert engine.step("use\tdocker")["kind"] == DecisionKind.UPDATE
-    assert engine.step(" prohibit docker")["kind"] == DecisionKind.CLARIFY
+    assert engine.step(" prohibit docker")["kind"] == DecisionKind.ERROR
 
 
 def test_clear_premise_is_idempotent_update_when_already_null() -> None:
@@ -452,7 +452,7 @@ def test_set_premise_lifecycle_rules() -> None:
     before = engine.state
     d2 = engine.step("set premise new")
     assert d2 == {
-        "kind": DecisionKind.CLARIFY,
+        "kind": DecisionKind.ERROR,
         "state": None,
         "prompt_to_user": ("Premise already set.\nUse 'change premise to <value>' to modify it."),
     }
@@ -505,7 +505,7 @@ def test_change_premise_requires_existing_premise() -> None:
 
     d1 = engine.step("change premise to concise")
     assert d1 == {
-        "kind": "clarify",
+        "kind": "error",
         "state": None,
         "prompt_to_user": "No premise is set.\nUse 'set premise <value>' to define one.",
     }
@@ -613,7 +613,7 @@ def test_policy_directives_and_idempotent_update() -> None:
     assert engine.state["policies"] == {"docker": "use"}
 
     d3 = engine.step("prohibit docker")
-    assert d3["kind"] == "clarify"
+    assert d3["kind"] == "error"
     assert d3["prompt_to_user"] == (
         '"docker" is currently in use.\nRemove or replace it before prohibiting it.'
     )
@@ -626,7 +626,7 @@ def test_policy_directives_and_idempotent_update() -> None:
     assert engine2.state["policies"] == {"docker": "prohibit"}
 
     d5 = engine2.step("use docker")
-    assert d5["kind"] == "clarify"
+    assert d5["kind"] == "error"
     assert d5["prompt_to_user"] == (
         '"docker" is currently prohibited.\nRemove or replace it before using it.'
     )
@@ -815,7 +815,7 @@ def test_replace_use_missing_source_still_reports_target_prohibit_when_new_item_
 
     decision = engine.step("use kubectl instead of docker")
     assert decision == {
-        "kind": "clarify",
+        "kind": "error",
         "state": None,
         "prompt_to_user": (
             '"kubectl" is currently prohibited.\n'
@@ -860,7 +860,7 @@ def test_replace_use_missing_source_with_empty_probe_uses_invalid_prompt() -> No
     }
 
 
-def test_replace_use_ky_prohibit_returns_clarify_without_mutation() -> None:
+def test_replace_use_ky_prohibit_returns_error_without_mutation() -> None:
     engine = create_engine()
     engine.step("prohibit docker")
     engine.step("use pytest")
@@ -871,7 +871,7 @@ def test_replace_use_ky_prohibit_returns_clarify_without_mutation() -> None:
         "Submit explicit directive(s) to remove it or use a different item."
     )
     assert first == {
-        "kind": "clarify",
+        "kind": "error",
         "state": None,
         "prompt_to_user": expected,
     }
@@ -885,13 +885,13 @@ def test_replace_use_ky_prohibit_yes_does_not_authorize_mutation() -> None:
     first = engine.step("use kubectl instead of docker")
     before = engine.state
 
-    assert first["kind"] == "clarify"
+    assert first["kind"] == "error"
     decision = engine.step("yes")
     assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
-def test_replace_use_kx_prohibit_returns_clarify_without_mutation() -> None:
+def test_replace_use_kx_prohibit_returns_error_without_mutation() -> None:
     engine = create_engine()
     engine.step("use docker")
     engine.step("prohibit kubectl")
@@ -902,14 +902,14 @@ def test_replace_use_kx_prohibit_returns_clarify_without_mutation() -> None:
         "Submit explicit directive(s) to remove it or use a different item."
     )
     assert first == {
-        "kind": "clarify",
+        "kind": "error",
         "state": None,
         "prompt_to_user": expected,
     }
     assert engine.state["policies"] == {"docker": "use", "kubectl": "prohibit"}
 
 
-def test_replace_use_priority_prefers_source_prohibit_clarify_when_both_prohibit() -> None:
+def test_replace_use_priority_prefers_source_prohibit_error_when_both_prohibit() -> None:
     engine = create_engine()
     engine.step("prohibit docker")
     engine.step("prohibit kubectl")
@@ -920,7 +920,7 @@ def test_replace_use_priority_prefers_source_prohibit_clarify_when_both_prohibit
         "Submit explicit directive(s) to remove it or use a different item."
     )
     assert first == {
-        "kind": "clarify",
+        "kind": "error",
         "state": None,
         "prompt_to_user": expected,
     }
@@ -935,7 +935,7 @@ def test_replace_use_invalid_source_state_prohibit_clarifies_without_mutation() 
 
     decision = engine.step("use kubectl instead of docker")
     assert decision == {
-        "kind": "clarify",
+        "kind": "error",
         "state": None,
         "prompt_to_user": (
             '"docker" is currently prohibited.\n'
@@ -952,7 +952,7 @@ def test_replace_use_kx_prohibit_no_followup_has_no_mutation() -> None:
     first = engine.step("use kubectl instead of docker")
     before = engine.state
 
-    assert first["kind"] == "clarify"
+    assert first["kind"] == "error"
     decision = engine.step("no")
     assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
@@ -1092,7 +1092,7 @@ def test_prohibited_replacement_yes_cannot_override_conflicting_target_polarity(
     engine.step("prohibit kubectl")
 
     first = engine.step("use kubectl instead of docker")
-    assert first["kind"] == "clarify"
+    assert first["kind"] == "error"
     assert engine.state["policies"] == {"docker": "use", "kubectl": "prohibit"}
 
     second = engine.step("yes")
@@ -1248,7 +1248,7 @@ def test_directive_like_substrings_inside_larger_words_do_not_trigger_compound_r
 
     decision = engine.step(user_input)
 
-    assert decision["kind"] != DecisionKind.CLARIFY
+    assert decision["kind"] != DecisionKind.ERROR
     assert decision["kind"] == expected_decision_kind
     assert engine.state == expected_state
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -404,7 +404,11 @@ def test_non_matching_input_is_no_directive() -> None:
         "don't use docker",
     ]:
         decision = engine.step(text)
-        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+        assert decision == {
+            "kind": DecisionKind.NO_DIRECTIVE,
+            "state": None,
+            "prompt_to_user": None,
+        }
 
     assert engine.state == before
 
@@ -412,12 +416,12 @@ def test_non_matching_input_is_no_directive() -> None:
 def test_lexical_normalization_accepts_canonical_directives() -> None:
     engine = create_engine()
 
-    assert engine.step("clear premise ")["kind"] == "update"
-    assert engine.step(" reset policies")["kind"] == "update"
-    assert engine.step("clear state\t")["kind"] == "update"
-    assert engine.step("Use docker")["kind"] == "update"
-    assert engine.step("use\tdocker")["kind"] == "update"
-    assert engine.step(" prohibit docker")["kind"] == "clarify"
+    assert engine.step("clear premise ")["kind"] == DecisionKind.UPDATE
+    assert engine.step(" reset policies")["kind"] == DecisionKind.UPDATE
+    assert engine.step("clear state\t")["kind"] == DecisionKind.UPDATE
+    assert engine.step("Use docker")["kind"] == DecisionKind.UPDATE
+    assert engine.step("use\tdocker")["kind"] == DecisionKind.UPDATE
+    assert engine.step(" prohibit docker")["kind"] == DecisionKind.CLARIFY
 
 
 def test_clear_premise_is_idempotent_update_when_already_null() -> None:
@@ -425,7 +429,7 @@ def test_clear_premise_is_idempotent_update_when_already_null() -> None:
     before = engine.state
 
     decision = engine.step("clear premise")
-    assert decision == {"kind": "update", "state": before, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.UPDATE, "state": before, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -434,7 +438,7 @@ def test_clear_state_is_idempotent_update_when_already_empty() -> None:
     before = engine.state
 
     decision = engine.step("clear state")
-    assert decision == {"kind": "update", "state": before, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.UPDATE, "state": before, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -442,13 +446,13 @@ def test_set_premise_lifecycle_rules() -> None:
     engine = create_engine()
 
     d1 = engine.step("set premise   concise   replies")
-    assert d1["kind"] == "update"
+    assert d1["kind"] == DecisionKind.UPDATE
     assert engine.state["premise"] == "concise replies"
 
     before = engine.state
     d2 = engine.step("set premise new")
     assert d2 == {
-        "kind": "clarify",
+        "kind": DecisionKind.CLARIFY,
         "state": None,
         "prompt_to_user": ("Premise already set.\nUse 'change premise to <value>' to modify it."),
     }
@@ -459,7 +463,7 @@ def test_set_premise_empty_payload_remains_no_directive() -> None:
     engine = create_engine()
     before = engine.state
     d1 = engine.step("set premise")
-    assert d1 == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert d1 == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -467,7 +471,7 @@ def test_set_premise_whitespace_payload_remains_no_directive() -> None:
     engine = create_engine()
     before = engine.state
     d1 = engine.step("set premise    ")
-    assert d1 == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert d1 == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -475,7 +479,11 @@ def test_set_premise_to_variant_remains_no_directive() -> None:
     engine = create_engine()
 
     decision = engine.step("set premise to concise replies")
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
@@ -484,7 +492,11 @@ def test_set_premise_to_with_whitespace_payload_remains_no_directive() -> None:
 
     decision = engine.step("set premise to   ")
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
@@ -501,7 +513,7 @@ def test_change_premise_requires_existing_premise() -> None:
 
     engine.step("set premise first")
     d2 = engine.step("change premise to second")
-    assert d2["kind"] == "update"
+    assert d2["kind"] == DecisionKind.UPDATE
     assert engine.state["premise"] == "second"
 
 
@@ -511,7 +523,7 @@ def test_change_premise_to_empty_payload_remains_no_directive() -> None:
     before = engine.state
 
     d1 = engine.step("change premise to")
-    assert d1 == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert d1 == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -521,10 +533,18 @@ def test_change_premise_to_without_space_payload_and_empty_variant_remain_no_dir
     before = engine.state
 
     near_miss = engine.step("change premise baseline")
-    assert near_miss == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert near_miss == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
 
     decision = engine.step("change premise to")
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert engine.state == before
 
 
@@ -534,7 +554,7 @@ def test_change_premise_to_whitespace_payload_remains_no_directive() -> None:
     before = engine.state
 
     d1 = engine.step("change premise to    ")
-    assert d1 == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert d1 == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -543,7 +563,7 @@ def test_change_premise_missing_to_variant_is_no_directive() -> None:
     before = engine.state
 
     decision = engine.step("change premise concise replies")
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -552,7 +572,7 @@ def test_change_premise_with_whitespace_after_prefix_remains_no_directive() -> N
 
     decision = engine.step("change premise   ")
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": "baseline", "policies": {}, "version": 2}
 
 
@@ -562,8 +582,8 @@ def test_canonical_premise_forms_still_update_normally() -> None:
     first = engine.step("set premise concise replies")
     second = engine.step("change premise to concise bullet points")
 
-    assert first["kind"] == "update"
-    assert second["kind"] == "update"
+    assert first["kind"] == DecisionKind.UPDATE
+    assert second["kind"] == DecisionKind.UPDATE
     assert engine.state["premise"] == "concise bullet points"
 
 
@@ -573,11 +593,11 @@ def test_clear_premise_and_clear_state() -> None:
     engine.step("use docker")
 
     d1 = engine.step("clear premise")
-    assert d1["kind"] == "update"
+    assert d1["kind"] == DecisionKind.UPDATE
     assert engine.state == {"premise": None, "policies": {"docker": "use"}, "version": 2}
 
     d2 = engine.step("clear state")
-    assert d2["kind"] == "update"
+    assert d2["kind"] == DecisionKind.UPDATE
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
@@ -585,11 +605,11 @@ def test_policy_directives_and_idempotent_update() -> None:
     engine = create_engine()
 
     d1 = engine.step("use   The Docker")
-    assert d1["kind"] == "update"
+    assert d1["kind"] == DecisionKind.UPDATE
     assert engine.state["policies"] == {"docker": "use"}
 
     d2 = engine.step("use docker")
-    assert d2["kind"] == "update"
+    assert d2["kind"] == DecisionKind.UPDATE
     assert engine.state["policies"] == {"docker": "use"}
 
     d3 = engine.step("prohibit docker")
@@ -619,7 +639,11 @@ def test_use_empty_payload_remains_no_directive() -> None:
 
     for text in ["use", "use ", "use    "]:
         decision = engine.step(text)
-        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+        assert decision == {
+            "kind": DecisionKind.NO_DIRECTIVE,
+            "state": None,
+            "prompt_to_user": None,
+        }
         assert engine.state == before
 
 
@@ -629,7 +653,11 @@ def test_prohibit_empty_payload_remains_no_directive() -> None:
 
     for text in ["prohibit", "prohibit ", "prohibit    "]:
         decision = engine.step(text)
-        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+        assert decision == {
+            "kind": DecisionKind.NO_DIRECTIVE,
+            "state": None,
+            "prompt_to_user": None,
+        }
         assert engine.state == before
 
 
@@ -645,19 +673,23 @@ def test_replace_use_incomplete_payload_remains_no_directive() -> None:
         "use instead of y",
     ]:
         decision = engine.step(text)
-        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+        assert decision == {
+            "kind": DecisionKind.NO_DIRECTIVE,
+            "state": None,
+            "prompt_to_user": None,
+        }
         assert engine.state == before
 
 
 def test_reset_policies_is_update_even_when_already_empty() -> None:
     engine = create_engine()
     d1 = engine.step("reset policies")
-    assert d1["kind"] == "update"
+    assert d1["kind"] == DecisionKind.UPDATE
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
     engine.step("use docker")
     d2 = engine.step("reset policies")
-    assert d2["kind"] == "update"
+    assert d2["kind"] == DecisionKind.UPDATE
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
@@ -667,7 +699,7 @@ def test_remove_policy_removes_existing_use_policy() -> None:
 
     decision = engine.step("remove policy docker")
 
-    assert decision["kind"] == "update"
+    assert decision["kind"] == DecisionKind.UPDATE
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
@@ -677,7 +709,7 @@ def test_remove_policy_removes_existing_prohibit_policy() -> None:
 
     decision = engine.step("remove policy docker")
 
-    assert decision["kind"] == "update"
+    assert decision["kind"] == DecisionKind.UPDATE
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
@@ -688,7 +720,7 @@ def test_remove_policy_missing_item_is_idempotent_update() -> None:
 
     decision = engine.step("remove policy podman")
 
-    assert decision == {"kind": "update", "state": before, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.UPDATE, "state": before, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -698,7 +730,7 @@ def test_remove_policy_empty_payload_remains_no_directive() -> None:
 
     decision = engine.step("remove policy")
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -708,7 +740,7 @@ def test_remove_policy_whitespace_payload_remains_no_directive() -> None:
 
     decision = engine.step("remove policy    ")
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -718,7 +750,7 @@ def test_replace_use_success() -> None:
 
     decision = engine.step("use kubectl instead of docker")
 
-    assert decision["kind"] == "update"
+    assert decision["kind"] == DecisionKind.UPDATE
     assert engine.state["policies"] == {"kubectl": "use"}
 
 
@@ -729,7 +761,7 @@ def test_replace_use_identity_is_noop_update() -> None:
 
     decision = engine.step("use the docker instead of docker")
 
-    assert decision["kind"] == "update"
+    assert decision["kind"] == DecisionKind.UPDATE
     assert engine.state == before
 
 
@@ -757,7 +789,11 @@ def test_replace_use_missing_source_yes_followup_is_no_directive() -> None:
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
     second = engine.step("yes")
-    assert second == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert second == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
 
@@ -767,7 +803,7 @@ def test_replace_use_missing_source_no_followup_has_no_mutation() -> None:
     before = engine.state
 
     decision = engine.step("no")
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -793,7 +829,7 @@ def test_replace_use_missing_source_ignores_unrelated_existing_policies() -> Non
     engine.step("use python and docker")
 
     decision = engine.step("use kubectl instead of python")
-    assert decision["kind"] == "update"
+    assert decision["kind"] == DecisionKind.UPDATE
     assert engine.state["policies"] == {"kubectl": "use", "python and docker": "use"}
 
 
@@ -803,7 +839,7 @@ def test_replace_use_missing_source_ignores_other_conflicting_entries() -> None:
     engine.step("prohibit python tooling")
 
     decision = engine.step("use kubectl instead of python")
-    assert decision["kind"] == "update"
+    assert decision["kind"] == DecisionKind.UPDATE
     assert engine.state["policies"] == {
         "kubectl": "use",
         "python and docker": "use",
@@ -816,7 +852,7 @@ def test_replace_use_missing_source_with_empty_probe_uses_invalid_prompt() -> No
     engine.step("use python and docker")
 
     decision = engine.step("use kubectl instead of the")
-    assert decision["kind"] == "update"
+    assert decision["kind"] == DecisionKind.UPDATE
     assert engine.state == {
         "premise": None,
         "policies": {"kubectl": "use", "python and docker": "use"},
@@ -851,7 +887,7 @@ def test_replace_use_ky_prohibit_yes_does_not_authorize_mutation() -> None:
 
     assert first["kind"] == "clarify"
     decision = engine.step("yes")
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -918,7 +954,7 @@ def test_replace_use_kx_prohibit_no_followup_has_no_mutation() -> None:
 
     assert first["kind"] == "clarify"
     decision = engine.step("no")
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -932,7 +968,7 @@ def test_missing_source_replacement_does_not_block_following_directives() -> Non
     assert engine.state["policies"] == {"docker": "use", "kubectl": "use"}
 
     third = engine.step("yes")
-    assert third == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert third == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state["policies"] == {"docker": "use", "kubectl": "use"}
 
 
@@ -948,7 +984,11 @@ def test_missing_source_replacement_does_not_suspend_admin_commands() -> None:
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
     resolved = engine.step("yes")
-    assert resolved == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert resolved == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert engine.state["policies"] == {}
 
 
@@ -958,7 +998,7 @@ def test_missing_source_replacement_negative_followup_is_no_directive() -> None:
 
     decision = engine.step("no")
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state["policies"] == {"kubectl": "use"}
 
 
@@ -967,7 +1007,7 @@ def test_missing_source_replacement_affirmative_followup_tokens_are_no_directive
     engine.step("use kubectl instead of docker")
 
     decision = engine.step("  YES!!!  ")
-    assert decision["kind"] == "no_directive"
+    assert decision["kind"] == DecisionKind.NO_DIRECTIVE
     assert engine.state["policies"] == {"kubectl": "use"}
 
 
@@ -976,7 +1016,7 @@ def test_missing_source_replacement_affirmative_token_variants_are_no_directive(
         engine = create_engine()
         engine.step("use kubectl instead of docker")
         decision = engine.step(token)
-        assert decision["kind"] == "no_directive"
+        assert decision["kind"] == DecisionKind.NO_DIRECTIVE
         assert engine.state["policies"] == {"kubectl": "use"}
 
 
@@ -986,7 +1026,7 @@ def test_missing_source_replacement_negative_tokens_are_no_directive() -> None:
     before = engine.state
 
     decision = engine.step("  NO!!!  ")
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -996,7 +1036,7 @@ def test_missing_source_replacement_no_thanks_is_no_directive() -> None:
     before = engine.state
 
     decision = engine.step("no thanks.")
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -1006,7 +1046,11 @@ def test_missing_source_replacement_negative_token_variants_are_no_directive() -
         engine.step("use kubectl instead of docker")
         before = engine.state
         decision = engine.step(token)
-        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+        assert decision == {
+            "kind": DecisionKind.NO_DIRECTIVE,
+            "state": None,
+            "prompt_to_user": None,
+        }
         assert engine.state == before
 
 
@@ -1016,7 +1060,11 @@ def test_missing_source_replacement_unmatched_followup_is_no_directive() -> None
     before = engine.state
 
     second = engine.step("maybe")
-    assert second == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert second == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert engine.state == before
 
 
@@ -1025,9 +1073,13 @@ def test_missing_source_replacement_unmatched_followups_remain_no_directive() ->
     engine.step("use kubectl instead of docker")
     before = engine.state
 
-    assert engine.step("later") == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert engine.step("later") == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert engine.step("still later") == {
-        "kind": "no_directive",
+        "kind": DecisionKind.NO_DIRECTIVE,
         "state": None,
         "prompt_to_user": None,
     }
@@ -1044,24 +1096,32 @@ def test_prohibited_replacement_yes_cannot_override_conflicting_target_polarity(
     assert engine.state["policies"] == {"docker": "use", "kubectl": "prohibit"}
 
     second = engine.step("yes")
-    assert second["kind"] == "no_directive"
+    assert second["kind"] == DecisionKind.NO_DIRECTIVE
     assert engine.state["policies"] == {"docker": "use", "kubectl": "prohibit"}
 
 
 def test_import_json_does_not_change_independent_yes_no_followup_behavior() -> None:
     engine = create_engine()
     first = engine.step("use kubectl instead of docker")
-    assert first["kind"] == "update"
+    assert first["kind"] == DecisionKind.UPDATE
 
     imported = {"premise": "baseline", "policies": {"pytest": "use"}, "version": 2}
     engine.import_json(json.dumps(imported))
 
     yes_decision = engine.step("yes")
-    assert yes_decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert yes_decision == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
     assert engine.state == imported
 
     no_decision = engine.step("no")
-    assert no_decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert no_decision == {
+        "kind": DecisionKind.NO_DIRECTIVE,
+        "state": None,
+        "prompt_to_user": None,
+    }
 
 
 def test_remove_policy_uses_normalized_item_matching() -> None:
@@ -1069,7 +1129,7 @@ def test_remove_policy_uses_normalized_item_matching() -> None:
     engine.step("use The Docker")
 
     decision = engine.step("remove policy the docker")
-    assert decision["kind"] == "update"
+    assert decision["kind"] == DecisionKind.UPDATE
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
@@ -1132,7 +1192,7 @@ def test_compound_directives_remain_no_directive_without_mutation(
 
     decision = engine.step(user_input)
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == before
 
 
@@ -1141,7 +1201,7 @@ def test_quoted_non_directive_leading_input_remains_no_directive() -> None:
 
     decision = engine.step('"use docker and prohibit peanuts"')
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": None, "policies": {}, "version": 2}
 
 
@@ -1188,7 +1248,7 @@ def test_directive_like_substrings_inside_larger_words_do_not_trigger_compound_r
 
     decision = engine.step(user_input)
 
-    assert decision["kind"] != "clarify"
+    assert decision["kind"] != DecisionKind.CLARIFY
     assert decision["kind"] == expected_decision_kind
     assert engine.state == expected_state
 
@@ -1250,7 +1310,11 @@ def test_valid_single_directives_still_work(
 
     decision = engine.step(user_input)
 
-    assert decision == {"kind": "update", "state": expected_state, "prompt_to_user": None}
+    assert decision == {
+        "kind": DecisionKind.UPDATE,
+        "state": expected_state,
+        "prompt_to_user": None,
+    }
     assert engine.state == expected_state
 
 
@@ -1277,21 +1341,21 @@ def test_all_canonical_directive_starts_remain_single_directive_when_valid(
 
     decision = engine.step(directive_start)
 
-    assert decision["kind"] != "no_directive"
+    assert decision["kind"] != DecisionKind.NO_DIRECTIVE
 
 
 def test_compound_no_directive_after_prior_missing_source_replacement_update() -> None:
     engine = create_engine()
     first = engine.step("use kubectl instead of docker")
     assert first == {
-        "kind": "update",
+        "kind": DecisionKind.UPDATE,
         "state": {"premise": None, "policies": {"kubectl": "use"}, "version": 2},
         "prompt_to_user": None,
     }
 
     decision = engine.step("use docker and prohibit peanuts")
 
-    assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+    assert decision == {"kind": DecisionKind.NO_DIRECTIVE, "state": None, "prompt_to_user": None}
     assert engine.state == {"premise": None, "policies": {"kubectl": "use"}, "version": 2}
 
 

--- a/tests/test_examples_behavior.py
+++ b/tests/test_examples_behavior.py
@@ -29,10 +29,10 @@ def _load_example_module(filename: str) -> ModuleType:
     return module
 
 
-def test_example_03_clarify_gate_blocks_llm_and_allows_later_update(
+def test_example_03_error_gate_blocks_llm_and_allows_later_update(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    module = _load_example_module("03_ambiguity_with_clarification.py")
+    module = _load_example_module("03_ambiguity_with_error.py")
     decision_kinds: list[DecisionKind] = []
     llm_calls: list[str] = []
 
@@ -54,10 +54,10 @@ def test_example_03_clarify_gate_blocks_llm_and_allows_later_update(
 
     assert decision_kinds == [
         DecisionKind.UPDATE,
-        DecisionKind.CLARIFY,
+        DecisionKind.ERROR,
         DecisionKind.UPDATE,
     ]
-    assert "Host behavior: clarification returned, do NOT call LLM." in output
+    assert "Host behavior: error returned, do NOT call LLM." in output
     assert llm_calls == []
 
 
@@ -85,7 +85,7 @@ def test_example_04_tool_governance_blocks_and_allows_expected_tools(
     assert allowed_tools == ["kubectl"]
 
 
-def test_example_05_dispatches_no_directive_update_and_clarify_correctly(
+def test_example_05_dispatches_no_directive_update_and_error_correctly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _load_example_module("05_llm_integration_pattern.py")
@@ -108,15 +108,15 @@ def test_example_05_dispatches_no_directive_update_and_clarify_correctly(
 
     module.handle_turn("hello there", engine)  # no_directive
     module.handle_turn("set premise concise replies", engine)  # update
-    calls_before_clarify = len(llm_calls)
-    module.handle_turn("set premise verbose replies", engine)  # clarify
+    calls_before_error = len(llm_calls)
+    module.handle_turn("set premise verbose replies", engine)  # error
 
     assert decision_kinds == [
         DecisionKind.NO_DIRECTIVE,
         DecisionKind.UPDATE,
-        DecisionKind.CLARIFY,
+        DecisionKind.ERROR,
     ]
-    assert len(llm_calls) == calls_before_clarify
+    assert len(llm_calls) == calls_before_error
     assert llm_calls[0][0] is None
     assert llm_calls[0][1] == "hello there"
     assert llm_calls[1][0] is not None

--- a/tests/test_examples_behavior.py
+++ b/tests/test_examples_behavior.py
@@ -79,7 +79,7 @@ def test_example_04_tool_governance_blocks_and_allows_expected_tools(
     assert allowed_tools == ["kubectl"]
 
 
-def test_example_05_dispatches_passthrough_update_and_clarify_correctly(
+def test_example_05_dispatches_no_directive_update_and_clarify_correctly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _load_example_module("05_llm_integration_pattern.py")
@@ -100,12 +100,12 @@ def test_example_05_dispatches_passthrough_update_and_clarify_correctly(
     monkeypatch.setattr(module, "print_decision_summary", capture_decision_summary)
     monkeypatch.setattr(module, "fake_llm", capture_fake_llm)
 
-    module.handle_turn("hello there", engine)  # passthrough
+    module.handle_turn("hello there", engine)  # no_directive
     module.handle_turn("set premise concise replies", engine)  # update
     calls_before_clarify = len(llm_calls)
     module.handle_turn("set premise verbose replies", engine)  # clarify
 
-    assert decision_kinds == ["passthrough", "update", "clarify"]
+    assert decision_kinds == ["no_directive", "update", "clarify"]
     assert len(llm_calls) == calls_before_clarify
     assert llm_calls[0][0] is None
     assert llm_calls[0][1] == "hello there"

--- a/tests/test_examples_behavior.py
+++ b/tests/test_examples_behavior.py
@@ -5,6 +5,8 @@ from types import ModuleType
 
 import pytest
 
+from context_compiler.engine import DecisionKind
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 EXAMPLES_DIR = REPO_ROOT / "examples"
 
@@ -31,13 +33,13 @@ def test_example_03_clarify_gate_blocks_llm_and_allows_later_update(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     module = _load_example_module("03_ambiguity_with_clarification.py")
-    decision_kinds: list[str] = []
+    decision_kinds: list[DecisionKind] = []
     llm_calls: list[str] = []
 
     def capture_decision_summary(decision: object) -> None:
         assert isinstance(decision, dict)
         kind = decision.get("kind")
-        assert isinstance(kind, str)
+        assert isinstance(kind, DecisionKind)
         decision_kinds.append(kind)
 
     def fake_llm(user_input: str) -> str:
@@ -50,7 +52,11 @@ def test_example_03_clarify_gate_blocks_llm_and_allows_later_update(
     module.main()
     output = capsys.readouterr().out
 
-    assert decision_kinds == ["update", "clarify", "update"]
+    assert decision_kinds == [
+        DecisionKind.UPDATE,
+        DecisionKind.CLARIFY,
+        DecisionKind.UPDATE,
+    ]
     assert "Host behavior: clarification returned, do NOT call LLM." in output
     assert llm_calls == []
 
@@ -84,13 +90,13 @@ def test_example_05_dispatches_no_directive_update_and_clarify_correctly(
 ) -> None:
     module = _load_example_module("05_llm_integration_pattern.py")
     engine = module.create_engine()
-    decision_kinds: list[str] = []
+    decision_kinds: list[DecisionKind] = []
     llm_calls: list[tuple[object, str]] = []
 
     def capture_decision_summary(decision: object) -> None:
         assert isinstance(decision, dict)
         kind = decision.get("kind")
-        assert isinstance(kind, str)
+        assert isinstance(kind, DecisionKind)
         decision_kinds.append(kind)
 
     def capture_fake_llm(state: object, user_input: str) -> str:
@@ -105,7 +111,11 @@ def test_example_05_dispatches_no_directive_update_and_clarify_correctly(
     calls_before_clarify = len(llm_calls)
     module.handle_turn("set premise verbose replies", engine)  # clarify
 
-    assert decision_kinds == ["no_directive", "update", "clarify"]
+    assert decision_kinds == [
+        DecisionKind.NO_DIRECTIVE,
+        DecisionKind.UPDATE,
+        DecisionKind.CLARIFY,
+    ]
     assert len(llm_calls) == calls_before_clarify
     assert llm_calls[0][0] is None
     assert llm_calls[0][1] == "hello there"

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.contract
         (
             "05_llm_integration_pattern.py",
             (
-                "Host action: passthrough -> call fake_llm() without state",
+                "Host action: no_directive -> core recognized no canonical directive",
                 "Host action: update -> call fake_llm() with compiled state",
             ),
         ),

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -26,9 +26,9 @@ pytestmark = pytest.mark.contract
             ),
         ),
         (
-            "03_ambiguity_with_clarification.py",
+            "03_ambiguity_with_error.py",
             (
-                "Host behavior: clarification returned, do NOT call LLM.",
+                "Host behavior: error returned, do NOT call LLM.",
                 "Remove or replace it before using it.",
             ),
         ),

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -329,7 +329,7 @@ def test_step_fixtures() -> None:
 
         assert decision["kind"] == expected_decision["kind"], fixture_id
 
-        if decision["kind"] == DecisionKind.CLARIFY:
+        if decision["kind"] == DecisionKind.ERROR:
             assert decision["state"] == expected_decision["state"], fixture_id
             expected_prompt = expected_decision["prompt_to_user"]
             actual_prompt = decision["prompt_to_user"]

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -6,6 +6,7 @@ import pytest
 
 from context_compiler import create_engine, get_decision_state
 from context_compiler.controller import get_step_state, preview, state_diff, step
+from context_compiler.engine import DecisionKind
 from context_compiler.grammar import (
     DirectiveKind,
     decompose_directive,
@@ -328,7 +329,7 @@ def test_step_fixtures() -> None:
 
         assert decision["kind"] == expected_decision["kind"], fixture_id
 
-        if decision["kind"] == "clarify":
+        if decision["kind"] == DecisionKind.CLARIFY:
             assert decision["state"] == expected_decision["state"], fixture_id
             expected_prompt = expected_decision["prompt_to_user"]
             actual_prompt = decision["prompt_to_user"]
@@ -339,7 +340,7 @@ def test_step_fixtures() -> None:
         else:
             assert decision == expected_decision, fixture_id
 
-        if decision["kind"] == "update":
+        if decision["kind"] == DecisionKind.UPDATE:
             assert decision["state"] == engine.state, fixture_id
 
         assert engine.state == expected["state"], fixture_id

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -8,7 +8,7 @@ from hypothesis import strategies as st
 
 from context_compiler import create_engine
 from context_compiler.controller import preview, state_diff
-from context_compiler.engine import State
+from context_compiler.engine import DecisionKind, State
 from context_compiler.grammar import (
     DirectiveKind,
     match_canonical_directive_start,
@@ -304,8 +304,8 @@ def test_use_item_with_empty_normalized_payload_clarifies_without_mutation(
     d2 = engine.step(f"use {item}")
 
     expected_prompt = "Policy item cannot be empty.\nUse 'use <item>' with a non-empty value."
-    assert d1 == {"kind": "clarify", "state": None, "prompt_to_user": expected_prompt}
-    assert d2 == {"kind": "clarify", "state": None, "prompt_to_user": expected_prompt}
+    assert d1 == {"kind": DecisionKind.CLARIFY, "state": None, "prompt_to_user": expected_prompt}
+    assert d2 == {"kind": DecisionKind.CLARIFY, "state": None, "prompt_to_user": expected_prompt}
     assert engine.state == before
 
 
@@ -318,8 +318,8 @@ def test_idempotent_prohibit_item_is_update_and_stable_state(item: str) -> None:
     d1 = engine.step(f"prohibit {item}")
     d2 = engine.step(f"prohibit {item}")
 
-    assert d1["kind"] == "update"
-    assert d2["kind"] == "update"
+    assert d1["kind"] == DecisionKind.UPDATE
+    assert d2["kind"] == DecisionKind.UPDATE
     assert len(engine.state["policies"]) == 1
 
 
@@ -340,8 +340,8 @@ def test_prohibit_item_with_empty_normalized_payload_clarifies_without_mutation(
     d2 = engine.step(f"prohibit {item}")
 
     expected_prompt = "Policy item cannot be empty.\nUse 'prohibit <item>' with a non-empty value."
-    assert d1 == {"kind": "clarify", "state": None, "prompt_to_user": expected_prompt}
-    assert d2 == {"kind": "clarify", "state": None, "prompt_to_user": expected_prompt}
+    assert d1 == {"kind": DecisionKind.CLARIFY, "state": None, "prompt_to_user": expected_prompt}
+    assert d2 == {"kind": DecisionKind.CLARIFY, "state": None, "prompt_to_user": expected_prompt}
     assert engine.state == before
 
 
@@ -352,7 +352,7 @@ def test_non_matching_inputs_can_remain_no_directive_only(inputs: list[str]) -> 
 
     for text in inputs:
         decision = engine.step(f"please {text}")
-        assert decision["kind"] == "no_directive"
+        assert decision["kind"] == DecisionKind.NO_DIRECTIVE
 
     assert engine.state == before
 
@@ -364,7 +364,11 @@ def test_no_directive_sequence_preserves_state_and_decision_kind(inputs: list[st
 
     for text in inputs:
         decision = engine.step(f"prefix {text}")
-        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+        assert decision == {
+            "kind": DecisionKind.NO_DIRECTIVE,
+            "state": None,
+            "prompt_to_user": None,
+        }
         assert engine.state == before
 
 
@@ -378,7 +382,7 @@ def test_contradiction_use_after_prohibit_always_clarifies(item: str) -> None:
     before = engine.state
 
     decision = engine.step(f"use {item}")
-    assert decision["kind"] == "clarify"
+    assert decision["kind"] == DecisionKind.CLARIFY
     assert engine.state == before
 
 
@@ -395,7 +399,7 @@ def test_contradiction_prohibit_after_use_always_clarifies(item: str) -> None:
     before = engine.state
 
     decision = engine.step(f"prohibit {item}")
-    assert decision["kind"] == "clarify"
+    assert decision["kind"] == DecisionKind.CLARIFY
     assert engine.state == before
 
 
@@ -454,13 +458,21 @@ def test_deterministic_replacement_matches_equivalent_explicit_transition(
     engine = create_engine(state=initial_state)
     decision = engine.step(f"use {new_item} instead of {old_item}")
 
-    assert expected_decision == {"kind": "update", "state": expected_state, "prompt_to_user": None}
+    assert expected_decision == {
+        "kind": DecisionKind.UPDATE,
+        "state": expected_state,
+        "prompt_to_user": None,
+    }
     assert decision == expected_decision
     assert engine.state == expected_state
 
     if not old_present:
         followup = engine.step("yes")
-        assert followup == {"kind": "no_directive", "state": None, "prompt_to_user": None}
+        assert followup == {
+            "kind": DecisionKind.NO_DIRECTIVE,
+            "state": None,
+            "prompt_to_user": None,
+        }
         assert engine.state == expected_state
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -304,8 +304,8 @@ def test_use_item_with_empty_normalized_payload_clarifies_without_mutation(
     d2 = engine.step(f"use {item}")
 
     expected_prompt = "Policy item cannot be empty.\nUse 'use <item>' with a non-empty value."
-    assert d1 == {"kind": DecisionKind.CLARIFY, "state": None, "prompt_to_user": expected_prompt}
-    assert d2 == {"kind": DecisionKind.CLARIFY, "state": None, "prompt_to_user": expected_prompt}
+    assert d1 == {"kind": DecisionKind.ERROR, "state": None, "prompt_to_user": expected_prompt}
+    assert d2 == {"kind": DecisionKind.ERROR, "state": None, "prompt_to_user": expected_prompt}
     assert engine.state == before
 
 
@@ -340,8 +340,8 @@ def test_prohibit_item_with_empty_normalized_payload_clarifies_without_mutation(
     d2 = engine.step(f"prohibit {item}")
 
     expected_prompt = "Policy item cannot be empty.\nUse 'prohibit <item>' with a non-empty value."
-    assert d1 == {"kind": DecisionKind.CLARIFY, "state": None, "prompt_to_user": expected_prompt}
-    assert d2 == {"kind": DecisionKind.CLARIFY, "state": None, "prompt_to_user": expected_prompt}
+    assert d1 == {"kind": DecisionKind.ERROR, "state": None, "prompt_to_user": expected_prompt}
+    assert d2 == {"kind": DecisionKind.ERROR, "state": None, "prompt_to_user": expected_prompt}
     assert engine.state == before
 
 
@@ -382,7 +382,7 @@ def test_contradiction_use_after_prohibit_always_clarifies(item: str) -> None:
     before = engine.state
 
     decision = engine.step(f"use {item}")
-    assert decision["kind"] == DecisionKind.CLARIFY
+    assert decision["kind"] == DecisionKind.ERROR
     assert engine.state == before
 
 
@@ -399,7 +399,7 @@ def test_contradiction_prohibit_after_use_always_clarifies(item: str) -> None:
     before = engine.state
 
     decision = engine.step(f"prohibit {item}")
-    assert decision["kind"] == DecisionKind.CLARIFY
+    assert decision["kind"] == DecisionKind.ERROR
     assert engine.state == before
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -346,25 +346,25 @@ def test_prohibit_item_with_empty_normalized_payload_clarifies_without_mutation(
 
 
 @given(st.lists(st.text(max_size=80), min_size=0, max_size=20))
-def test_non_matching_inputs_can_remain_passthrough_only(inputs: list[str]) -> None:
+def test_non_matching_inputs_can_remain_no_directive_only(inputs: list[str]) -> None:
     engine = create_engine()
     before = engine.state
 
     for text in inputs:
         decision = engine.step(f"please {text}")
-        assert decision["kind"] == "passthrough"
+        assert decision["kind"] == "no_directive"
 
     assert engine.state == before
 
 
 @given(st.lists(st.text(max_size=50), min_size=0, max_size=30))
-def test_passthrough_sequence_preserves_state_and_decision_kind(inputs: list[str]) -> None:
+def test_no_directive_sequence_preserves_state_and_decision_kind(inputs: list[str]) -> None:
     engine = create_engine()
     before = engine.state
 
     for text in inputs:
         decision = engine.step(f"prefix {text}")
-        assert decision == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+        assert decision == {"kind": "no_directive", "state": None, "prompt_to_user": None}
         assert engine.state == before
 
 
@@ -460,7 +460,7 @@ def test_deterministic_replacement_matches_equivalent_explicit_transition(
 
     if not old_present:
         followup = engine.step("yes")
-        assert followup == {"kind": "passthrough", "state": None, "prompt_to_user": None}
+        assert followup == {"kind": "no_directive", "state": None, "prompt_to_user": None}
         assert engine.state == expected_state
 
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -9,6 +9,7 @@ import pytest
 
 import context_compiler.repl as repl_module
 from context_compiler import __version__, create_engine
+from context_compiler.engine import DecisionKind
 from context_compiler.repl import run_repl
 
 pytestmark = pytest.mark.contract
@@ -516,7 +517,7 @@ def test_repl_non_interactive_json_bare_input_step_result() -> None:
     assert row["command"] == "input"
     decision = row["decision"]
     assert isinstance(decision, dict)
-    assert decision["kind"] == "update"
+    assert decision["kind"] == DecisionKind.UPDATE
 
 
 def test_repl_non_interactive_json_step_and_preview_results() -> None:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -168,10 +168,10 @@ def test_main_with_json_flag_runs_repl_with_json_mode(monkeypatch: pytest.Monkey
     assert called["json_mode"] is True
 
 
-def test_render_decision_lines_uses_error_prefix_for_all_clarify_prompts() -> None:
+def test_render_decision_lines_uses_error_prefix_for_all_error_prompts() -> None:
     lines = repl_module._render_decision_lines(
         {
-            "kind": "clarify",
+            "kind": "error",
             "state": None,
             "prompt_to_user": "Proceed?",
         }
@@ -440,7 +440,7 @@ def test_repl_update_flow() -> None:
     assert lines == ["updated", "premise: concise", "policies: (none)"]
 
 
-def test_repl_clarify_flow() -> None:
+def test_repl_error_flow() -> None:
     lines = _run_non_interactive_lines("prohibit docker\nuse kubectl instead of docker\nquit\n")
     assert _contains_subsequence(
         lines, ["updated", "premise: (none)", "policies:", "- prohibit docker"]
@@ -485,7 +485,7 @@ def test_repl_interactive_help_commands() -> None:
         "  clear state",
         "Bare input behavior remains unchanged.",
         "preview is a deterministic dry-run and never mutates live state.",
-        "clarify results are immediate messages and do not reserve later input.",
+        "error results are immediate messages and do not reserve later input.",
     ]
     assert lines[0] == "Context Compiler REPL (0.5). Type help for commands."
     assert lines[1] == "Non-directive input is no_directive."
@@ -543,12 +543,12 @@ def test_repl_non_interactive_json_state_command() -> None:
     assert state["policies"] == {}
 
 
-def test_repl_non_interactive_json_clarify_and_no_directive() -> None:
+def test_repl_non_interactive_json_error_and_no_directive() -> None:
     rows = _run_non_interactive_json_lines(
         "prohibit docker\nuse kubectl instead of docker\nyes\nhello\nquit\n"
     )
     assert rows[1]["mode"] == "step"
-    assert rows[1]["decision"]["kind"] == "clarify"
+    assert rows[1]["decision"]["kind"] == "error"
     assert rows[3]["mode"] == "step"
     assert rows[3]["decision"]["kind"] == "no_directive"
 
@@ -788,7 +788,7 @@ def test_repl_interactive_rejects_multi_command_chunk() -> None:
     assert "updated" not in lines
 
 
-def test_repl_non_interactive_rejects_multi_command_chunk_with_human_readable_clarify() -> None:
+def test_repl_non_interactive_rejects_multi_command_chunk_with_human_readable_error() -> None:
     out = StringIO()
     run_repl(
         _ChunkedInput(["set premise concise\nprohibit peanuts\n", "quit\n"]),  # type: ignore[arg-type]
@@ -862,7 +862,7 @@ def test_repl_non_interactive_remove_policy_flow() -> None:
     assert lines.count("policies: (none)") == 2
 
 
-def test_repl_contradiction_clarify_does_not_reserve_followup_tokens() -> None:
+def test_repl_contradiction_error_does_not_reserve_followup_tokens() -> None:
     lines = _run_non_interactive_lines("use docker\nprohibit docker\nno\nquit\n")
     assert _contains_subsequence(lines, ["updated", "premise: (none)", "policies:", "- use docker"])
     assert _contains_subsequence(
@@ -933,7 +933,7 @@ def test_repl_replacement_invalid_followups_are_no_directive() -> None:
     assert lines[-2:] == ["no_directive", "no_directive"]
 
 
-def test_repl_interactive_prints_error_for_clarify_output() -> None:
+def test_repl_interactive_prints_error_for_error_output() -> None:
     error_out = _TTYStringIO()
     run_repl(_TTYStringIO("use docker\nprohibit docker\nquit\n"), error_out)
     error_lines = error_out.getvalue().splitlines()
@@ -1026,7 +1026,7 @@ def test_repl_interactive_admin_idempotency_outputs_updated_with_unchanged_state
     assert lines.count("policies: (none)") == 3
 
 
-def test_repl_interactive_clarify_output_alignment_for_actual_behaviors() -> None:
+def test_repl_interactive_error_output_alignment_for_actual_behaviors() -> None:
     lines = _run_interactive_lines(
         "set premise concise\n"
         "set premise verbose\n"

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -487,7 +487,7 @@ def test_repl_interactive_help_commands() -> None:
         "clarify results are immediate messages and do not reserve later input.",
     ]
     assert lines[0] == "Context Compiler REPL (0.5). Type help for commands."
-    assert lines[1] == "Non-directive input is passthrough."
+    assert lines[1] == "Non-directive input is no_directive."
     expected_help_len = len(expected_help)
     assert lines[2 : 2 + expected_help_len] == expected_help
     assert lines[2 + expected_help_len : 2 + (2 * expected_help_len)] == expected_help
@@ -498,7 +498,7 @@ def test_repl_non_interactive_uses_human_readable_output() -> None:
     run_repl(StringIO("hello\nquit\n"), out)
 
     lines = out.getvalue().splitlines()
-    assert lines == ["passthrough"]
+    assert lines == ["no_directive"]
 
 
 def _run_non_interactive_json_lines(text: str) -> list[dict[str, object]]:
@@ -542,14 +542,14 @@ def test_repl_non_interactive_json_state_command() -> None:
     assert state["policies"] == {}
 
 
-def test_repl_non_interactive_json_clarify_and_passthrough() -> None:
+def test_repl_non_interactive_json_clarify_and_no_directive() -> None:
     rows = _run_non_interactive_json_lines(
         "prohibit docker\nuse kubectl instead of docker\nyes\nhello\nquit\n"
     )
     assert rows[1]["mode"] == "step"
     assert rows[1]["decision"]["kind"] == "clarify"
     assert rows[3]["mode"] == "step"
-    assert rows[3]["decision"]["kind"] == "passthrough"
+    assert rows[3]["decision"]["kind"] == "no_directive"
 
 
 def test_repl_non_interactive_json_machine_readable_errors() -> None:
@@ -645,8 +645,8 @@ def test_repl_non_interactive_preview_reports_no_mutation_after_invalid_replacem
         lines,
         ["updated", "premise: (none)", "policies:", "- use kubectl"],
     )
-    assert _contains_subsequence(lines, ["preview", "passthrough", "would_mutate: no"])
-    assert lines[-1] == "passthrough"
+    assert _contains_subsequence(lines, ["preview", "no_directive", "would_mutate: no"])
+    assert lines[-1] == "no_directive"
 
 
 def test_repl_non_interactive_preview_decline_reports_no_mutation() -> None:
@@ -654,7 +654,7 @@ def test_repl_non_interactive_preview_decline_reports_no_mutation() -> None:
     run_repl(StringIO("use kubectl instead of docker\npreview no\nquit\n"), out)
     lines = [line for line in out.getvalue().splitlines() if line.strip()]
 
-    assert _contains_subsequence(lines, ["preview", "passthrough"])
+    assert _contains_subsequence(lines, ["preview", "no_directive"])
     assert _contains_subsequence(lines, ["would_mutate: no", "diff:", "- (none)"])
 
 
@@ -685,7 +685,7 @@ def test_repl_state_command_after_invalid_replacement_shows_unchanged_state() ->
         ["updated", "premise: (none)", "policies:", "- use kubectl"],
     )
     assert _contains_subsequence(lines, ["premise: (none)", "policies:", "- use kubectl"])
-    assert lines[-1] == "passthrough"
+    assert lines[-1] == "no_directive"
 
 
 def test_repl_step_command_runs_normally_after_invalid_replacement() -> None:
@@ -704,10 +704,10 @@ def test_repl_step_command_runs_normally_after_invalid_replacement() -> None:
         lines,
         ["updated", "premise: concise", "policies:", "- use kubectl"],
     )
-    assert lines[-1] == "passthrough"
+    assert lines[-1] == "no_directive"
 
 
-def test_repl_step_command_affirmative_followup_is_passthrough() -> None:
+def test_repl_step_command_affirmative_followup_is_no_directive() -> None:
     out = StringIO()
     run_repl(StringIO("use kubectl instead of docker\nstep yes\nquit\n"), out)
     lines = [line for line in out.getvalue().splitlines() if line.strip()]
@@ -716,10 +716,10 @@ def test_repl_step_command_affirmative_followup_is_passthrough() -> None:
         lines,
         ["updated", "premise: (none)", "policies:", "- use kubectl"],
     )
-    assert lines[-1] == "passthrough"
+    assert lines[-1] == "no_directive"
 
 
-def test_repl_step_command_negative_followup_is_passthrough() -> None:
+def test_repl_step_command_negative_followup_is_no_directive() -> None:
     out = StringIO()
     run_repl(StringIO("use kubectl instead of docker\nstep no\nquit\n"), out)
     lines = [line for line in out.getvalue().splitlines() if line.strip()]
@@ -728,7 +728,7 @@ def test_repl_step_command_negative_followup_is_passthrough() -> None:
         lines,
         ["updated", "premise: (none)", "policies:", "- use kubectl"],
     )
-    assert lines[-1] == "passthrough"
+    assert lines[-1] == "no_directive"
 
 
 def test_repl_preview_available_after_invalid_replacement() -> None:
@@ -736,8 +736,8 @@ def test_repl_preview_available_after_invalid_replacement() -> None:
     run_repl(StringIO("use kubectl instead of docker\npreview yes\nyes\nquit\n"), out)
     lines = [line for line in out.getvalue().splitlines() if line.strip()]
 
-    assert _contains_subsequence(lines, ["preview", "passthrough", "would_mutate: no"])
-    assert lines[-1] == "passthrough"
+    assert _contains_subsequence(lines, ["preview", "no_directive", "would_mutate: no"])
+    assert lines[-1] == "no_directive"
 
 
 def test_repl_interactive_preview_available_after_invalid_replacement() -> None:
@@ -747,8 +747,8 @@ def test_repl_interactive_preview_available_after_invalid_replacement() -> None:
         lines,
         ["updated", "premise: (none)", "policies:", "- use kubectl"],
     )
-    assert _contains_subsequence(lines, ["preview", "passthrough", "would_mutate: no"])
-    assert lines[-1] == "passthrough"
+    assert _contains_subsequence(lines, ["preview", "no_directive", "would_mutate: no"])
+    assert lines[-1] == "no_directive"
 
 
 def test_repl_interactive_help_available_after_invalid_replacement() -> None:
@@ -760,7 +760,7 @@ def test_repl_interactive_help_available_after_invalid_replacement() -> None:
     )
     assert _contains_subsequence(lines, ["Commands: help/? exit/quit"])
     assert _contains_subsequence(lines, ["REPL command layer (not engine directives):"])
-    assert lines[-1] == "passthrough"
+    assert lines[-1] == "no_directive"
 
 
 def test_repl_preview_idempotent_admin_action_reports_no_mutation() -> None:
@@ -817,7 +817,7 @@ def test_repl_non_interactive_accepts_crlf_single_line_without_multi_command_err
     )
 
     lines = out.getvalue().splitlines()
-    assert lines == ["passthrough"]
+    assert lines == ["no_directive"]
 
 
 def test_repl_interactive_rejects_embedded_carriage_return_multi_command_chunk() -> None:
@@ -833,23 +833,23 @@ def test_repl_interactive_rejects_embedded_carriage_return_multi_command_chunk()
     assert "updated" not in lines
 
 
-def test_repl_invalid_directive_near_misses_remain_passthrough() -> None:
+def test_repl_invalid_directive_near_misses_remain_no_directive() -> None:
     lines = _run_non_interactive_lines("actually use uv\nno use peanuts\nallow docker\nquit\n")
-    assert lines == ["passthrough", "passthrough", "passthrough"]
+    assert lines == ["no_directive", "no_directive", "no_directive"]
 
 
-def test_repl_empty_policy_payloads_and_incomplete_replacement_remain_passthrough() -> None:
+def test_repl_empty_policy_payloads_and_incomplete_replacement_remain_no_directive() -> None:
     lines = _run_non_interactive_lines(
         "use\nprohibit   \nuse x instead of\nuse instead of y\nquit\n"
     )
-    assert lines == ["passthrough", "passthrough", "passthrough", "passthrough"]
+    assert lines == ["no_directive", "no_directive", "no_directive", "no_directive"]
 
 
-def test_repl_premise_to_variant_near_misses_remain_passthrough() -> None:
+def test_repl_premise_to_variant_near_misses_remain_no_directive() -> None:
     lines = _run_non_interactive_lines(
         "set premise to concise replies\nchange premise concise replies\nquit\n"
     )
-    assert lines == ["passthrough", "passthrough"]
+    assert lines == ["no_directive", "no_directive"]
 
 
 def test_repl_non_interactive_remove_policy_flow() -> None:
@@ -869,7 +869,7 @@ def test_repl_contradiction_clarify_does_not_reserve_followup_tokens() -> None:
         [
             'error: "docker" is currently in use.',
             "Remove or replace it before prohibiting it.",
-            "passthrough",
+            "no_directive",
         ],
     )
 
@@ -885,14 +885,14 @@ def test_repl_change_premise_without_existing_premise_renders_exact_error() -> N
     )
 
 
-def test_repl_set_premise_empty_payload_remains_passthrough() -> None:
+def test_repl_set_premise_empty_payload_remains_no_directive() -> None:
     lines = _run_non_interactive_lines("set premise\nquit\n")
-    assert lines == ["passthrough"]
+    assert lines == ["no_directive"]
 
 
-def test_repl_change_premise_empty_payload_remains_passthrough() -> None:
+def test_repl_change_premise_empty_payload_remains_no_directive() -> None:
     lines = _run_non_interactive_lines("change premise to\nquit\n")
-    assert lines == ["passthrough"]
+    assert lines == ["no_directive"]
 
 
 def test_repl_use_item_when_prohibited_renders_exact_error() -> None:
@@ -926,10 +926,10 @@ def test_repl_replace_use_when_old_policy_not_use_renders_exact_error(
     )
 
 
-def test_repl_replacement_invalid_followups_are_passthrough() -> None:
+def test_repl_replacement_invalid_followups_are_no_directive() -> None:
     lines = _run_non_interactive_lines("use podman instead of docker\nmaybe\nyes please!!\nquit\n")
     assert _contains_subsequence(lines, ["updated", "premise: (none)", "policies:", "- use podman"])
-    assert lines[-2:] == ["passthrough", "passthrough"]
+    assert lines[-2:] == ["no_directive", "no_directive"]
 
 
 def test_repl_interactive_prints_error_for_clarify_output() -> None:
@@ -940,7 +940,7 @@ def test_repl_interactive_prints_error_for_clarify_output() -> None:
     assert "Remove or replace it before prohibiting it." in error_lines
 
 
-def test_repl_prohibited_replacement_followup_tokens_remain_passthrough() -> None:
+def test_repl_prohibited_replacement_followup_tokens_remain_no_directive() -> None:
     lines = _run_non_interactive_lines(
         "use docker\nprohibit podman\nuse podman instead of docker\nno\nno\nquit\n"
     )
@@ -967,7 +967,7 @@ def test_repl_prohibited_replacement_followup_tokens_remain_passthrough() -> Non
             "Submit explicit directive(s) to remove it or use a different item.",
         ],
     )
-    assert lines[-1] == "passthrough"
+    assert lines[-1] == "no_directive"
 
 
 def test_repl_premise_lifecycle_outputs_expected_state_shape() -> None:
@@ -999,22 +999,22 @@ def test_repl_interactive_renders_updated_state_blocks_for_multiple_operations()
     assert _contains_subsequence(lines, ["updated", "premise: (none)", "policies:", "- use docker"])
 
 
-def test_repl_interactive_tokens_after_invalid_replacement_are_passthrough() -> None:
+def test_repl_interactive_tokens_after_invalid_replacement_are_no_directive() -> None:
     lines_yes = _run_interactive_lines("use podman instead of docker\nyeah\nquit\n")
     assert "updated" in lines_yes
-    assert lines_yes[-1] == "passthrough"
+    assert lines_yes[-1] == "no_directive"
 
     lines_ok = _run_interactive_lines("use buildah instead of docker\nok\nquit\n")
     assert "updated" in lines_ok
-    assert lines_ok[-1] == "passthrough"
+    assert lines_ok[-1] == "no_directive"
 
     lines_nope = _run_interactive_lines("use nerdctl instead of docker\nnope\nquit\n")
     assert "updated" in lines_nope
-    assert lines_nope[-1] == "passthrough"
+    assert lines_nope[-1] == "no_directive"
 
     lines_no_thanks = _run_interactive_lines("use helm instead of docker\nno thanks\nquit\n")
     assert "updated" in lines_no_thanks
-    assert lines_no_thanks[-1] == "passthrough"
+    assert lines_no_thanks[-1] == "no_directive"
 
 
 def test_repl_interactive_admin_idempotency_outputs_updated_with_unchanged_state() -> None:
@@ -1045,16 +1045,16 @@ def test_repl_interactive_clarify_output_alignment_for_actual_behaviors() -> Non
     )
 
 
-def test_repl_interactive_passthrough_prints_passthrough_label() -> None:
+def test_repl_interactive_no_directive_prints_no_directive_label() -> None:
     lines = _run_interactive_lines("actually use uv\nquit\n")
-    assert "passthrough" in lines
+    assert "no_directive" in lines
 
 
 def test_repl_interactive_blank_line_is_ignored_without_output() -> None:
     lines = _run_interactive_lines("\nset premise concise\nquit\n")
 
     assert lines[0] == "Context Compiler REPL (0.5). Type help for commands."
-    assert lines[1] == "Non-directive input is passthrough."
+    assert lines[1] == "Non-directive input is no_directive."
     assert lines.count("updated") == 1
     assert _contains_subsequence(lines, ["updated", "premise: concise", "policies: (none)"])
 
@@ -1063,7 +1063,7 @@ def test_repl_interactive_eof_returns_cleanly_after_startup_banner() -> None:
     lines = _run_interactive_lines("")
     assert lines == [
         "Context Compiler REPL (0.5). Type help for commands.",
-        "Non-directive input is passthrough.",
+        "Non-directive input is no_directive.",
     ]
 
 
@@ -1127,7 +1127,7 @@ def test_repl_interactive_step_command_paths_after_invalid_replacement() -> None
         lines,
         ["updated", "premise: (none)", "policies:", "- use kubectl"],
     )
-    assert lines[-2:] == ["passthrough", "passthrough"]
+    assert lines[-2:] == ["no_directive", "no_directive"]
 
 
 def test_repl_interactive_preview_requires_payload() -> None:

--- a/tests/test_repl_properties.py
+++ b/tests/test_repl_properties.py
@@ -33,8 +33,8 @@ def _run_repl_lines(lines: list[str]) -> tuple[str, list[str]]:
 
 def _oracle_render_decision(decision: dict[str, object]) -> list[str]:
     kind = decision["kind"]
-    if kind == "passthrough":
-        return ["passthrough"]
+    if kind == "no_directive":
+        return ["no_directive"]
 
     if kind == "clarify":
         prompt_obj = decision["prompt_to_user"]

--- a/tests/test_repl_properties.py
+++ b/tests/test_repl_properties.py
@@ -36,7 +36,7 @@ def _oracle_render_decision(decision: dict[str, object]) -> list[str]:
     if kind == "no_directive":
         return ["no_directive"]
 
-    if kind == "clarify":
+    if kind == "error":
         prompt_obj = decision["prompt_to_user"]
         prompt = prompt_obj if isinstance(prompt_obj, str) else ""
         prompt_lines = prompt.splitlines() if prompt else [""]

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -50,7 +50,7 @@ def _info_report() -> run_demo.InfoReport:
 
 def test_demo_file_mapping_uses_current_0_5_demo_filenames() -> None:
     assert run_demo.DEMO_FILES == {
-        "1": "01_llm_contradiction_clarify.py",
+        "1": "01_llm_contradiction_error.py",
         "2": "02_llm_constraint_guardrail.py",
         "3": "03_llm_premise_guardrail.py",
         "4": "04_llm_tool_denylist_guardrail.py",

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -58,7 +58,7 @@ def test_demo_file_mapping_uses_current_0_5_demo_filenames() -> None:
         "6": "06_llm_context_compaction.py",
         "7": "07_llm_prompt_vs_state.py",
         "8": "08_llm_replacement_precondition.py",
-        "9": "09_llm_confirmation_passthrough.py",
+        "9": "09_llm_confirmation_no_directive.py",
     }
 
     demos_dir = REPO_ROOT / "demos"


### PR DESCRIPTION
## What changed

- renamed the `Decision.kind` contract value `passthrough` to `no_directive` across runtime code, public exports, docs, demos, tests, and conformance fixtures
- renamed the `Decision.kind` contract value `clarify` to `error` across the same public surface, including helper names and fixture IDs/filenames where they are part of the contract surface
- updated Python-side comparisons to use `DecisionKind` where appropriate instead of raw decision-kind literals, while leaving JSON fixtures and documented wire values as literals

## Why

- the existing decision taxonomy was carrying stale terminology that no longer matched the compiler-like contract semantics
- `no_directive` better expresses that core did not recognize a canonical directive and made no authoritative state change
- `error` better expresses the current semantic outcome than `clarify`
- using `DecisionKind` in Python comparisons makes the internal code and tests more consistent without changing the public wire contract

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
