### PR TITLE
refactor: consolidate directive grammar API

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -72,11 +72,9 @@ Public grammar surface:
 - `DirectiveKind`
 - `InvalidDirectiveSyntax`
 - `decompose_directive(text)`
-- `render_directive(kind, /, **operands)`
 
 Use this surface for exact canonical directive decomposition and
-classification via `decompose_directive(...)` or canonical directive string
-construction only.
+classification via `decompose_directive(...)` only.
 
 Boundary notes:
 
@@ -91,9 +89,6 @@ Boundary notes:
   caller casing or formatting may remain visible there
 - `CanonicalDirective.text` is not canonical serialized directive text
 - operands are grammar-level text, not normalized semantic values
-- `render_directive(...)` produces canonical directive text from semantic kind
-  and operands
-- rendering is syntax-only and performs no state interpretation
 - `engine.step(...)` remains the authority for error, state
   transitions, and mutation behavior
 - `engine.step(...)` is not a general natural-language repair surface; host
@@ -107,8 +102,8 @@ Boundary notes:
 `CanonicalDirective.operands` preserves the grammar-recognized operand text.
 Core does not lowercase operands, collapse internal operand whitespace, or
 convert operand text into engine/domain identifiers at the grammar layer.
-Canonical serialized directive output comes from
-`render_directive(kind, /, **operands)`, not from `CanonicalDirective.text`.
+`CanonicalDirective.text` should not be treated as canonical serialized
+directive output.
 
 ### `engine.premise`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -70,6 +70,7 @@ Public grammar surface:
 
 - `CanonicalDirective`
 - `DirectiveKind`
+- `InvalidDirectiveSyntax`
 - `match_canonical_directive_start(text, start)`
 - `contains_multiple_canonical_directives(text)`
 - `decompose_directive(text)`
@@ -87,14 +88,16 @@ Boundary notes:
   directive-shaped structure only; it is not full decomposition
 - use `decompose_directive(text)` to determine whether text is a complete
   canonical directive
-- a non-`None` decomposition returns a `CanonicalDirective` with `kind`,
-  `operands`, and preserved accepted `text`
+- `decompose_directive(...)` returns `CanonicalDirective` for accepted
+  canonical directives
+- `decompose_directive(...)` returns `InvalidDirectiveSyntax` for
+  directive-shaped input that is not valid canonical syntax
+- `decompose_directive(...)` returns `None` when no directive is present
 - `CanonicalDirective.text` preserves the original accepted input text, so
   caller casing or formatting may remain visible there
 - `CanonicalDirective.text` is not canonical serialized directive text
 - `match_canonical_directive_start(...)` is only for shallow syntax detection
 - operands are grammar-level text, not normalized semantic values
-- decomposition returns `None` for any non-canonical input
 - `render_directive(...)` produces canonical directive text from semantic kind
   and operands
 - rendering is syntax-only and performs no state interpretation

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -71,21 +71,15 @@ Public grammar surface:
 - `CanonicalDirective`
 - `DirectiveKind`
 - `InvalidDirectiveSyntax`
-- `match_canonical_directive_start(text, start)`
-- `contains_multiple_canonical_directives(text)`
 - `decompose_directive(text)`
 - `render_directive(kind, /, **operands)`
 
 Use this surface for exact canonical directive decomposition and
-classification via `decompose_directive(...)`, shallow syntax-start detection,
-or canonical directive string construction only.
+classification via `decompose_directive(...)` or canonical directive string
+construction only.
 
 Boundary notes:
 
-- `match_canonical_directive_start(...)` only matches a canonical directive
-  prefix at a position; it does not decompose or accept a whole directive
-- `contains_multiple_canonical_directives(...)` detects compound
-  directive-shaped structure only; it is not full decomposition
 - use `decompose_directive(text)` to determine whether text is a complete
   canonical directive
 - `decompose_directive(...)` returns `CanonicalDirective` for accepted
@@ -96,7 +90,6 @@ Boundary notes:
 - `CanonicalDirective.text` preserves the original accepted input text, so
   caller casing or formatting may remain visible there
 - `CanonicalDirective.text` is not canonical serialized directive text
-- `match_canonical_directive_start(...)` is only for shallow syntax detection
 - operands are grammar-level text, not normalized semantic values
 - `render_directive(...)` produces canonical directive text from semantic kind
   and operands

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -20,7 +20,7 @@ from .const import (
     STATE_PREMISE,
     STATE_VERSION,
 )
-from .grammar import DirectiveKind, decompose_directive
+from .grammar import CanonicalDirective, DirectiveKind, decompose_directive
 
 PolicyValue = Literal["use", "prohibit"]
 
@@ -120,8 +120,9 @@ class Engine:
     def step(self, user_input: str) -> Decision:
         """Evaluate and commit one user input against authoritative state.
 
-        Non-directive input returns ``no_directive`` without changing state.
-        Invalid directives return ``error`` without changing state. Accepted
+        Non-canonical input does not produce a state transition and returns
+        ``no_directive``. At the current engine boundary, invalid directive
+        classification is handled the same way as no-directive input. Accepted
         directives return ``update`` and commit the resulting authoritative
         state before the decision is returned.
         """
@@ -299,7 +300,7 @@ class Engine:
 
 def _parse_directive(user_input: str) -> Action | None:
     parsed = decompose_directive(user_input)
-    if parsed is None:
+    if not isinstance(parsed, CanonicalDirective):
         return None
 
     if parsed.kind is DirectiveKind.SET_PREMISE:

--- a/src/context_compiler/grammar.py
+++ b/src/context_compiler/grammar.py
@@ -37,6 +37,14 @@ class CanonicalDirective:
 
 
 @dataclass(frozen=True, slots=True)
+class _InvalidDirectiveSyntax:
+    """Represent directive-shaped input that fails canonical syntax parsing."""
+
+
+_INVALID_DIRECTIVE = _InvalidDirectiveSyntax()
+
+
+@dataclass(frozen=True, slots=True)
 class _DirectiveSpec:
     kind: DirectiveKind
     operand_names: tuple[str, ...]
@@ -70,6 +78,17 @@ _CANONICAL_DIRECTIVE_STARTS: tuple[tuple[str, bool], ...] = (
     ("clear premise", False),
     ("clear state", False),
     (_PROHIBIT_PREFIX.removesuffix(" "), True),
+    ("use", True),
+)
+
+_DIRECTIVE_FAMILY_STARTS: tuple[tuple[str, bool], ...] = (
+    ("change premise", True),
+    ("set premise", True),
+    ("remove policy", True),
+    ("reset policies", False),
+    ("clear premise", False),
+    ("clear state", False),
+    ("prohibit", True),
     ("use", True),
 )
 
@@ -263,6 +282,16 @@ def contains_multiple_canonical_directives(text: str) -> bool:
     return False
 
 
