### PR TITLE
docs: prefer branch-first decision examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ Use Context Compiler in your host application first:
 ```python
 from context_compiler import (
     create_engine,
-    get_error_message,
     is_error,
     is_update,
 )
@@ -148,7 +147,7 @@ user_input = "set premise current project uses uv"
 decision = engine.step(user_input)
 
 if is_error(decision):
-    show_to_user(get_error_message(decision))
+    show_to_user(decision["message"])
 elif is_update(decision):
     messages = build_messages(engine.state, user_input)
     render(call_llm(messages))

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -159,12 +159,12 @@ Helper functions:
 Typical use:
 
 ```python
-from context_compiler import get_error_message, is_error, is_update
+from context_compiler import is_error, is_update
 
 decision = engine.step(user_input)
 
 if is_error(decision):
-    show_to_user(get_error_message(decision))
+    show_to_user(decision["message"])
 elif is_update(decision):
     apply_runtime_rules()
 ```

--- a/examples/03_ambiguity_with_error.py
+++ b/examples/03_ambiguity_with_error.py
@@ -2,7 +2,7 @@
 
 from _util import print_decision_summary, print_state_summary
 
-from context_compiler import create_engine, get_error_message, is_error
+from context_compiler import create_engine, is_error
 
 
 def fake_llm(user_input: str) -> str:
@@ -25,7 +25,7 @@ def main() -> None:
 
     if is_error(decision2):
         print("Host behavior: error returned, do NOT call LLM.")
-        print(f"Error message: {get_error_message(decision2)}")
+        print(f"Error message: {decision2['message']}")
     else:
         fake_llm("use peanuts")
     print()

--- a/examples/05_llm_integration_pattern.py
+++ b/examples/05_llm_integration_pattern.py
@@ -6,8 +6,6 @@ from context_compiler import (
     Engine,
     State,
     create_engine,
-    get_decision_state,
-    get_error_message,
     is_error,
     is_no_directive,
     is_update,
@@ -35,10 +33,10 @@ def handle_turn(engine_input: str, engine: Engine) -> None:
         fake_llm(None, engine_input)
     elif is_update(decision):
         print("Host action: update -> call fake_llm() with compiled state")
-        fake_llm(get_decision_state(decision), engine_input)
+        fake_llm(decision["state"], engine_input)
     elif is_error(decision):
         print("Host action: error -> show prompt, DO NOT call LLM")
-        print("error message:", get_error_message(decision))
+        print("error message:", decision["message"])
     print()
 
 

--- a/examples/_util.py
+++ b/examples/_util.py
@@ -4,8 +4,6 @@ from typing import Any, Literal
 from context_compiler import (
     POLICY_PROHIBIT,
     POLICY_USE,
-    get_decision_state,
-    get_error_message,
     is_error,
     is_update,
 )
@@ -39,15 +37,14 @@ def print_state_summary(state: Any, label: str = "state") -> None:
 def print_decision_summary(decision: Any) -> None:
     if is_update(decision):
         print("result: updated")
-        state = get_decision_state(decision)
-        assert isinstance(state, dict)
+        state = decision["state"]
         print_state_summary(state, "compiled state")
         return
 
     if is_error(decision):
         print("result: error")
-        prompt = get_error_message(decision)
-        if isinstance(prompt, str) and prompt:
+        prompt = decision["message"]
+        if prompt:
             print("error message:")
             for line in prompt.splitlines():
                 print(f"- {line}")


### PR DESCRIPTION
## What changed

- updated the README and API reference to show branch-first Decision handling
- updated the ambiguity and integration examples to branch with is_error(...) / is_update(...) before reading variant payloads
- updated the shared example utility to read decision["message"] and decision["state"] only inside the matching branch

## Why

- Decision is now a true discriminated union, so examples and presentation code should teach the natural union-usage pattern
- this keeps get_error_message(...) and get_decision_state(...) available as compatibility conveniences without making them the preferred style

## Checklist

- [x] pre-commit run (uv run pre-commit run --all-files)
- [x] tests pass (uv run pytest)