### PR TITLE
chore: bump version to 0.9.0dev5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           enable-cache: true
 
       - name: Install dev dependencies
-        run: uv sync --extra dev
+        run: uv sync --dev
 
       - name: Ruff (lint)
         run: uv run ruff check .
@@ -90,7 +90,7 @@ jobs:
           enable-cache: true
 
       - name: Install dev dependencies
-        run: uv sync --extra dev
+        run: uv sync --dev
 
       - name: Contract tests with strict REPL coverage gate (100%)
         run: uv run pytest -m contract --cov=context_compiler.repl --cov-report=term-missing --cov-fail-under=100
@@ -111,7 +111,7 @@ jobs:
           enable-cache: true
 
       - name: Install dev dependencies
-        run: uv sync --extra dev
+        run: uv sync --dev
 
       - name: Contract tests with strict engine coverage gate (100%)
         run: uv run pytest -m contract --cov=context_compiler.engine --cov-report=term-missing --cov-fail-under=100
@@ -132,7 +132,7 @@ jobs:
           enable-cache: true
 
       - name: Install dev dependencies
-        run: uv sync --extra dev
+        run: uv sync --dev
 
       - name: Contract tests with strict grammar coverage gate (100%)
         run: uv run pytest tests/test_grammar.py tests/test_grammar_api_contract_fixture.py tests/test_fixtures.py::test_grammar_fixtures --cov=context_compiler.grammar --cov-report=term-missing --cov-fail-under=100

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,7 +27,7 @@ jobs:
           enable-cache: true
 
       - name: Install dev and demos dependencies
-        run: uv sync --extra dev --extra demos
+        run: uv sync --dev --extra demos
 
       - name: Run pytest stress loop
         shell: bash

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -31,7 +31,7 @@ jobs:
           enable-cache: true
 
       - name: Install dev and demos dependencies
-        run: uv sync --extra dev --extra demos
+        run: uv sync --dev --extra demos
 
       - name: Run pytest stress loop
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ Do not rewrite captured outputs, fixture-sensitive examples, or eval evidence un
 Use the project's existing tooling:
 
 - Run commands via `uv run` when appropriate.
-- Development dependencies are installed with `uv sync --group dev`.
+- Development dependencies are installed with `uv sync --dev`.
 
 ## Structured Regression Fixtures
 - Deterministic engine behavior changes that affect `tests/fixtures/engine-regression/structured/` outputs must update the corresponding fixtures.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Contributions are typically submitted via fork and pull request:
 ## Development Setup
 
 ```bash
-uv sync --group dev
+uv sync --dev
 ```
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Packaging notes:
 ### Development
 
 ```bash
-uv sync --group dev
+uv sync --dev
 uv run pytest
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.9.0dev4"
+version = "0.9.0dev5"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ include = [
 demos = [
   "litellm>=1.0.0",
 ]
+[dependency-groups]
 dev = [
   "pytest",
   "pytest-cov",

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.9.0.dev4"
+version = "0.9.0.dev5"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -303,6 +303,8 @@ source = { editable = "." }
 demos = [
     { name = "litellm" },
 ]
+
+[package.dev-dependencies]
 dev = [
     { name = "coverage" },
     { name = "hypothesis" },
@@ -314,17 +316,19 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "coverage", marker = "extra == 'dev'" },
-    { name = "hypothesis", marker = "extra == 'dev'" },
-    { name = "litellm", marker = "extra == 'demos'", specifier = ">=1.0.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.12,<2.0" },
-    { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12,<1.0" },
+requires-dist = [{ name = "litellm", marker = "extra == 'demos'", specifier = ">=1.0.0" }]
+provides-extras = ["demos"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "coverage" },
+    { name = "hypothesis" },
+    { name = "mypy", specifier = ">=1.12,<2.0" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff", specifier = ">=0.12,<1.0" },
 ]
-provides-extras = ["demos", "dev"]
 
 [[package]]
 name = "coverage"


### PR DESCRIPTION
## What changed

- Bumped the development release version.
- Included the state opacity refactor:
  - removed the public raw state API (`State`, `Engine.state`, and `state=` construction);
  - moved consumers to semantic reads (`premise` / `policies`) and JSON persistence.
- Included policy identity normalization cleanup:
  - retained Unicode normalization, apostrophe normalization, case-insensitive matching, and whitespace normalization;
  - removed article stripping (`a`, `an`, `the`);
  - removed `dont` → `don't` rewriting.
- Updated tests and conformance fixtures to match the current public contract.
- Updated CI and contributor documentation to use the new uv development dependency group workflow.

## Why

- Prepare the next development release after completing the state opacity migration.
- Align runtime behavior with the documented policy identity contract.
- Remove legacy normalization behavior that introduced language-specific transformations into identity matching.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