+def _starts_with_directive_family(text: str) -> bool:
+    for token, require_space_or_end in _DIRECTIVE_FAMILY_STARTS:
+        if (
+            _match_directive_token(text, 0, token, require_space_or_end=require_space_or_end)
+            is not None
+        ):
+            return True
+    return False
+
+
 def _parse_replace_use(trimmed_text: str) -> CanonicalDirective | None:
     match = _REPLACE_RE.fullmatch(trimmed_text)
     if match is None:
@@ -285,7 +314,7 @@ def _parse_replace_use(trimmed_text: str) -> CanonicalDirective | None:
     )
 
 
-def decompose_directive(text: str) -> CanonicalDirective | None:
+def decompose_directive(text: str) -> CanonicalDirective | _InvalidDirectiveSyntax | None:
     """Parse one canonical directive into its semantic kind and operands.
 
     This determines whether ``text`` is a single canonical directive and, when
@@ -298,8 +327,12 @@ def decompose_directive(text: str) -> CanonicalDirective | None:
     trimmed_text = _trim_ascii_whitespace(text)
     if trimmed_text == "":
         return None
-    if contains_multiple_canonical_directives(trimmed_text):
+    if not _starts_with_directive_family(trimmed_text):
         return None
+    if contains_multiple_canonical_directives(trimmed_text):
+        return _INVALID_DIRECTIVE
+
+    invalid_result = _INVALID_DIRECTIVE
 
     normalized = _normalized_for_matching(trimmed_text)
 
@@ -321,10 +354,10 @@ def decompose_directive(text: str) -> CanonicalDirective | None:
     if normalized.startswith("set premise "):
         match = _SET_PREMISE_RE.fullmatch(trimmed_text)
         if match is None:
-            return None
+            return invalid_result
         value = match.group("value")
         if not _operand_has_content(value) or _operand_starts_with_token(value, "to"):
-            return None
+            return invalid_result
         return CanonicalDirective(
             text=text,
             kind=DirectiveKind.SET_PREMISE,
@@ -334,10 +367,10 @@ def decompose_directive(text: str) -> CanonicalDirective | None:
     if normalized.startswith("change premise to "):
         match = _CHANGE_PREMISE_RE.fullmatch(trimmed_text)
         if match is None:
-            return None
+            return invalid_result
         value = match.group("value")
         if not _operand_has_content(value):
-            return None
+            return invalid_result
         return CanonicalDirective(
             text=text,
             kind=DirectiveKind.CHANGE_PREMISE,
@@ -351,7 +384,7 @@ def decompose_directive(text: str) -> CanonicalDirective | None:
     if normalized.startswith("use "):
         match = _USE_RE.fullmatch(trimmed_text)
         if match is None:
-            return None
+            return invalid_result
         item = match.group("item")
         normalized_item = _normalized_for_matching(item)
         if (
@@ -360,7 +393,7 @@ def decompose_directive(text: str) -> CanonicalDirective | None:
             or normalized_item.endswith(" instead of")
             or _INSTEAD_OF_DELIMITER in normalized_item
         ):
-            return None
+            return invalid_result
         return CanonicalDirective(
             text=text,
             kind=DirectiveKind.USE_ITEM,
@@ -370,10 +403,10 @@ def decompose_directive(text: str) -> CanonicalDirective | None:
     if normalized.startswith("prohibit "):
         match = _PROHIBIT_RE.fullmatch(trimmed_text)
         if match is None:
-            return None
+            return invalid_result
         item = match.group("item")
         if not _operand_has_content(item):
-            return None
+            return invalid_result
         return CanonicalDirective(
             text=text,
             kind=DirectiveKind.PROHIBIT_ITEM,
@@ -383,17 +416,17 @@ def decompose_directive(text: str) -> CanonicalDirective | None:
     if normalized.startswith("remove policy "):
         match = _REMOVE_POLICY_RE.fullmatch(trimmed_text)
         if match is None:
-            return None
+            return invalid_result
         item = match.group("item")
         if not _operand_has_content(item):
-            return None
+            return invalid_result
         return CanonicalDirective(
             text=text,
             kind=DirectiveKind.REMOVE_POLICY,
             operands=MappingProxyType({"item": item}),
         )
 
-    return None
+    return invalid_result
 
 
 def render_directive(kind: DirectiveKind, /, **operands: str) -> str:
@@ -433,7 +466,7 @@ def render_directive(kind: DirectiveKind, /, **operands: str) -> str:
     operand_view = MappingProxyType(normalized_operands)
     rendered = spec.renderer(operand_view)
     decomposed = decompose_directive(rendered)
-    if decomposed is None or decomposed.kind is not normalized_kind:
+    if not isinstance(decomposed, CanonicalDirective) or decomposed.kind is not normalized_kind:
         raise ValueError(f"Operands do not produce a canonical {normalized_kind.value} directive.")
     return rendered
 

--- a/src/context_compiler/grammar.py
+++ b/src/context_compiler/grammar.py
@@ -37,11 +37,8 @@ class CanonicalDirective:
 
 
 @dataclass(frozen=True, slots=True)
-class _InvalidDirectiveSyntax:
+class InvalidDirectiveSyntax:
     """Represent directive-shaped input that fails canonical syntax parsing."""
-
-
-_INVALID_DIRECTIVE = _InvalidDirectiveSyntax()
 
 
 @dataclass(frozen=True, slots=True)
@@ -314,15 +311,15 @@ def _parse_replace_use(trimmed_text: str) -> CanonicalDirective | None:
     )
 
 
-def decompose_directive(text: str) -> CanonicalDirective | _InvalidDirectiveSyntax | None:
+def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSyntax | None:
     """Parse one canonical directive into its semantic kind and operands.
 
     This determines whether ``text`` is a single canonical directive and, when
     it is, returns the directive kind plus canonical operand names with the
