### PR TITLE
refactor: separate directive parsing and application

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -69,7 +69,6 @@ submodule.
 Public grammar surface:
 
 - `CanonicalDirective`
-- `DirectiveKind`
 - `InvalidDirectiveSyntax`
 - `decompose_directive(text)`
 

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -20,7 +20,7 @@ from .const import (
     STATE_PREMISE,
     STATE_VERSION,
 )
-from .grammar import CanonicalDirective, DirectiveKind, decompose_directive
+from .grammar import CanonicalDirective, _DirectiveKind, decompose_directive
 
 PolicyValue = Literal["use", "prohibit"]
 
@@ -49,7 +49,7 @@ class Decision(TypedDict):
 
 
 @dataclass(frozen=True)
-class Action:
+class _Action:
     """Represent one parsed engine action before state validation or mutation."""
 
     kind: Literal[
@@ -154,10 +154,10 @@ class Engine:
         self._state = state
 
     def _pre_mutation_error(
-        self, directive: Action | CanonicalDirective, *, state: _State | None = None
+        self, directive: _Action | CanonicalDirective, *, state: _State | None = None
     ) -> Decision | None:
         candidate_state = self._state if state is None else state
-        action = directive if isinstance(directive, Action) else _directive_to_action(directive)
+        action = directive if isinstance(directive, _Action) else _directive_to_action(directive)
         # Single error path: all error outcomes are detected before any mutation.
         if action.kind in {"set_premise", "change_premise"}:
             assert action.value is not None
@@ -245,8 +245,8 @@ class Engine:
 
         return None
 
-    def _apply_directive(self, directive: Action | CanonicalDirective, *, state: _State) -> _State:
-        action = directive if isinstance(directive, Action) else _directive_to_action(directive)
+    def _apply_directive(self, directive: _Action | CanonicalDirective, *, state: _State) -> _State:
+        action = directive if isinstance(directive, _Action) else _directive_to_action(directive)
         next_state = deepcopy(state)
         kind = action.kind
 
@@ -307,28 +307,28 @@ class Engine:
         state[STATE_POLICIES][new_key] = POLICY_USE
 
 
-def _directive_to_action(parsed: CanonicalDirective) -> Action:
-    if parsed.kind is DirectiveKind.SET_PREMISE:
-        return Action(kind="set_premise", value=parsed.operands["value"])
-    if parsed.kind is DirectiveKind.CHANGE_PREMISE:
-        return Action(kind="change_premise", value=parsed.operands["value"])
-    if parsed.kind is DirectiveKind.USE_ITEM:
-        return Action(kind="use_item", item=parsed.operands["item"])
-    if parsed.kind is DirectiveKind.PROHIBIT_ITEM:
-        return Action(kind="prohibit_item", item=parsed.operands["item"])
-    if parsed.kind is DirectiveKind.REMOVE_POLICY:
-        return Action(kind="remove_policy_item", item=parsed.operands["item"])
-    if parsed.kind is DirectiveKind.REPLACE_USE:
-        return Action(
+def _directive_to_action(parsed: CanonicalDirective) -> _Action:
+    if parsed.kind is _DirectiveKind.SET_PREMISE:
+        return _Action(kind="set_premise", value=parsed.operands["value"])
+    if parsed.kind is _DirectiveKind.CHANGE_PREMISE:
+        return _Action(kind="change_premise", value=parsed.operands["value"])
+    if parsed.kind is _DirectiveKind.USE_ITEM:
+        return _Action(kind="use_item", item=parsed.operands["item"])
+    if parsed.kind is _DirectiveKind.PROHIBIT_ITEM:
+        return _Action(kind="prohibit_item", item=parsed.operands["item"])
+    if parsed.kind is _DirectiveKind.REMOVE_POLICY:
+        return _Action(kind="remove_policy_item", item=parsed.operands["item"])
+    if parsed.kind is _DirectiveKind.REPLACE_USE:
+        return _Action(
             kind="replace_use",
             new_item=parsed.operands["new_item"],
             old_item=parsed.operands["old_item"],
         )
-    if parsed.kind is DirectiveKind.CLEAR_PREMISE:
-        return Action(kind="clear_premise")
-    if parsed.kind is DirectiveKind.RESET_POLICIES:
-        return Action(kind="reset_policies")
-    return Action(kind="clear_state")
+    if parsed.kind is _DirectiveKind.CLEAR_PREMISE:
+        return _Action(kind="clear_premise")
+    if parsed.kind is _DirectiveKind.RESET_POLICIES:
+        return _Action(kind="reset_policies")
+    return _Action(kind="clear_state")
 
 
 def _initial_state() -> _State:

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -127,29 +127,37 @@ class Engine:
         state before the decision is returned.
         """
 
-        evaluated = self._evaluate_transition(self._state, user_input)
+        directive = decompose_directive(user_input)
+        if not isinstance(directive, CanonicalDirective):
+            return _NO_DIRECTIVE.copy()
+
+        return self.apply_directive(directive)
+
+    def apply_directive(self, directive: CanonicalDirective) -> Decision:
+        """Evaluate and commit one canonical directive against authoritative state."""
+
+        evaluated = self._evaluate_directive_transition(self._state, directive)
         self._replace_state(evaluated.next_state)
         return evaluated.decision
 
-    def _evaluate_transition(self, state: _State, user_input: str) -> _EvaluatedTransition:
-        action = _parse_directive(user_input)
-        if action is None:
-            return _EvaluatedTransition(decision=_NO_DIRECTIVE.copy(), next_state=deepcopy(state))
-
-        error_decision = self._pre_mutation_error(action, state=state)
+    def _evaluate_directive_transition(
+        self, state: _State, directive: CanonicalDirective
+    ) -> _EvaluatedTransition:
+        error_decision = self._pre_mutation_error(directive, state=state)
         if error_decision is not None:
             return _EvaluatedTransition(decision=error_decision, next_state=deepcopy(state))
 
-        next_state = self._apply_action(action, state=state)
+        next_state = self._apply_directive(directive, state=state)
         return _EvaluatedTransition(decision=_update_decision(next_state), next_state=next_state)
 
     def _replace_state(self, state: _State) -> None:
         self._state = state
 
     def _pre_mutation_error(
-        self, action: Action, *, state: _State | None = None
+        self, directive: Action | CanonicalDirective, *, state: _State | None = None
     ) -> Decision | None:
         candidate_state = self._state if state is None else state
+        action = directive if isinstance(directive, Action) else _directive_to_action(directive)
         # Single error path: all error outcomes are detected before any mutation.
         if action.kind in {"set_premise", "change_premise"}:
             assert action.value is not None
@@ -237,7 +245,8 @@ class Engine:
 
         return None
 
-    def _apply_action(self, action: Action, *, state: _State) -> _State:
+    def _apply_directive(self, directive: Action | CanonicalDirective, *, state: _State) -> _State:
+        action = directive if isinstance(directive, Action) else _directive_to_action(directive)
         next_state = deepcopy(state)
         kind = action.kind
 
@@ -303,6 +312,10 @@ def _parse_directive(user_input: str) -> Action | None:
     if not isinstance(parsed, CanonicalDirective):
         return None
 
+    return _directive_to_action(parsed)
+
+
+def _directive_to_action(parsed: CanonicalDirective) -> Action:
     if parsed.kind is DirectiveKind.SET_PREMISE:
         return Action(kind="set_premise", value=parsed.operands["value"])
     if parsed.kind is DirectiveKind.CHANGE_PREMISE:

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -307,14 +307,6 @@ class Engine:
         state[STATE_POLICIES][new_key] = POLICY_USE
 
 
-def _parse_directive(user_input: str) -> Action | None:
-    parsed = decompose_directive(user_input)
-    if not isinstance(parsed, CanonicalDirective):
-        return None
-
-    return _directive_to_action(parsed)
-
-
 def _directive_to_action(parsed: CanonicalDirective) -> Action:
     if parsed.kind is DirectiveKind.SET_PREMISE:
         return Action(kind="set_premise", value=parsed.operands["value"])

--- a/src/context_compiler/grammar.py
+++ b/src/context_compiler/grammar.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from types import MappingProxyType
 
 
-class DirectiveKind(StrEnum):
+class _DirectiveKind(StrEnum):
     """Enumerate the supported canonical directive families."""
 
     SET_PREMISE = "set_premise"
@@ -30,7 +30,7 @@ class CanonicalDirective:
     """
 
     text: str
-    kind: DirectiveKind
+    kind: _DirectiveKind
     operands: MappingProxyType[str, str]
 
 
@@ -41,7 +41,7 @@ class InvalidDirectiveSyntax:
 
 @dataclass(frozen=True, slots=True)
 class _DirectiveSpec:
-    kind: DirectiveKind
+    kind: _DirectiveKind
     operand_names: tuple[str, ...]
     exact_text: str | None
     renderer: Callable[[MappingProxyType[str, str]], str]
@@ -126,56 +126,56 @@ def _render_exact(text: str) -> Callable[[MappingProxyType[str, str]], str]:
 
 _DIRECTIVE_SPECS = MappingProxyType(
     {
-        DirectiveKind.SET_PREMISE: _DirectiveSpec(
-            kind=DirectiveKind.SET_PREMISE,
+        _DirectiveKind.SET_PREMISE: _DirectiveSpec(
+            kind=_DirectiveKind.SET_PREMISE,
             operand_names=("value",),
             exact_text=None,
             renderer=_render_with_prefix(_SET_PREMISE_PREFIX, "value"),
         ),
-        DirectiveKind.CHANGE_PREMISE: _DirectiveSpec(
-            kind=DirectiveKind.CHANGE_PREMISE,
+        _DirectiveKind.CHANGE_PREMISE: _DirectiveSpec(
+            kind=_DirectiveKind.CHANGE_PREMISE,
             operand_names=("value",),
             exact_text=None,
             renderer=_render_with_prefix(_CHANGE_PREMISE_PREFIX, "value"),
         ),
-        DirectiveKind.USE_ITEM: _DirectiveSpec(
-            kind=DirectiveKind.USE_ITEM,
+        _DirectiveKind.USE_ITEM: _DirectiveSpec(
+            kind=_DirectiveKind.USE_ITEM,
             operand_names=("item",),
             exact_text=None,
             renderer=_render_with_prefix(_USE_PREFIX, "item"),
         ),
-        DirectiveKind.PROHIBIT_ITEM: _DirectiveSpec(
-            kind=DirectiveKind.PROHIBIT_ITEM,
+        _DirectiveKind.PROHIBIT_ITEM: _DirectiveSpec(
+            kind=_DirectiveKind.PROHIBIT_ITEM,
             operand_names=("item",),
             exact_text=None,
             renderer=_render_with_prefix(_PROHIBIT_PREFIX, "item"),
         ),
-        DirectiveKind.REMOVE_POLICY: _DirectiveSpec(
-            kind=DirectiveKind.REMOVE_POLICY,
+        _DirectiveKind.REMOVE_POLICY: _DirectiveSpec(
+            kind=_DirectiveKind.REMOVE_POLICY,
             operand_names=("item",),
             exact_text=None,
             renderer=_render_with_prefix(_REMOVE_POLICY_PREFIX, "item"),
         ),
-        DirectiveKind.REPLACE_USE: _DirectiveSpec(
-            kind=DirectiveKind.REPLACE_USE,
+        _DirectiveKind.REPLACE_USE: _DirectiveSpec(
+            kind=_DirectiveKind.REPLACE_USE,
             operand_names=("new_item", "old_item"),
             exact_text=None,
             renderer=_render_replace_use,
         ),
-        DirectiveKind.CLEAR_PREMISE: _DirectiveSpec(
-            kind=DirectiveKind.CLEAR_PREMISE,
+        _DirectiveKind.CLEAR_PREMISE: _DirectiveSpec(
+            kind=_DirectiveKind.CLEAR_PREMISE,
             operand_names=(),
             exact_text=_CLEAR_PREMISE_TEXT,
             renderer=_render_exact(_CLEAR_PREMISE_TEXT),
         ),
-        DirectiveKind.RESET_POLICIES: _DirectiveSpec(
-            kind=DirectiveKind.RESET_POLICIES,
+        _DirectiveKind.RESET_POLICIES: _DirectiveSpec(
+            kind=_DirectiveKind.RESET_POLICIES,
             operand_names=(),
             exact_text=_RESET_POLICIES_TEXT,
             renderer=_render_exact(_RESET_POLICIES_TEXT),
         ),
-        DirectiveKind.CLEAR_STATE: _DirectiveSpec(
-            kind=DirectiveKind.CLEAR_STATE,
+        _DirectiveKind.CLEAR_STATE: _DirectiveSpec(
+            kind=_DirectiveKind.CLEAR_STATE,
             operand_names=(),
             exact_text=_CLEAR_STATE_TEXT,
             renderer=_render_exact(_CLEAR_STATE_TEXT),
@@ -305,7 +305,7 @@ def _parse_replace_use(trimmed_text: str) -> CanonicalDirective | None:
         return None
     return CanonicalDirective(
         text=trimmed_text,
-        kind=DirectiveKind.REPLACE_USE,
+        kind=_DirectiveKind.REPLACE_USE,
         operands=MappingProxyType({"new_item": new_item, "old_item": old_item}),
     )
 
@@ -334,17 +334,17 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
 
     if normalized == _CLEAR_PREMISE_TEXT:
         return CanonicalDirective(
-            text=text, kind=DirectiveKind.CLEAR_PREMISE, operands=MappingProxyType({})
+            text=text, kind=_DirectiveKind.CLEAR_PREMISE, operands=MappingProxyType({})
         )
     if normalized == _RESET_POLICIES_TEXT:
         return CanonicalDirective(
             text=text,
-            kind=DirectiveKind.RESET_POLICIES,
+            kind=_DirectiveKind.RESET_POLICIES,
             operands=MappingProxyType({}),
         )
     if normalized == _CLEAR_STATE_TEXT:
         return CanonicalDirective(
-            text=text, kind=DirectiveKind.CLEAR_STATE, operands=MappingProxyType({})
+            text=text, kind=_DirectiveKind.CLEAR_STATE, operands=MappingProxyType({})
         )
 
     if normalized.startswith("set premise "):
@@ -356,7 +356,7 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
             return invalid_result
         return CanonicalDirective(
             text=text,
-            kind=DirectiveKind.SET_PREMISE,
+            kind=_DirectiveKind.SET_PREMISE,
             operands=MappingProxyType({"value": value}),
         )
 
@@ -369,7 +369,7 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
             return invalid_result
         return CanonicalDirective(
             text=text,
-            kind=DirectiveKind.CHANGE_PREMISE,
+            kind=_DirectiveKind.CHANGE_PREMISE,
             operands=MappingProxyType({"value": value}),
         )
 
@@ -392,7 +392,7 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
             return invalid_result
         return CanonicalDirective(
             text=text,
-            kind=DirectiveKind.USE_ITEM,
+            kind=_DirectiveKind.USE_ITEM,
             operands=MappingProxyType({"item": item}),
         )
 
@@ -405,7 +405,7 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
             return invalid_result
         return CanonicalDirective(
             text=text,
-            kind=DirectiveKind.PROHIBIT_ITEM,
+            kind=_DirectiveKind.PROHIBIT_ITEM,
             operands=MappingProxyType({"item": item}),
         )
 
@@ -418,17 +418,17 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
             return invalid_result
         return CanonicalDirective(
             text=text,
-            kind=DirectiveKind.REMOVE_POLICY,
+            kind=_DirectiveKind.REMOVE_POLICY,
             operands=MappingProxyType({"item": item}),
         )
 
     return invalid_result
 
 
-def _render_directive(kind: DirectiveKind, /, **operands: str) -> str:
+def _render_directive(kind: _DirectiveKind | str, /, **operands: str) -> str:
     """Produce canonical directive text from a semantic kind and operands."""
     try:
-        normalized_kind = kind if isinstance(kind, DirectiveKind) else DirectiveKind(kind)
+        normalized_kind = kind if isinstance(kind, _DirectiveKind) else _DirectiveKind(kind)
         spec = _DIRECTIVE_SPECS[normalized_kind]
     except (KeyError, ValueError) as exc:
         raise ValueError(f"Unsupported directive kind: {kind!r}") from exc
@@ -439,18 +439,18 @@ def _render_directive(kind: DirectiveKind, /, **operands: str) -> str:
     missing_names = expected_names - actual_names
     if missing_names:
         missing = ", ".join(sorted(missing_names))
-        raise ValueError(f"Missing required operands for {kind.value}: {missing}")
+        raise ValueError(f"Missing required operands for {normalized_kind.value}: {missing}")
     if unexpected_names:
         unexpected = ", ".join(sorted(unexpected_names))
-        raise ValueError(f"Unexpected operands for {kind.value}: {unexpected}")
+        raise ValueError(f"Unexpected operands for {normalized_kind.value}: {unexpected}")
 
     normalized_operands: dict[str, str] = {}
     for name in spec.operand_names:
         raw_value = operands[name]
         if not isinstance(raw_value, str):
-            raise ValueError(f"Operand {name!r} for {kind.value} must be a string.")
+            raise ValueError(f"Operand {name!r} for {normalized_kind.value} must be a string.")
         if raw_value.strip() == "":
-            raise ValueError(f"Operand {name!r} for {kind.value} cannot be empty.")
+            raise ValueError(f"Operand {name!r} for {normalized_kind.value} cannot be empty.")
         normalized_operands[name] = raw_value
 
     operand_view = MappingProxyType(normalized_operands)
@@ -463,7 +463,6 @@ def _render_directive(kind: DirectiveKind, /, **operands: str) -> str:
 
 __all__ = [
     "CanonicalDirective",
-    "DirectiveKind",
     "InvalidDirectiveSyntax",
     "decompose_directive",
 ]

--- a/tests/fixtures/conformance/api/public-api-v2.json
+++ b/tests/fixtures/conformance/api/public-api-v2.json
@@ -195,6 +195,18 @@
             "params": []
           }
         },
+        "apply_directive": {
+          "kind": "method",
+          "signature": {
+            "params": [
+              {
+                "name": "directive",
+                "kind": "POSITIONAL_OR_KEYWORD",
+                "has_default": false
+              }
+            ]
+          }
+        },
         "import_json": {
           "kind": "method",
           "signature": {

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -5,15 +5,11 @@
   "exports": {
     "names": [
       "CanonicalDirective",
-      "DirectiveKind",
       "InvalidDirectiveSyntax",
       "decompose_directive"
     ],
     "members": {
       "CanonicalDirective": {
-        "kind": "class"
-      },
-      "DirectiveKind": {
         "kind": "class"
       },
       "InvalidDirectiveSyntax": {

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -9,7 +9,6 @@ from context_compiler.engine import (
     Action,
     _directive_to_action,
     _load_state_obj,
-    _parse_directive,
 )
 from context_compiler.grammar import (
     CanonicalDirective,
@@ -38,27 +37,39 @@ def _import_state(engine: object, payload: dict[str, object]) -> None:
     engine.import_json(json.dumps(payload, sort_keys=True, separators=(",", ":")))
 
 
-def test_parse_directive_delegates_canonical_kinds_to_existing_actions() -> None:
-    assert _parse_directive("set premise concise replies") == Action(
-        kind="set_premise", value="concise replies"
-    )
-    assert _parse_directive("change premise to concise replies") == Action(
-        kind="change_premise", value="concise replies"
-    )
-    assert _parse_directive("use docker") == Action(kind="use_item", item="docker")
-    assert _parse_directive("prohibit peanuts") == Action(kind="prohibit_item", item="peanuts")
-    assert _parse_directive("remove policy docker") == Action(
-        kind="remove_policy_item", item="docker"
-    )
-    assert _parse_directive("use podman instead of docker") == Action(
+def test_directive_to_action_delegates_canonical_kinds_to_existing_actions() -> None:
+    parsed = decompose_directive("set premise concise replies")
+    assert isinstance(parsed, CanonicalDirective)
+    assert _directive_to_action(parsed) == Action(kind="set_premise", value="concise replies")
+    parsed = decompose_directive("change premise to concise replies")
+    assert isinstance(parsed, CanonicalDirective)
+    assert _directive_to_action(parsed) == Action(kind="change_premise", value="concise replies")
+    parsed = decompose_directive("use docker")
+    assert isinstance(parsed, CanonicalDirective)
+    assert _directive_to_action(parsed) == Action(kind="use_item", item="docker")
+    parsed = decompose_directive("prohibit peanuts")
+    assert isinstance(parsed, CanonicalDirective)
+    assert _directive_to_action(parsed) == Action(kind="prohibit_item", item="peanuts")
+    parsed = decompose_directive("remove policy docker")
+    assert isinstance(parsed, CanonicalDirective)
+    assert _directive_to_action(parsed) == Action(kind="remove_policy_item", item="docker")
+    parsed = decompose_directive("use podman instead of docker")
+    assert isinstance(parsed, CanonicalDirective)
+    assert _directive_to_action(parsed) == Action(
         kind="replace_use", new_item="podman", old_item="docker"
     )
-    assert _parse_directive("clear premise") == Action(kind="clear_premise")
-    assert _parse_directive("reset policies") == Action(kind="reset_policies")
-    assert _parse_directive("clear state") == Action(kind="clear_state")
+    parsed = decompose_directive("clear premise")
+    assert isinstance(parsed, CanonicalDirective)
+    assert _directive_to_action(parsed) == Action(kind="clear_premise")
+    parsed = decompose_directive("reset policies")
+    assert isinstance(parsed, CanonicalDirective)
+    assert _directive_to_action(parsed) == Action(kind="reset_policies")
+    parsed = decompose_directive("clear state")
+    assert isinstance(parsed, CanonicalDirective)
+    assert _directive_to_action(parsed) == Action(kind="clear_state")
 
 
-def test_engine_parse_directive_matches_public_decomposition_boundary() -> None:
+def test_engine_directive_to_action_matches_public_decomposition_boundary() -> None:
     parsed = decompose_directive("use podman instead of docker")
 
     assert isinstance(parsed, CanonicalDirective)
@@ -67,21 +78,16 @@ def test_engine_parse_directive_matches_public_decomposition_boundary() -> None:
         new_item=parsed.operands["new_item"],
         old_item=parsed.operands["old_item"],
     )
-    assert _parse_directive(parsed.text) == _directive_to_action(parsed)
 
 
-def test_parse_directive_uses_decompose_directive_as_authoritative_boundary(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_directive_to_action_uses_canonical_operands_from_decompose_directive() -> None:
     parsed = CanonicalDirective(
         text="use docker",
         kind=DirectiveKind.USE_ITEM,
         operands=MappingProxyType({"item": "docker"}),
     )
 
-    monkeypatch.setattr("context_compiler.engine.decompose_directive", lambda _: parsed)
-
-    assert _parse_directive("ignored input") == Action(kind="use_item", item="docker")
+    assert _directive_to_action(parsed) == Action(kind="use_item", item="docker")
 
 
 def test_apply_directive_updates_state_from_canonical_directive() -> None:
@@ -117,23 +123,17 @@ def test_step_routes_canonical_directives_through_apply_directive(
     assert seen == [parsed]
 
 
-def test_parse_directive_ignores_noncanonical_decompose_results_at_engine_boundary(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("context_compiler.engine.decompose_directive", lambda _: object())
-
-    assert _parse_directive("ignored input") is None
-
-
-def test_parse_directive_returns_none_for_invalid_syntax_and_no_directive_inputs() -> None:
-    assert _parse_directive("set premise") is None
-    assert _parse_directive("change premise to") is None
-    assert _parse_directive("use") is None
-    assert _parse_directive("prohibit") is None
-    assert _parse_directive("remove policy") is None
-    assert _parse_directive("use instead of docker") is None
-    assert _parse_directive("use docker and prohibit peanuts") is None
-    assert _parse_directive("hello there") is None
+def test_decompose_directive_rejects_invalid_and_nondirective_inputs() -> None:
+    assert not isinstance(decompose_directive("set premise"), CanonicalDirective)
+    assert not isinstance(decompose_directive("change premise to"), CanonicalDirective)
+    assert not isinstance(decompose_directive("use"), CanonicalDirective)
+    assert not isinstance(decompose_directive("prohibit"), CanonicalDirective)
+    assert not isinstance(decompose_directive("remove policy"), CanonicalDirective)
+    assert not isinstance(decompose_directive("use instead of docker"), CanonicalDirective)
+    assert not isinstance(
+        decompose_directive("use docker and prohibit peanuts"), CanonicalDirective
+    )
+    assert not isinstance(decompose_directive("hello there"), CanonicalDirective)
 
 
 def test_pre_mutation_error_empty_operand_branches_remain_stable() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,13 +6,13 @@ import pytest
 
 from context_compiler import DECISION_ERROR, DECISION_NO_DIRECTIVE, DECISION_UPDATE, create_engine
 from context_compiler.engine import (
-    Action,
+    _Action,
     _directive_to_action,
     _load_state_obj,
 )
 from context_compiler.grammar import (
     CanonicalDirective,
-    DirectiveKind,
+    _DirectiveKind,
     decompose_directive,
 )
 
@@ -40,40 +40,40 @@ def _import_state(engine: object, payload: dict[str, object]) -> None:
 def test_directive_to_action_delegates_canonical_kinds_to_existing_actions() -> None:
     parsed = decompose_directive("set premise concise replies")
     assert isinstance(parsed, CanonicalDirective)
-    assert _directive_to_action(parsed) == Action(kind="set_premise", value="concise replies")
+    assert _directive_to_action(parsed) == _Action(kind="set_premise", value="concise replies")
     parsed = decompose_directive("change premise to concise replies")
     assert isinstance(parsed, CanonicalDirective)
-    assert _directive_to_action(parsed) == Action(kind="change_premise", value="concise replies")
+    assert _directive_to_action(parsed) == _Action(kind="change_premise", value="concise replies")
     parsed = decompose_directive("use docker")
     assert isinstance(parsed, CanonicalDirective)
-    assert _directive_to_action(parsed) == Action(kind="use_item", item="docker")
+    assert _directive_to_action(parsed) == _Action(kind="use_item", item="docker")
     parsed = decompose_directive("prohibit peanuts")
     assert isinstance(parsed, CanonicalDirective)
-    assert _directive_to_action(parsed) == Action(kind="prohibit_item", item="peanuts")
+    assert _directive_to_action(parsed) == _Action(kind="prohibit_item", item="peanuts")
     parsed = decompose_directive("remove policy docker")
     assert isinstance(parsed, CanonicalDirective)
-    assert _directive_to_action(parsed) == Action(kind="remove_policy_item", item="docker")
+    assert _directive_to_action(parsed) == _Action(kind="remove_policy_item", item="docker")
     parsed = decompose_directive("use podman instead of docker")
     assert isinstance(parsed, CanonicalDirective)
-    assert _directive_to_action(parsed) == Action(
+    assert _directive_to_action(parsed) == _Action(
         kind="replace_use", new_item="podman", old_item="docker"
     )
     parsed = decompose_directive("clear premise")
     assert isinstance(parsed, CanonicalDirective)
-    assert _directive_to_action(parsed) == Action(kind="clear_premise")
+    assert _directive_to_action(parsed) == _Action(kind="clear_premise")
     parsed = decompose_directive("reset policies")
     assert isinstance(parsed, CanonicalDirective)
-    assert _directive_to_action(parsed) == Action(kind="reset_policies")
+    assert _directive_to_action(parsed) == _Action(kind="reset_policies")
     parsed = decompose_directive("clear state")
     assert isinstance(parsed, CanonicalDirective)
-    assert _directive_to_action(parsed) == Action(kind="clear_state")
+    assert _directive_to_action(parsed) == _Action(kind="clear_state")
 
 
 def test_engine_directive_to_action_matches_public_decomposition_boundary() -> None:
     parsed = decompose_directive("use podman instead of docker")
 
     assert isinstance(parsed, CanonicalDirective)
-    assert _directive_to_action(parsed) == Action(
+    assert _directive_to_action(parsed) == _Action(
         kind="replace_use",
         new_item=parsed.operands["new_item"],
         old_item=parsed.operands["old_item"],
@@ -83,11 +83,11 @@ def test_engine_directive_to_action_matches_public_decomposition_boundary() -> N
 def test_directive_to_action_uses_canonical_operands_from_decompose_directive() -> None:
     parsed = CanonicalDirective(
         text="use docker",
-        kind=DirectiveKind.USE_ITEM,
+        kind=_DirectiveKind.USE_ITEM,
         operands=MappingProxyType({"item": "docker"}),
     )
 
-    assert _directive_to_action(parsed) == Action(kind="use_item", item="docker")
+    assert _directive_to_action(parsed) == _Action(kind="use_item", item="docker")
 
 
 def test_apply_directive_updates_state_from_canonical_directive() -> None:
@@ -139,30 +139,30 @@ def test_decompose_directive_rejects_invalid_and_nondirective_inputs() -> None:
 def test_pre_mutation_error_empty_operand_branches_remain_stable() -> None:
     engine = create_engine()
 
-    assert engine._pre_mutation_error(Action(kind="set_premise", value="")) == {
+    assert engine._pre_mutation_error(_Action(kind="set_premise", value="")) == {
         "kind": "error",
         "message": (
             "Premise value cannot be empty.\nUse 'set premise <value>' with a non-empty value."
         ),
     }
-    assert engine._pre_mutation_error(Action(kind="change_premise", value="")) == {
+    assert engine._pre_mutation_error(_Action(kind="change_premise", value="")) == {
         "kind": "error",
         "message": (
             "Premise value cannot be empty.\n"
             "Use 'change premise to <value>' with a non-empty value."
         ),
     }
-    assert engine._pre_mutation_error(Action(kind="remove_policy_item", item="")) == {
+    assert engine._pre_mutation_error(_Action(kind="remove_policy_item", item="")) == {
         "kind": "error",
         "message": (
             "Policy item cannot be empty.\nUse 'remove policy <item>' with a non-empty value."
         ),
     }
-    assert engine._pre_mutation_error(Action(kind="use_item", item="")) == {
+    assert engine._pre_mutation_error(_Action(kind="use_item", item="")) == {
         "kind": "error",
         "message": "Policy item cannot be empty.\nUse 'use <item>' with a non-empty value.",
     }
-    assert engine._pre_mutation_error(Action(kind="prohibit_item", item="")) == {
+    assert engine._pre_mutation_error(_Action(kind="prohibit_item", item="")) == {
         "kind": "error",
         "message": ("Policy item cannot be empty.\nUse 'prohibit <item>' with a non-empty value."),
     }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -7,6 +7,7 @@ import pytest
 from context_compiler import DECISION_ERROR, DECISION_NO_DIRECTIVE, DECISION_UPDATE, create_engine
 from context_compiler.engine import (
     Action,
+    _directive_to_action,
     _load_state_obj,
     _parse_directive,
 )
@@ -61,11 +62,12 @@ def test_engine_parse_directive_matches_public_decomposition_boundary() -> None:
     parsed = decompose_directive("use podman instead of docker")
 
     assert isinstance(parsed, CanonicalDirective)
-    assert _parse_directive(parsed.text) == Action(
+    assert _directive_to_action(parsed) == Action(
         kind="replace_use",
         new_item=parsed.operands["new_item"],
         old_item=parsed.operands["old_item"],
     )
+    assert _parse_directive(parsed.text) == _directive_to_action(parsed)
 
 
 def test_parse_directive_uses_decompose_directive_as_authoritative_boundary(
@@ -80,6 +82,39 @@ def test_parse_directive_uses_decompose_directive_as_authoritative_boundary(
     monkeypatch.setattr("context_compiler.engine.decompose_directive", lambda _: parsed)
 
     assert _parse_directive("ignored input") == Action(kind="use_item", item="docker")
+
+
+def test_apply_directive_updates_state_from_canonical_directive() -> None:
+    engine = create_engine()
+    parsed = decompose_directive("use docker")
+
+    assert isinstance(parsed, CanonicalDirective)
+    decision = engine.apply_directive(parsed)
+
+    assert decision == {"kind": DECISION_UPDATE, "message": None}
+    _assert_observations(engine, premise=None, policies={"docker": "use"})
+
+
+def test_step_routes_canonical_directives_through_apply_directive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = create_engine()
+    parsed = decompose_directive("use docker")
+    assert isinstance(parsed, CanonicalDirective)
+
+    seen: list[CanonicalDirective] = []
+    original = engine.apply_directive
+
+    def recording_apply_directive(directive: CanonicalDirective) -> dict[str, str | None]:
+        seen.append(directive)
+        return original(directive)
+
+    monkeypatch.setattr(engine, "apply_directive", recording_apply_directive)
+
+    decision = engine.step("use docker")
+
+    assert decision == {"kind": DECISION_UPDATE, "message": None}
+    assert seen == [parsed]
 
 
 def test_parse_directive_ignores_noncanonical_decompose_results_at_engine_boundary(

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -7,7 +7,6 @@ import context_compiler.grammar as grammar_module
 from context_compiler import DECISION_ERROR, create_engine
 from context_compiler.grammar import (
     CanonicalDirective,
-    DirectiveKind,
     decompose_directive,
 )
 
@@ -243,9 +242,7 @@ def test_grammar_fixtures() -> None:
                 assert directive.kind.value == expected_directive["kind"], fixture_id
                 assert dict(directive.operands) == expected_directive["operands"], fixture_id
         else:
-            rendered = grammar_module._render_directive(
-                DirectiveKind(action["kind"]), **action["operands"]
-            )
+            rendered = grammar_module._render_directive(action["kind"], **action["operands"])
             assert rendered == expected["text"], fixture_id
             directive = decompose_directive(rendered)
             assert isinstance(directive, CanonicalDirective), fixture_id

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -6,14 +6,14 @@ import pytest
 import context_compiler.grammar as grammar_module
 from context_compiler.grammar import (
     CanonicalDirective,
-    DirectiveKind,
     InvalidDirectiveSyntax,
+    _DirectiveKind,
     decompose_directive,
 )
 
 
 def test_directive_kind_members_and_values() -> None:
-    assert [member.name for member in DirectiveKind] == [
+    assert [member.name for member in _DirectiveKind] == [
         "SET_PREMISE",
         "CHANGE_PREMISE",
         "USE_ITEM",
@@ -24,7 +24,7 @@ def test_directive_kind_members_and_values() -> None:
         "RESET_POLICIES",
         "CLEAR_STATE",
     ]
-    assert [member.value for member in DirectiveKind] == [
+    assert [member.value for member in _DirectiveKind] == [
         "set_premise",
         "change_premise",
         "use_item",
@@ -35,40 +35,40 @@ def test_directive_kind_members_and_values() -> None:
         "reset_policies",
         "clear_state",
     ]
-    assert DirectiveKind("set_premise") is DirectiveKind.SET_PREMISE
+    assert _DirectiveKind("set_premise") is _DirectiveKind.SET_PREMISE
 
 
 def test_canonical_directive_is_frozen_and_slotted() -> None:
     directive = CanonicalDirective(
         text="use docker",
-        kind=DirectiveKind.USE_ITEM,
+        kind=_DirectiveKind.USE_ITEM,
         operands=MappingProxyType({"item": "docker"}),
     )
     assert directive.__slots__ == ("text", "kind", "operands")
     with pytest.raises(FrozenInstanceError):
-        directive.kind = DirectiveKind.PROHIBIT_ITEM  # type: ignore[misc]
+        directive.kind = _DirectiveKind.PROHIBIT_ITEM  # type: ignore[misc]
 
 
 @pytest.mark.parametrize(
     ("text", "expected_kind", "expected_operands"),
     [
-        ("set premise concise replies", DirectiveKind.SET_PREMISE, {"value": "concise replies"}),
-        ("change premise to formal tone", DirectiveKind.CHANGE_PREMISE, {"value": "formal tone"}),
-        ("use docker", DirectiveKind.USE_ITEM, {"item": "docker"}),
-        ("prohibit peanuts", DirectiveKind.PROHIBIT_ITEM, {"item": "peanuts"}),
-        ("remove policy docker", DirectiveKind.REMOVE_POLICY, {"item": "docker"}),
+        ("set premise concise replies", _DirectiveKind.SET_PREMISE, {"value": "concise replies"}),
+        ("change premise to formal tone", _DirectiveKind.CHANGE_PREMISE, {"value": "formal tone"}),
+        ("use docker", _DirectiveKind.USE_ITEM, {"item": "docker"}),
+        ("prohibit peanuts", _DirectiveKind.PROHIBIT_ITEM, {"item": "peanuts"}),
+        ("remove policy docker", _DirectiveKind.REMOVE_POLICY, {"item": "docker"}),
         (
             "use podman instead of docker",
-            DirectiveKind.REPLACE_USE,
+            _DirectiveKind.REPLACE_USE,
             {"new_item": "podman", "old_item": "docker"},
         ),
-        ("clear premise", DirectiveKind.CLEAR_PREMISE, {}),
-        ("reset policies", DirectiveKind.RESET_POLICIES, {}),
-        ("clear state", DirectiveKind.CLEAR_STATE, {}),
+        ("clear premise", _DirectiveKind.CLEAR_PREMISE, {}),
+        ("reset policies", _DirectiveKind.RESET_POLICIES, {}),
+        ("clear state", _DirectiveKind.CLEAR_STATE, {}),
     ],
 )
 def test_decompose_directive_accepts_each_canonical_family(
-    text: str, expected_kind: DirectiveKind, expected_operands: dict[str, str]
+    text: str, expected_kind: _DirectiveKind, expected_operands: dict[str, str]
 ) -> None:
     decomposed = decompose_directive(text)
     assert decomposed == CanonicalDirective(
@@ -130,27 +130,27 @@ def test_decompose_directive_preserves_current_operand_casing_and_whitespace(
 @pytest.mark.parametrize(
     ("kind", "operands", "expected"),
     [
-        (DirectiveKind.SET_PREMISE, {"value": "concise replies"}, "set premise concise replies"),
+        (_DirectiveKind.SET_PREMISE, {"value": "concise replies"}, "set premise concise replies"),
         (
-            DirectiveKind.CHANGE_PREMISE,
+            _DirectiveKind.CHANGE_PREMISE,
             {"value": "formal tone"},
             "change premise to formal tone",
         ),
-        (DirectiveKind.USE_ITEM, {"item": "docker"}, "use docker"),
-        (DirectiveKind.PROHIBIT_ITEM, {"item": "peanuts"}, "prohibit peanuts"),
-        (DirectiveKind.REMOVE_POLICY, {"item": "docker"}, "remove policy docker"),
+        (_DirectiveKind.USE_ITEM, {"item": "docker"}, "use docker"),
+        (_DirectiveKind.PROHIBIT_ITEM, {"item": "peanuts"}, "prohibit peanuts"),
+        (_DirectiveKind.REMOVE_POLICY, {"item": "docker"}, "remove policy docker"),
         (
-            DirectiveKind.REPLACE_USE,
+            _DirectiveKind.REPLACE_USE,
             {"new_item": "podman", "old_item": "docker"},
             "use podman instead of docker",
         ),
-        (DirectiveKind.CLEAR_PREMISE, {}, "clear premise"),
-        (DirectiveKind.RESET_POLICIES, {}, "reset policies"),
-        (DirectiveKind.CLEAR_STATE, {}, "clear state"),
+        (_DirectiveKind.CLEAR_PREMISE, {}, "clear premise"),
+        (_DirectiveKind.RESET_POLICIES, {}, "reset policies"),
+        (_DirectiveKind.CLEAR_STATE, {}, "clear state"),
     ],
 )
 def test_render_directive_outputs_exact_canonical_syntax(
-    kind: DirectiveKind, operands: dict[str, str], expected: str
+    kind: _DirectiveKind, operands: dict[str, str], expected: str
 ) -> None:
     rendered = grammar_module._render_directive(kind, **operands)
     assert rendered == expected
@@ -162,45 +162,45 @@ def test_render_directive_outputs_exact_canonical_syntax(
 @pytest.mark.parametrize(
     ("kind", "operands", "message"),
     [
-        (DirectiveKind.SET_PREMISE, {}, "Missing required operands"),
-        (DirectiveKind.REPLACE_USE, {"new_item": "podman"}, "Missing required operands"),
+        (_DirectiveKind.SET_PREMISE, {}, "Missing required operands"),
+        (_DirectiveKind.REPLACE_USE, {"new_item": "podman"}, "Missing required operands"),
         (
-            DirectiveKind.CLEAR_STATE,
+            _DirectiveKind.CLEAR_STATE,
             {"item": "docker"},
             "Unexpected operands",
         ),
         (
-            DirectiveKind.USE_ITEM,
+            _DirectiveKind.USE_ITEM,
             {"value": "docker"},
             "Missing required operands",
         ),
         (
-            DirectiveKind.USE_ITEM,
+            _DirectiveKind.USE_ITEM,
             {"item": "docker", "old_item": "podman"},
             "Unexpected operands",
         ),
         (
-            DirectiveKind.SET_PREMISE,
+            _DirectiveKind.SET_PREMISE,
             {"value": ""},
             "cannot be empty",
         ),
         (
-            DirectiveKind.SET_PREMISE,
+            _DirectiveKind.SET_PREMISE,
             {"value": "   "},
             "cannot be empty",
         ),
         (
-            DirectiveKind.USE_ITEM,
+            _DirectiveKind.USE_ITEM,
             {"item": "docker and prohibit peanuts"},
             "canonical use_item directive",
         ),
         (
-            DirectiveKind.SET_PREMISE,
+            _DirectiveKind.SET_PREMISE,
             {"value": "use docker and prohibit peanuts"},
             "canonical set_premise directive",
         ),
         (
-            DirectiveKind.USE_ITEM,
+            _DirectiveKind.USE_ITEM,
             {"item": "docker instead of podman"},
             "canonical use_item directive",
         ),
@@ -212,7 +212,7 @@ def test_render_directive_outputs_exact_canonical_syntax(
     ],
 )
 def test_render_directive_rejects_invalid_operand_combinations(
-    kind: DirectiveKind | str, operands: dict[str, str], message: str
+    kind: _DirectiveKind | str, operands: dict[str, str], message: str
 ) -> None:
     with pytest.raises(ValueError, match=message):
         grammar_module._render_directive(kind, **operands)
@@ -227,16 +227,15 @@ def test_internal_grammar_specs_use_immutable_mapping() -> None:
     specs = grammar_module._DIRECTIVE_SPECS
     assert isinstance(specs, MappingProxyType)
     with pytest.raises(TypeError):
-        specs[DirectiveKind.SET_PREMISE] = object()  # type: ignore[index]
-    spec = specs[DirectiveKind.SET_PREMISE]
+        specs[_DirectiveKind.SET_PREMISE] = object()  # type: ignore[index]
+    spec = specs[_DirectiveKind.SET_PREMISE]
     with pytest.raises(FrozenInstanceError):
-        spec.kind = DirectiveKind.CHANGE_PREMISE  # type: ignore[misc]
+        spec.kind = _DirectiveKind.CHANGE_PREMISE  # type: ignore[misc]
 
 
 def test_public_grammar_all_includes_semantic_surface() -> None:
     assert grammar_module.__all__ == [
         "CanonicalDirective",
-        "DirectiveKind",
         "InvalidDirectiveSyntax",
         "decompose_directive",
     ]
@@ -249,7 +248,7 @@ def test_decompose_directive_rejects_near_miss_without_required_delimiter() -> N
 
 def test_render_directive_rejects_non_string_operands() -> None:
     with pytest.raises(ValueError, match="must be a string"):
-        grammar_module._render_directive(DirectiveKind.SET_PREMISE, value=123)  # type: ignore[arg-type]
+        grammar_module._render_directive(_DirectiveKind.SET_PREMISE, value=123)  # type: ignore[arg-type]
 
 
 def test_render_directive_uses_decompose_directive_as_authoritative_round_trip(
@@ -260,12 +259,12 @@ def test_render_directive_uses_decompose_directive_as_authoritative_round_trip(
         "decompose_directive",
         lambda _: CanonicalDirective(
             text="use docker",
-            kind=DirectiveKind.USE_ITEM,
+            kind=_DirectiveKind.USE_ITEM,
             operands=MappingProxyType({"item": "docker"}),
         ),
     )
 
-    assert grammar_module._render_directive(DirectiveKind.USE_ITEM, item="docker") == "use docker"
+    assert grammar_module._render_directive(_DirectiveKind.USE_ITEM, item="docker") == "use docker"
 
 
 def test_render_directive_rejects_when_decompose_directive_disagrees_with_rendered_kind(
@@ -276,13 +275,13 @@ def test_render_directive_rejects_when_decompose_directive_disagrees_with_render
         "decompose_directive",
         lambda _: CanonicalDirective(
             text="use docker",
-            kind=DirectiveKind.PROHIBIT_ITEM,
+            kind=_DirectiveKind.PROHIBIT_ITEM,
             operands=MappingProxyType({"item": "docker"}),
         ),
     )
 
     with pytest.raises(ValueError, match="canonical use_item directive"):
-        grammar_module._render_directive(DirectiveKind.USE_ITEM, item="docker")
+        grammar_module._render_directive(_DirectiveKind.USE_ITEM, item="docker")
 
 
 def test_render_directive_rejects_when_decompose_directive_returns_noncanonical_result(
@@ -291,7 +290,7 @@ def test_render_directive_rejects_when_decompose_directive_returns_noncanonical_
     monkeypatch.setattr(grammar_module, "decompose_directive", lambda _: InvalidDirectiveSyntax())
 
     with pytest.raises(ValueError, match="canonical use_item directive"):
-        grammar_module._render_directive(DirectiveKind.USE_ITEM, item="docker")
+        grammar_module._render_directive(_DirectiveKind.USE_ITEM, item="docker")
 
 
 def test_decompose_directive_returns_canonical_operands_for_use_item() -> None:
@@ -299,7 +298,7 @@ def test_decompose_directive_returns_canonical_operands_for_use_item() -> None:
 
     assert parsed is not None
     assert parsed.text == "use docker"
-    assert parsed.kind is DirectiveKind.USE_ITEM
+    assert parsed.kind is _DirectiveKind.USE_ITEM
     assert parsed.operands == {"item": "docker"}
 
 
@@ -308,7 +307,7 @@ def test_decompose_directive_returns_text_kind_and_operands_without_projection_l
 
     assert decomposed is not None
     assert decomposed.text == "use docker"
-    assert decomposed.kind is DirectiveKind.USE_ITEM
+    assert decomposed.kind is _DirectiveKind.USE_ITEM
     assert decomposed.operands == {"item": "docker"}
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -10,7 +10,7 @@ import context_compiler.grammar as grammar_module
 from context_compiler import DECISION_ERROR, DECISION_NO_DIRECTIVE, DECISION_UPDATE, create_engine
 from context_compiler.grammar import (
     CanonicalDirective,
-    DirectiveKind,
+    _DirectiveKind,
     decompose_directive,
 )
 
@@ -198,19 +198,19 @@ def _payload_has_stable_export_import_cycle(payload: dict[str, object]) -> bool:
 
 GRAMMAR_RENDER_CASES = st.one_of(
     CANONICAL_GRAMMAR_PREMISE_TEXT.map(
-        lambda value: {"kind": DirectiveKind.SET_PREMISE, "operands": {"value": value}}
+        lambda value: {"kind": _DirectiveKind.SET_PREMISE, "operands": {"value": value}}
     ),
     CANONICAL_GRAMMAR_PREMISE_TEXT.map(
-        lambda value: {"kind": DirectiveKind.CHANGE_PREMISE, "operands": {"value": value}}
+        lambda value: {"kind": _DirectiveKind.CHANGE_PREMISE, "operands": {"value": value}}
     ),
     CANONICAL_GRAMMAR_ITEM_TEXT.map(
-        lambda item: {"kind": DirectiveKind.USE_ITEM, "operands": {"item": item}}
+        lambda item: {"kind": _DirectiveKind.USE_ITEM, "operands": {"item": item}}
     ),
     CANONICAL_GRAMMAR_ITEM_TEXT.map(
-        lambda item: {"kind": DirectiveKind.PROHIBIT_ITEM, "operands": {"item": item}}
+        lambda item: {"kind": _DirectiveKind.PROHIBIT_ITEM, "operands": {"item": item}}
     ),
     CANONICAL_GRAMMAR_ITEM_TEXT.map(
-        lambda item: {"kind": DirectiveKind.REMOVE_POLICY, "operands": {"item": item}}
+        lambda item: {"kind": _DirectiveKind.REMOVE_POLICY, "operands": {"item": item}}
     ),
     st.tuples(CANONICAL_GRAMMAR_ITEM_TEXT, CANONICAL_GRAMMAR_ITEM_TEXT)
     .filter(
@@ -218,15 +218,15 @@ GRAMMAR_RENDER_CASES = st.one_of(
     )
     .map(
         lambda pair: {
-            "kind": DirectiveKind.REPLACE_USE,
+            "kind": _DirectiveKind.REPLACE_USE,
             "operands": {"new_item": pair[0], "old_item": pair[1]},
         }
     ),
     st.sampled_from(
         [
-            {"kind": DirectiveKind.CLEAR_PREMISE, "operands": {}},
-            {"kind": DirectiveKind.RESET_POLICIES, "operands": {}},
-            {"kind": DirectiveKind.CLEAR_STATE, "operands": {}},
+            {"kind": _DirectiveKind.CLEAR_PREMISE, "operands": {}},
+            {"kind": _DirectiveKind.RESET_POLICIES, "operands": {}},
+            {"kind": _DirectiveKind.CLEAR_STATE, "operands": {}},
         ]
     ),
 )
@@ -239,12 +239,12 @@ def test_determinism_same_input_sequence_same_state(inputs: list[str]) -> None:
 
 @given(GRAMMAR_RENDER_CASES)
 def test_grammar_helper_render_decompose_round_trip_is_stable(
-    case: dict[str, DirectiveKind | dict[str, str]],
+    case: dict[str, _DirectiveKind | dict[str, str]],
 ) -> None:
     kind = case["kind"]
     operands = case["operands"]
 
-    assert isinstance(kind, DirectiveKind)
+    assert isinstance(kind, _DirectiveKind)
     assert isinstance(operands, dict)
 
     rendered = grammar_module._render_directive(kind, **operands)

--- a/tests/test_public_grammar_root_exports.py
+++ b/tests/test_public_grammar_root_exports.py
@@ -3,16 +3,21 @@ import context_compiler.grammar as grammar_module
 
 
 def test_root_does_not_export_public_grammar_surface() -> None:
-    for name in ("DirectiveKind",):
+    for name in (
+        "DirectiveKind",
+        "CanonicalDirective",
+        "InvalidDirectiveSyntax",
+        "decompose_directive",
+    ):
         assert name not in context_compiler.__all__
         assert not hasattr(context_compiler, name)
 
 
 def test_grammar_submodule_preserves_public_grammar_surface() -> None:
     assert grammar_module.CanonicalDirective is not None
-    assert grammar_module.DirectiveKind is not None
     assert grammar_module.InvalidDirectiveSyntax is not None
     assert grammar_module.decompose_directive is not None
+    assert not hasattr(grammar_module, "DirectiveKind")
     assert not hasattr(grammar_module, "render_directive")
     assert not hasattr(grammar_module, "contains_multiple_canonical_directives")
     assert not hasattr(grammar_module, "match_canonical_directive_start")


### PR DESCRIPTION
## What changed

- Added `Engine.apply_directive()` as the semantic application boundary for parsed directives.
- Removed the legacy `_parse_directive()` path so directive handling now flows through:
  - `decompose_directive()`
  - `CanonicalDirective`
  - `apply_directive()`
- Removed leaked implementation types from the public API:
  - `Action` is now internal to the engine.
  - `DirectiveKind` is now internal to grammar.
- Updated tests, fixtures, and documentation to reflect the reduced public surface.

## Why

The previous implementation mixed directive parsing and semantic application inside the engine.

This change separates responsibilities:
- grammar owns converting text into canonical directives;
- engine owns applying canonical directives to state.

Reducing the public surface prevents consumers from depending on internal semantic representations and keeps the supported integration path centered on parsed directives and engine application.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)