-    original operand text preserved. Callers can determine whether ``text`` is
-    a complete canonical directive by checking whether this returns a non-`None`
-    result. It does not repair input, infer intent, or evaluate directive
-    effects against compiler state.
+    original operand text preserved. It returns ``None`` when no canonical
+    directive is present and returns ``InvalidDirectiveSyntax`` when the text is
+    directive-shaped but not valid canonical syntax. It does not repair input,
+    infer intent, or evaluate directive effects against compiler state.
     """
     trimmed_text = _trim_ascii_whitespace(text)
     if trimmed_text == "":
@@ -330,9 +327,9 @@ def decompose_directive(text: str) -> CanonicalDirective | _InvalidDirectiveSynt
     if not _starts_with_directive_family(trimmed_text):
         return None
     if contains_multiple_canonical_directives(trimmed_text):
-        return _INVALID_DIRECTIVE
+        return InvalidDirectiveSyntax()
 
-    invalid_result = _INVALID_DIRECTIVE
+    invalid_result = InvalidDirectiveSyntax()
 
     normalized = _normalized_for_matching(trimmed_text)
 
@@ -474,6 +471,7 @@ def render_directive(kind: DirectiveKind, /, **operands: str) -> str:
 __all__ = [
     "CanonicalDirective",
     "DirectiveKind",
+    "InvalidDirectiveSyntax",
     "contains_multiple_canonical_directives",
     "decompose_directive",
     "match_canonical_directive_start",

--- a/src/context_compiler/grammar.py
+++ b/src/context_compiler/grammar.py
@@ -52,6 +52,10 @@ _CHANGE_PREMISE_PREFIX = "change premise to "
 _USE_PREFIX = "use "
 _PROHIBIT_PREFIX = "prohibit "
 _REMOVE_POLICY_PREFIX = "remove policy "
+_CLEAR_PREMISE_TEXT = "clear premise"
+_RESET_POLICIES_TEXT = "reset policies"
+_CLEAR_STATE_TEXT = "clear state"
+_CHANGE_PREMISE_FAMILY = "change premise"
 _INSTEAD_OF_DELIMITER = " instead of "
 _ASCII_WHITESPACE = " \t\n\r\x0b\x0c"
 _HORIZONTAL_WHITESPACE = " \t"
@@ -65,26 +69,37 @@ _REPLACE_RE = re.compile(
     r"(?i)^use[ \t]+(?P<new_item>.*?)[ \t]+instead[ \t]+of[ \t]+(?P<old_item>.+)$"
 )
 
-_CANONICAL_DIRECTIVE_STARTS: tuple[tuple[str, bool], ...] = (
+_PREFIX_DIRECTIVE_STARTS: tuple[tuple[str, bool], ...] = (
     (_CHANGE_PREMISE_PREFIX.removesuffix(" "), True),
     (_SET_PREMISE_PREFIX.removesuffix(" "), True),
     (_REMOVE_POLICY_PREFIX.removesuffix(" "), True),
-    ("reset policies", False),
-    ("clear premise", False),
-    ("clear state", False),
     (_PROHIBIT_PREFIX.removesuffix(" "), True),
-    ("use", True),
+    (_USE_PREFIX.removesuffix(" "), True),
+)
+
+_EXACT_DIRECTIVE_STARTS: tuple[tuple[str, bool], ...] = (
+    (_RESET_POLICIES_TEXT, False),
+    (_CLEAR_PREMISE_TEXT, False),
+    (_CLEAR_STATE_TEXT, False),
+)
+
+_CANONICAL_DIRECTIVE_STARTS: tuple[tuple[str, bool], ...] = (
+    _PREFIX_DIRECTIVE_STARTS[0],
+    _PREFIX_DIRECTIVE_STARTS[1],
+    _PREFIX_DIRECTIVE_STARTS[2],
+    _EXACT_DIRECTIVE_STARTS[0],
+    _EXACT_DIRECTIVE_STARTS[1],
+    _EXACT_DIRECTIVE_STARTS[2],
+    _PREFIX_DIRECTIVE_STARTS[3],
+    _PREFIX_DIRECTIVE_STARTS[4],
 )
 
 _DIRECTIVE_FAMILY_STARTS: tuple[tuple[str, bool], ...] = (
-    ("change premise", True),
-    ("set premise", True),
-    ("remove policy", True),
-    ("reset policies", False),
-    ("clear premise", False),
-    ("clear state", False),
-    ("prohibit", True),
-    ("use", True),
+    (_CHANGE_PREMISE_FAMILY, True),
+    _PREFIX_DIRECTIVE_STARTS[1],
+    _PREFIX_DIRECTIVE_STARTS[2],
+    *_EXACT_DIRECTIVE_STARTS,
+    *_PREFIX_DIRECTIVE_STARTS[3:],
 )
 
 
@@ -150,20 +165,20 @@ _DIRECTIVE_SPECS = MappingProxyType(
         DirectiveKind.CLEAR_PREMISE: _DirectiveSpec(
             kind=DirectiveKind.CLEAR_PREMISE,
             operand_names=(),
-            exact_text="clear premise",
-            renderer=_render_exact("clear premise"),
+            exact_text=_CLEAR_PREMISE_TEXT,
+            renderer=_render_exact(_CLEAR_PREMISE_TEXT),
         ),
         DirectiveKind.RESET_POLICIES: _DirectiveSpec(
             kind=DirectiveKind.RESET_POLICIES,
             operand_names=(),
-            exact_text="reset policies",
-            renderer=_render_exact("reset policies"),
+            exact_text=_RESET_POLICIES_TEXT,
+            renderer=_render_exact(_RESET_POLICIES_TEXT),
         ),
         DirectiveKind.CLEAR_STATE: _DirectiveSpec(
             kind=DirectiveKind.CLEAR_STATE,
             operand_names=(),
-            exact_text="clear state",
-            renderer=_render_exact("clear state"),
+            exact_text=_CLEAR_STATE_TEXT,
+            renderer=_render_exact(_CLEAR_STATE_TEXT),
         ),
     }
 )
@@ -317,17 +332,17 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
 
     normalized = _normalized_for_matching(trimmed_text)
 
-    if normalized == "clear premise":
+    if normalized == _CLEAR_PREMISE_TEXT:
         return CanonicalDirective(
             text=text, kind=DirectiveKind.CLEAR_PREMISE, operands=MappingProxyType({})
         )
-    if normalized == "reset policies":
+    if normalized == _RESET_POLICIES_TEXT:
         return CanonicalDirective(
             text=text,
             kind=DirectiveKind.RESET_POLICIES,
             operands=MappingProxyType({}),
         )
-    if normalized == "clear state":
+    if normalized == _CLEAR_STATE_TEXT:
         return CanonicalDirective(
             text=text, kind=DirectiveKind.CLEAR_STATE, operands=MappingProxyType({})
         )

--- a/src/context_compiler/grammar.py
+++ b/src/context_compiler/grammar.py
@@ -193,15 +193,8 @@ def _operand_starts_with_token(value: str, token: str) -> bool:
     return normalized == token or normalized.startswith(f"{token} ")
 
 
-def match_canonical_directive_start(text: str, start: int) -> int | None:
-    """Locate a canonical directive prefix at a given character position.
-
-    This is a shallow syntax-start matcher: it classifies whether canonical
-    directive syntax begins at ``start`` and, when it does, returns the index
-    immediately after the directive keyword prefix. It does not parse operands,
-    validate the full directive payload, or evaluate multi-directive state
-    semantics.
-    """
+def _match_canonical_directive_start(text: str, start: int) -> int | None:
+    """Locate a canonical directive prefix at a given character position."""
     if start < 0 or start >= len(text):
         return None
 
@@ -258,21 +251,14 @@ def _match_directive_token(
     return index
 
 
-def contains_multiple_canonical_directives(text: str) -> bool:
-    """Report whether text contains more than one canonical directive start.
-
-    This detects compound directive structure by looking for multiple canonical
-    directive prefixes in the same input. It is not a replacement for full
-    directive validation, and it does not parse directive operands, repair
-    malformed text, or determine whether a whole string should be accepted as a
-    single directive.
-    """
-    first_start = match_canonical_directive_start(text, 0)
+def _contains_multiple_canonical_directives(text: str) -> bool:
+    """Report whether text contains more than one canonical directive start."""
+    first_start = _match_canonical_directive_start(text, 0)
     if first_start is None:
         return False
 
     for index in range(first_start, len(text)):
-        next_start = match_canonical_directive_start(text, index)
+        next_start = _match_canonical_directive_start(text, index)
         if next_start is not None:
             return True
 
@@ -326,7 +312,7 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
         return None
     if not _starts_with_directive_family(trimmed_text):
         return None
-    if contains_multiple_canonical_directives(trimmed_text):
+    if _contains_multiple_canonical_directives(trimmed_text):
         return InvalidDirectiveSyntax()
 
     invalid_result = InvalidDirectiveSyntax()
@@ -472,8 +458,6 @@ __all__ = [
     "CanonicalDirective",
     "DirectiveKind",
     "InvalidDirectiveSyntax",
-    "contains_multiple_canonical_directives",
     "decompose_directive",
-    "match_canonical_directive_start",
     "render_directive",
 ]

--- a/src/context_compiler/grammar.py
+++ b/src/context_compiler/grammar.py
@@ -26,9 +26,7 @@ class CanonicalDirective:
     """Represent one parsed canonical directive and its named operands.
 
     ``text`` preserves the original accepted input text. It may retain caller
-    formatting or casing and is not canonical serialized directive text; use
-    :func:`render_directive` to produce canonical directive text from semantic
-    kind and operands.
+    formatting or casing and is not canonical serialized directive text.
     """
 
     text: str
@@ -412,14 +410,8 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
     return invalid_result
 
 
-def render_directive(kind: DirectiveKind, /, **operands: str) -> str:
-    """Produce canonical directive text from a semantic kind and operands.
-
-    This determines the exact canonical spelling for an existing grammar
-    capability and rejects operand combinations that would not round-trip as the
-    requested directive kind. It does not infer missing operands, parse user
-    input, or extend the grammar with new behaviors.
-    """
+def _render_directive(kind: DirectiveKind, /, **operands: str) -> str:
+    """Produce canonical directive text from a semantic kind and operands."""
     try:
         normalized_kind = kind if isinstance(kind, DirectiveKind) else DirectiveKind(kind)
         spec = _DIRECTIVE_SPECS[normalized_kind]
@@ -459,5 +451,4 @@ __all__ = [
     "DirectiveKind",
     "InvalidDirectiveSyntax",
     "decompose_directive",
-    "render_directive",
 ]

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -7,9 +7,7 @@
       "CanonicalDirective",
       "DirectiveKind",
       "InvalidDirectiveSyntax",
-      "contains_multiple_canonical_directives",
       "decompose_directive",
-      "match_canonical_directive_start",
       "render_directive"
     ],
     "members": {
@@ -21,38 +19,6 @@
       },
       "InvalidDirectiveSyntax": {
         "kind": "class"
-      },
-      "contains_multiple_canonical_directives": {
-        "kind": "callable",
-        "signature": {
-          "params": [
-            {
-              "name": "text",
-              "kind": "POSITIONAL_OR_KEYWORD",
-              "has_default": false
-            }
-          ]
-        },
-        "shape_probes": [
-          {
-            "kwargs": {
-              "text": "use docker and prohibit peanuts"
-            },
-            "return_shape": {
-              "type": "boolean",
-              "const": true
-            }
-          },
-          {
-            "kwargs": {
-              "text": "use docker"
-            },
-            "return_shape": {
-              "type": "boolean",
-              "const": false
-            }
-          }
-        ]
       },
       "decompose_directive": {
         "kind": "callable",
@@ -82,44 +48,6 @@
           {
             "kwargs": {
               "text": "please use docker"
-            },
-            "return_shape": {
-              "type": "null"
-            }
-          }
-        ]
-      },
-      "match_canonical_directive_start": {
-        "kind": "callable",
-        "signature": {
-          "params": [
-            {
-              "name": "text",
-              "kind": "POSITIONAL_OR_KEYWORD",
-              "has_default": false
-            },
-            {
-              "name": "start",
-              "kind": "POSITIONAL_OR_KEYWORD",
-              "has_default": false
-            }
-          ]
-        },
-        "shape_probes": [
-          {
-            "kwargs": {
-              "text": "please use docker",
-              "start": 7
-            },
-            "return_shape": {
-              "type": "number",
-              "const": 10
-            }
-          },
-          {
-            "kwargs": {
-              "text": "abuse docker",
-              "start": 1
             },
             "return_shape": {
               "type": "null"

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -7,8 +7,7 @@
       "CanonicalDirective",
       "DirectiveKind",
       "InvalidDirectiveSyntax",
-      "decompose_directive",
-      "render_directive"
+      "decompose_directive"
     ],
     "members": {
       "CanonicalDirective": {
@@ -51,34 +50,6 @@
             },
             "return_shape": {
               "type": "null"
-            }
-          }
-        ]
-      },
-      "render_directive": {
-        "kind": "callable",
-        "signature": {
-          "params": [
-            {
-              "name": "kind",
-              "kind": "POSITIONAL_ONLY",
-              "has_default": false
-            },
-            {
-              "name": "operands",
-              "kind": "VAR_KEYWORD",
-              "has_default": false
-            }
-          ]
-        },
-        "shape_probes": [
-          {
-            "args": [
-              "clear_state"
-            ],
-            "return_shape": {
-              "type": "string",
-              "const": "clear state"
             }
           }
         ]

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -6,6 +6,7 @@
     "names": [
       "CanonicalDirective",
       "DirectiveKind",
+      "InvalidDirectiveSyntax",
       "contains_multiple_canonical_directives",
       "decompose_directive",
       "match_canonical_directive_start",
@@ -16,6 +17,9 @@
         "kind": "class"
       },
       "DirectiveKind": {
+        "kind": "class"
+      },
+      "InvalidDirectiveSyntax": {
         "kind": "class"
       },
       "contains_multiple_canonical_directives": {

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Mapping
+from types import MappingProxyType
 
 import pytest
 
@@ -11,6 +12,7 @@ from context_compiler.engine import (
 )
 from context_compiler.grammar import (
     CanonicalDirective,
+    DirectiveKind,
     contains_multiple_canonical_directives,
     decompose_directive,
     match_canonical_directive_start,
@@ -66,6 +68,28 @@ def test_engine_parse_directive_matches_public_decomposition_boundary() -> None:
         new_item=parsed.operands["new_item"],
         old_item=parsed.operands["old_item"],
     )
+
+
+def test_parse_directive_uses_decompose_directive_as_authoritative_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parsed = CanonicalDirective(
+        text="use docker",
+        kind=DirectiveKind.USE_ITEM,
+        operands=MappingProxyType({"item": "docker"}),
+    )
+
+    monkeypatch.setattr("context_compiler.engine.decompose_directive", lambda _: parsed)
+
+    assert _parse_directive("ignored input") == Action(kind="use_item", item="docker")
+
+
+def test_parse_directive_ignores_noncanonical_decompose_results_at_engine_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("context_compiler.engine.decompose_directive", lambda _: object())
+
+    assert _parse_directive("ignored input") is None
 
 
 def test_parse_directive_returns_none_for_invalid_syntax_and_no_directive_inputs() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,9 +13,7 @@ from context_compiler.engine import (
 from context_compiler.grammar import (
     CanonicalDirective,
     DirectiveKind,
-    contains_multiple_canonical_directives,
     decompose_directive,
-    match_canonical_directive_start,
 )
 
 pytestmark = pytest.mark.contract
@@ -133,18 +131,6 @@ def test_pre_mutation_error_empty_operand_branches_remain_stable() -> None:
         "kind": "error",
         "message": ("Policy item cannot be empty.\nUse 'prohibit <item>' with a non-empty value."),
     }
-
-
-def test_grammar_owned_compound_detection_helpers_remain_unchanged() -> None:
-    assert contains_multiple_canonical_directives("use docker and prohibit peanuts") is True
-    assert contains_multiple_canonical_directives("hello there") is False
-    assert contains_multiple_canonical_directives("use docker") is False
-    assert match_canonical_directive_start("use docker", -1) is None
-    assert match_canonical_directive_start("use docker", len("use docker")) is None
-    assert match_canonical_directive_start("abuse docker", 1) is None
-    assert match_canonical_directive_start("use", 0) == len("use")
-    assert match_canonical_directive_start("use docker", 0) == len("use")
-    assert match_canonical_directive_start("clear premise!", 0) == len("clear premise")
 
 
 def test_initial_state_and_engine_properties() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -10,6 +10,7 @@ from context_compiler.engine import (
     _parse_directive,
 )
 from context_compiler.grammar import (
+    CanonicalDirective,
     contains_multiple_canonical_directives,
     decompose_directive,
     match_canonical_directive_start,
@@ -59,7 +60,7 @@ def test_parse_directive_delegates_canonical_kinds_to_existing_actions() -> None
 def test_engine_parse_directive_matches_public_decomposition_boundary() -> None:
     parsed = decompose_directive("use podman instead of docker")
 
-    assert parsed is not None
+    assert isinstance(parsed, CanonicalDirective)
     assert _parse_directive(parsed.text) == Action(
         kind="replace_use",
         new_item=parsed.operands["new_item"],

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -3,12 +3,12 @@ from pathlib import Path
 
 import pytest
 
+import context_compiler.grammar as grammar_module
 from context_compiler import DECISION_ERROR, create_engine
 from context_compiler.grammar import (
     CanonicalDirective,
     DirectiveKind,
     decompose_directive,
-    render_directive,
 )
 
 _STEP_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "conformance" / "step"
@@ -243,7 +243,9 @@ def test_grammar_fixtures() -> None:
                 assert directive.kind.value == expected_directive["kind"], fixture_id
                 assert dict(directive.operands) == expected_directive["operands"], fixture_id
         else:
-            rendered = render_directive(DirectiveKind(action["kind"]), **action["operands"])
+            rendered = grammar_module._render_directive(
+                DirectiveKind(action["kind"]), **action["operands"]
+            )
             assert rendered == expected["text"], fixture_id
             directive = decompose_directive(rendered)
             assert isinstance(directive, CanonicalDirective), fixture_id

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -5,6 +5,7 @@ import pytest
 
 from context_compiler import DECISION_ERROR, create_engine
 from context_compiler.grammar import (
+    CanonicalDirective,
     DirectiveKind,
     decompose_directive,
     render_directive,
@@ -235,9 +236,9 @@ def test_grammar_fixtures() -> None:
             directive = decompose_directive(action["text"])
             expected_directive = expected["directive"]
             if expected_directive is None:
-                assert directive is None, fixture_id
+                assert not isinstance(directive, CanonicalDirective), fixture_id
             else:
-                assert directive is not None, fixture_id
+                assert isinstance(directive, CanonicalDirective), fixture_id
                 assert directive.text == expected_directive["text"], fixture_id
                 assert directive.kind.value == expected_directive["kind"], fixture_id
                 assert dict(directive.operands) == expected_directive["operands"], fixture_id
@@ -245,7 +246,7 @@ def test_grammar_fixtures() -> None:
             rendered = render_directive(DirectiveKind(action["kind"]), **action["operands"])
             assert rendered == expected["text"], fixture_id
             directive = decompose_directive(rendered)
-            assert directive is not None, fixture_id
+            assert isinstance(directive, CanonicalDirective), fixture_id
             assert directive.kind.value == expected["directive_kind"], fixture_id
 
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -261,6 +261,50 @@ def test_render_directive_rejects_non_string_operands() -> None:
         render_directive(DirectiveKind.SET_PREMISE, value=123)  # type: ignore[arg-type]
 
 
+def test_render_directive_uses_decompose_directive_as_authoritative_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        grammar_module,
+        "decompose_directive",
+        lambda _: CanonicalDirective(
+            text="use docker",
+            kind=DirectiveKind.USE_ITEM,
+            operands=MappingProxyType({"item": "docker"}),
+        ),
+    )
+
+    assert render_directive(DirectiveKind.USE_ITEM, item="docker") == "use docker"
+
+
+def test_render_directive_rejects_when_decompose_directive_disagrees_with_rendered_kind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        grammar_module,
+        "decompose_directive",
+        lambda _: CanonicalDirective(
+            text="use docker",
+            kind=DirectiveKind.PROHIBIT_ITEM,
+            operands=MappingProxyType({"item": "docker"}),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="canonical use_item directive"):
+        render_directive(DirectiveKind.USE_ITEM, item="docker")
+
+
+def test_render_directive_rejects_when_decompose_directive_returns_noncanonical_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        grammar_module, "decompose_directive", lambda _: grammar_module._INVALID_DIRECTIVE
+    )
+
+    with pytest.raises(ValueError, match="canonical use_item directive"):
+        render_directive(DirectiveKind.USE_ITEM, item="docker")
+
+
 @pytest.mark.parametrize(
     ("text", "start", "expected"),
     [

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -9,7 +9,6 @@ from context_compiler.grammar import (
     DirectiveKind,
     InvalidDirectiveSyntax,
     decompose_directive,
-    render_directive,
 )
 
 
@@ -153,7 +152,7 @@ def test_decompose_directive_preserves_current_operand_casing_and_whitespace(
 def test_render_directive_outputs_exact_canonical_syntax(
     kind: DirectiveKind, operands: dict[str, str], expected: str
 ) -> None:
-    rendered = render_directive(kind, **operands)
+    rendered = grammar_module._render_directive(kind, **operands)
     assert rendered == expected
     directive = decompose_directive(rendered)
     assert directive is not None
@@ -216,7 +215,7 @@ def test_render_directive_rejects_invalid_operand_combinations(
     kind: DirectiveKind | str, operands: dict[str, str], message: str
 ) -> None:
     with pytest.raises(ValueError, match=message):
-        render_directive(kind, **operands)
+        grammar_module._render_directive(kind, **operands)
 
 
 def test_no_exported_mutable_grammar_registry() -> None:
@@ -240,7 +239,6 @@ def test_public_grammar_all_includes_semantic_surface() -> None:
         "DirectiveKind",
         "InvalidDirectiveSyntax",
         "decompose_directive",
-        "render_directive",
     ]
 
 
@@ -251,7 +249,7 @@ def test_decompose_directive_rejects_near_miss_without_required_delimiter() -> N
 
 def test_render_directive_rejects_non_string_operands() -> None:
     with pytest.raises(ValueError, match="must be a string"):
-        render_directive(DirectiveKind.SET_PREMISE, value=123)  # type: ignore[arg-type]
+        grammar_module._render_directive(DirectiveKind.SET_PREMISE, value=123)  # type: ignore[arg-type]
 
 
 def test_render_directive_uses_decompose_directive_as_authoritative_round_trip(
@@ -267,7 +265,7 @@ def test_render_directive_uses_decompose_directive_as_authoritative_round_trip(
         ),
     )
 
-    assert render_directive(DirectiveKind.USE_ITEM, item="docker") == "use docker"
+    assert grammar_module._render_directive(DirectiveKind.USE_ITEM, item="docker") == "use docker"
 
 
 def test_render_directive_rejects_when_decompose_directive_disagrees_with_rendered_kind(
@@ -284,7 +282,7 @@ def test_render_directive_rejects_when_decompose_directive_disagrees_with_render
     )
 
     with pytest.raises(ValueError, match="canonical use_item directive"):
-        render_directive(DirectiveKind.USE_ITEM, item="docker")
+        grammar_module._render_directive(DirectiveKind.USE_ITEM, item="docker")
 
 
 def test_render_directive_rejects_when_decompose_directive_returns_noncanonical_result(
@@ -293,7 +291,7 @@ def test_render_directive_rejects_when_decompose_directive_returns_noncanonical_
     monkeypatch.setattr(grammar_module, "decompose_directive", lambda _: InvalidDirectiveSyntax())
 
     with pytest.raises(ValueError, match="canonical use_item directive"):
-        render_directive(DirectiveKind.USE_ITEM, item="docker")
+        grammar_module._render_directive(DirectiveKind.USE_ITEM, item="docker")
 
 
 def test_decompose_directive_returns_canonical_operands_for_use_item() -> None:

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -7,6 +7,7 @@ import context_compiler.grammar as grammar_module
 from context_compiler.grammar import (
     CanonicalDirective,
     DirectiveKind,
+    InvalidDirectiveSyntax,
     contains_multiple_canonical_directives,
     decompose_directive,
     match_canonical_directive_start,
@@ -108,7 +109,7 @@ def test_decompose_directive_returns_none_when_no_directive_is_present(text: str
     ],
 )
 def test_decompose_directive_marks_invalid_directive_syntax(text: str) -> None:
-    assert decompose_directive(text) is grammar_module._INVALID_DIRECTIVE
+    assert isinstance(decompose_directive(text), InvalidDirectiveSyntax)
 
 
 @pytest.mark.parametrize(
@@ -244,6 +245,7 @@ def test_public_grammar_all_includes_semantic_surface() -> None:
     assert grammar_module.__all__ == [
         "CanonicalDirective",
         "DirectiveKind",
+        "InvalidDirectiveSyntax",
         "contains_multiple_canonical_directives",
         "decompose_directive",
         "match_canonical_directive_start",
@@ -297,9 +299,7 @@ def test_render_directive_rejects_when_decompose_directive_disagrees_with_render
 def test_render_directive_rejects_when_decompose_directive_returns_noncanonical_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        grammar_module, "decompose_directive", lambda _: grammar_module._INVALID_DIRECTIVE
-    )
+    monkeypatch.setattr(grammar_module, "decompose_directive", lambda _: InvalidDirectiveSyntax())
 
     with pytest.raises(ValueError, match="canonical use_item directive"):
         render_directive(DirectiveKind.USE_ITEM, item="docker")
@@ -433,7 +433,7 @@ def test_decompose_directive_defensively_rejects_when_branch_regex_match_is_miss
 ) -> None:
     monkeypatch.setattr(grammar_module, pattern_name, _FakePattern(None))
 
-    assert decompose_directive(text) is grammar_module._INVALID_DIRECTIVE
+    assert isinstance(decompose_directive(text), InvalidDirectiveSyntax)
 
 
 @pytest.mark.parametrize(
@@ -452,4 +452,4 @@ def test_decompose_directive_defensively_rejects_whitespace_only_operands_after_
 ) -> None:
     monkeypatch.setattr(grammar_module, pattern_name, _FakePattern(_FakeMatch(groups)))
 
-    assert decompose_directive(text) is grammar_module._INVALID_DIRECTIVE
+    assert isinstance(decompose_directive(text), InvalidDirectiveSyntax)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -85,6 +85,17 @@ def test_decompose_directive_accepts_each_canonical_family(
     [
         "",
         "hello there",
+        "please use docker",
+        '"use docker and prohibit peanuts"',
+    ],
+)
+def test_decompose_directive_returns_none_when_no_directive_is_present(text: str) -> None:
+    assert decompose_directive(text) is None
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
         "use",
         "prohibit",
         "remove policy",
@@ -94,12 +105,10 @@ def test_decompose_directive_accepts_each_canonical_family(
         "change premise concise",
         "use docker and prohibit peanuts",
         "clear state then set premise project",
-        "please use docker",
-        '"use docker and prohibit peanuts"',
     ],
 )
-def test_decompose_directive_rejects_non_canonical_inputs(text: str) -> None:
-    assert decompose_directive(text) is None
+def test_decompose_directive_marks_invalid_directive_syntax(text: str) -> None:
+    assert decompose_directive(text) is grammar_module._INVALID_DIRECTIVE
 
 
 @pytest.mark.parametrize(
@@ -380,7 +389,7 @@ def test_decompose_directive_defensively_rejects_when_branch_regex_match_is_miss
 ) -> None:
     monkeypatch.setattr(grammar_module, pattern_name, _FakePattern(None))
 
-    assert decompose_directive(text) is None
+    assert decompose_directive(text) is grammar_module._INVALID_DIRECTIVE
 
 
 @pytest.mark.parametrize(
@@ -399,4 +408,4 @@ def test_decompose_directive_defensively_rejects_whitespace_only_operands_after_
 ) -> None:
     monkeypatch.setattr(grammar_module, pattern_name, _FakePattern(_FakeMatch(groups)))
 
-    assert decompose_directive(text) is None
+    assert decompose_directive(text) is grammar_module._INVALID_DIRECTIVE

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -8,9 +8,7 @@ from context_compiler.grammar import (
     CanonicalDirective,
     DirectiveKind,
     InvalidDirectiveSyntax,
-    contains_multiple_canonical_directives,
     decompose_directive,
-    match_canonical_directive_start,
     render_directive,
 )
 
@@ -236,19 +234,12 @@ def test_internal_grammar_specs_use_immutable_mapping() -> None:
         spec.kind = DirectiveKind.CHANGE_PREMISE  # type: ignore[misc]
 
 
-def test_internal_canonical_start_match_rejects_out_of_range_positions() -> None:
-    assert match_canonical_directive_start("use docker", -1) is None
-    assert match_canonical_directive_start("use docker", len("use docker")) is None
-
-
 def test_public_grammar_all_includes_semantic_surface() -> None:
     assert grammar_module.__all__ == [
         "CanonicalDirective",
         "DirectiveKind",
         "InvalidDirectiveSyntax",
-        "contains_multiple_canonical_directives",
         "decompose_directive",
-        "match_canonical_directive_start",
         "render_directive",
     ]
 
@@ -305,36 +296,6 @@ def test_render_directive_rejects_when_decompose_directive_returns_noncanonical_
         render_directive(DirectiveKind.USE_ITEM, item="docker")
 
 
-@pytest.mark.parametrize(
-    ("text", "start", "expected"),
-    [
-        ("use docker", 0, len("use")),
-        ("please use docker", 7, len("please use")),
-        ("clear premise!", 0, len("clear premise")),
-        ("abuse docker", 1, None),
-    ],
-)
-def test_match_canonical_directive_start_finds_public_directive_prefixes(
-    text: str, start: int, expected: int | None
-) -> None:
-    assert match_canonical_directive_start(text, start) == expected
-
-
-@pytest.mark.parametrize(
-    ("text", "expected"),
-    [
-        ("use docker and prohibit peanuts", True),
-        ("hello there", False),
-        ("use docker", False),
-        ('"use docker and prohibit peanuts"', False),
-    ],
-)
-def test_contains_multiple_canonical_directives_reports_public_compound_detection(
-    text: str, expected: bool
-) -> None:
-    assert contains_multiple_canonical_directives(text) is expected
-
-
 def test_decompose_directive_returns_canonical_operands_for_use_item() -> None:
     parsed = decompose_directive("use docker")
 
@@ -372,6 +333,41 @@ def test_internal_match_directive_token_rejects_truncated_and_non_whitespace_sep
         )
         is None
     )
+
+
+def test_internal_canonical_start_match_rejects_out_of_range_positions() -> None:
+    assert grammar_module._match_canonical_directive_start("use docker", -1) is None
+    assert grammar_module._match_canonical_directive_start("use docker", len("use docker")) is None
+
+
+@pytest.mark.parametrize(
+    ("text", "start", "expected"),
+    [
+        ("use docker", 0, len("use")),
+        ("please use docker", 7, len("please use")),
+        ("clear premise!", 0, len("clear premise")),
+        ("abuse docker", 1, None),
+    ],
+)
+def test_internal_match_canonical_directive_start_finds_public_prefix_shapes(
+    text: str, start: int, expected: int | None
+) -> None:
+    assert grammar_module._match_canonical_directive_start(text, start) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("use docker and prohibit peanuts", True),
+        ("hello there", False),
+        ("use docker", False),
+        ('"use docker and prohibit peanuts"', False),
+    ],
+)
+def test_internal_contains_multiple_canonical_directives_reports_compound_detection(
+    text: str, expected: bool
+) -> None:
+    assert grammar_module._contains_multiple_canonical_directives(text) is expected
 
 
 def test_parse_replace_use_rejects_blank_new_item() -> None:

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -12,7 +12,6 @@ from context_compiler.grammar import (
     CanonicalDirective,
     DirectiveKind,
     decompose_directive,
-    render_directive,
 )
 
 
@@ -248,7 +247,7 @@ def test_grammar_helper_render_decompose_round_trip_is_stable(
     assert isinstance(kind, DirectiveKind)
     assert isinstance(operands, dict)
 
-    rendered = render_directive(kind, **operands)
+    rendered = grammar_module._render_directive(kind, **operands)
     directive = decompose_directive(rendered)
 
     assert isinstance(directive, CanonicalDirective)
@@ -256,7 +255,7 @@ def test_grammar_helper_render_decompose_round_trip_is_stable(
     assert directive.text == rendered
     assert dict(directive.operands) == operands
     assert decompose_directive(directive.text) == directive
-    assert render_directive(kind, **operands) == rendered
+    assert grammar_module._render_directive(kind, **operands) == rendered
 
 
 @given(st.text(min_size=1, max_size=30))

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -6,12 +6,12 @@ from unicodedata import normalize as unicode_normalize
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
+import context_compiler.grammar as grammar_module
 from context_compiler import DECISION_ERROR, DECISION_NO_DIRECTIVE, DECISION_UPDATE, create_engine
 from context_compiler.grammar import (
     CanonicalDirective,
     DirectiveKind,
     decompose_directive,
-    match_canonical_directive_start,
     render_directive,
 )
 
@@ -42,7 +42,7 @@ def _is_stable_policy_key_like_engine(value: str) -> bool:
 
 def _contains_canonical_start_fragment(value: str) -> bool:
     for start in range(len(value)):
-        if match_canonical_directive_start(value, start) is not None:
+        if grammar_module._match_canonical_directive_start(value, start) is not None:
             return True
     return False
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -8,6 +8,7 @@ from hypothesis import strategies as st
 
 from context_compiler import DECISION_ERROR, DECISION_NO_DIRECTIVE, DECISION_UPDATE, create_engine
 from context_compiler.grammar import (
+    CanonicalDirective,
     DirectiveKind,
     decompose_directive,
     match_canonical_directive_start,
@@ -44,6 +45,10 @@ def _contains_canonical_start_fragment(value: str) -> bool:
         if match_canonical_directive_start(value, start) is not None:
             return True
     return False
+
+
+def _is_canonical_directive(value: object) -> bool:
+    return isinstance(value, CanonicalDirective)
 
 
 def _sanitize_premise_like_engine(value: str) -> str:
@@ -90,11 +95,11 @@ VALID_NONEMPTY_ITEM_TEXT = NORMALIZATION_SENSITIVE_TEXT.filter(
 )
 
 VALID_USE_ITEM_TEXT = VALID_NONEMPTY_ITEM_TEXT.filter(
-    lambda value: decompose_directive(f"use {value}") is not None
+    lambda value: _is_canonical_directive(decompose_directive(f"use {value}"))
 )
 
 VALID_PROHIBIT_ITEM_TEXT = VALID_NONEMPTY_ITEM_TEXT.filter(
-    lambda value: decompose_directive(f"prohibit {value}") is not None
+    lambda value: _is_canonical_directive(decompose_directive(f"prohibit {value}"))
 )
 
 VALID_PREMISE_TEXT = NORMALIZATION_SENSITIVE_TEXT.filter(
@@ -106,17 +111,17 @@ CANONICAL_GRAMMAR_PREMISE_TEXT = NORMALIZATION_SENSITIVE_TEXT.map(
 ).filter(
     lambda value: (
         value != ""
-        and decompose_directive(f"set premise {value}") is not None
-        and decompose_directive(f"change premise to {value}") is not None
+        and _is_canonical_directive(decompose_directive(f"set premise {value}"))
+        and _is_canonical_directive(decompose_directive(f"change premise to {value}"))
     )
 )
 
 CANONICAL_GRAMMAR_ITEM_TEXT = NORMALIZATION_SENSITIVE_TEXT.map(_normalize_item_like_engine).filter(
     lambda value: (
         value != ""
-        and decompose_directive(f"use {value}") is not None
-        and decompose_directive(f"prohibit {value}") is not None
-        and decompose_directive(f"remove policy {value}") is not None
+        and _is_canonical_directive(decompose_directive(f"use {value}"))
+        and _is_canonical_directive(decompose_directive(f"prohibit {value}"))
+        and _is_canonical_directive(decompose_directive(f"remove policy {value}"))
     )
 )
 
@@ -166,7 +171,7 @@ DETERMINISTIC_REPLACEMENT_CASES = (
     .filter(
         lambda args: (
             _normalize_item_like_engine(args[2]) != _normalize_item_like_engine(args[3])
-            and decompose_directive(f"use {args[2]} instead of {args[3]}") is not None
+            and _is_canonical_directive(decompose_directive(f"use {args[2]} instead of {args[3]}"))
             and not any(
                 key in {_normalize_item_like_engine(args[2]), _normalize_item_like_engine(args[3])}
                 and value == "prohibit"
@@ -246,7 +251,7 @@ def test_grammar_helper_render_decompose_round_trip_is_stable(
     rendered = render_directive(kind, **operands)
     directive = decompose_directive(rendered)
 
-    assert directive is not None
+    assert isinstance(directive, CanonicalDirective)
     assert directive.kind is kind
     assert directive.text == rendered
     assert dict(directive.operands) == operands
@@ -261,7 +266,7 @@ def test_idempotent_use_item_is_update_and_stable_state(item: str) -> None:
     assume(not item.endswith(" instead of"))
     assume(_normalize_item_like_engine(item) != "")
     assume(not _contains_canonical_start_fragment(item))
-    assume(decompose_directive(f"use {item}") is not None)
+    assume(_is_canonical_directive(decompose_directive(f"use {item}")))
     engine = create_engine()
     d1 = engine.step(f"use {item}")
     d2 = engine.step(f"use {item}")
@@ -289,7 +294,7 @@ def test_use_item_with_whitespace_only_payload_remains_no_directive(item: str) -
 def test_idempotent_prohibit_item_is_update_and_stable_state(item: str) -> None:
     assume(_normalize_item_like_engine(item) != "")
     assume(not _contains_canonical_start_fragment(item))
-    assume(decompose_directive(f"prohibit {item}") is not None)
+    assume(_is_canonical_directive(decompose_directive(f"prohibit {item}")))
     engine = create_engine()
     d1 = engine.step(f"prohibit {item}")
     d2 = engine.step(f"prohibit {item}")
@@ -339,8 +344,8 @@ def test_no_directive_sequence_preserves_state_and_decision_kind(inputs: list[st
 @given(st.text(min_size=1, max_size=30))
 def test_contradiction_use_after_prohibit_always_clarifies(item: str) -> None:
     assume(not _contains_canonical_start_fragment(item))
-    assume(decompose_directive(f"prohibit {item}") is not None)
-    assume(decompose_directive(f"use {item}") is not None)
+    assume(_is_canonical_directive(decompose_directive(f"prohibit {item}")))
+    assume(_is_canonical_directive(decompose_directive(f"use {item}")))
     engine = create_engine()
     engine.step(f"prohibit {item}")
     before = _observations(engine)
@@ -356,8 +361,8 @@ def test_contradiction_prohibit_after_use_always_clarifies(item: str) -> None:
     assume(not item.startswith("instead of "))
     assume(not item.endswith(" instead of"))
     assume(not _contains_canonical_start_fragment(item))
-    assume(decompose_directive(f"use {item}") is not None)
-    assume(decompose_directive(f"prohibit {item}") is not None)
+    assume(_is_canonical_directive(decompose_directive(f"use {item}")))
+    assume(_is_canonical_directive(decompose_directive(f"prohibit {item}")))
     engine = create_engine()
     engine.step(f"use {item}")
     before = _observations(engine)

--- a/tests/test_public_grammar_root_exports.py
+++ b/tests/test_public_grammar_root_exports.py
@@ -17,6 +17,8 @@ def test_grammar_submodule_preserves_public_grammar_surface() -> None:
     assert grammar_module.InvalidDirectiveSyntax is not None
     assert grammar_module.decompose_directive is not None
     assert grammar_module.render_directive is not None
+    assert not hasattr(grammar_module, "contains_multiple_canonical_directives")
+    assert not hasattr(grammar_module, "match_canonical_directive_start")
 
 
 def test_root_does_not_export_private_grammar_implementation() -> None:

--- a/tests/test_public_grammar_root_exports.py
+++ b/tests/test_public_grammar_root_exports.py
@@ -14,6 +14,7 @@ def test_root_does_not_export_public_grammar_surface() -> None:
 def test_grammar_submodule_preserves_public_grammar_surface() -> None:
     assert grammar_module.CanonicalDirective is not None
     assert grammar_module.DirectiveKind is not None
+    assert grammar_module.InvalidDirectiveSyntax is not None
     assert grammar_module.decompose_directive is not None
     assert grammar_module.render_directive is not None
 

--- a/tests/test_public_grammar_root_exports.py
+++ b/tests/test_public_grammar_root_exports.py
@@ -3,10 +3,7 @@ import context_compiler.grammar as grammar_module
 
 
 def test_root_does_not_export_public_grammar_surface() -> None:
-    for name in (
-        "DirectiveKind",
-        "render_directive",
-    ):
+    for name in ("DirectiveKind",):
         assert name not in context_compiler.__all__
         assert not hasattr(context_compiler, name)
 
@@ -16,7 +13,7 @@ def test_grammar_submodule_preserves_public_grammar_surface() -> None:
     assert grammar_module.DirectiveKind is not None
     assert grammar_module.InvalidDirectiveSyntax is not None
     assert grammar_module.decompose_directive is not None
-    assert grammar_module.render_directive is not None
+    assert not hasattr(grammar_module, "render_directive")
     assert not hasattr(grammar_module, "contains_multiple_canonical_directives")
     assert not hasattr(grammar_module, "match_canonical_directive_start")
 


### PR DESCRIPTION
## What changed

- Made `decompose_directive()` the authoritative grammar parsing boundary.
- Added explicit invalid directive syntax classification:
  - `CanonicalDirective`
  - no directive (`None`)
  - `InvalidDirectiveSyntax`
- Reduced grammar API leakage:
  - made directive rendering internal;
  - made parser classification helpers internal.
- Consolidated grammar-defining literals and directive syntax constants.
- Preserved engine semantic behavior; this PR only changes grammar classification and ownership boundaries.

## Why

The previous grammar API returned only `CanonicalDirective | None`, which required downstream consumers to reconstruct grammar distinctions.

This change makes grammar responsible for syntax classification while keeping semantic application in the engine layer.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)