### PR TITLE
chore: bump dev version to 0.9.0dev10

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -75,8 +75,10 @@ Public grammar surface:
 
 - `DirectiveKind`
 - `DirectiveSyntaxFailure`
+- `DirectiveMetadata`
 - `CanonicalDirective`
 - `InvalidDirectiveSyntax`
+- `get_directive_metadata()`
 - `decompose_directive(text)`
 
 Use this surface for exact canonical directive decomposition and
@@ -84,6 +86,12 @@ classification via `decompose_directive(...)` only.
 
 Boundary notes:
 
+- `get_directive_metadata()` returns immutable directive metadata derived from
+  the internal grammar specs
+- each `DirectiveMetadata` exposes only `kind`, `canonical_start`, and
+  `operand_names`
+- directive metadata is descriptive only; it does not parse text or recognize
+  malformed input
 - use `decompose_directive(text)` to determine whether text is a complete
   canonical directive
 - `decompose_directive(...)` returns `CanonicalDirective` for accepted
@@ -115,6 +123,15 @@ Core does not lowercase operands, collapse internal operand whitespace, or
 convert operand text into engine/domain identifiers at the grammar layer.
 `CanonicalDirective.text` should not be treated as canonical serialized
 directive output.
+
+Typical metadata use:
+
+```python
+from context_compiler.grammar import get_directive_metadata
+
+for metadata in get_directive_metadata():
+    print(metadata.kind, metadata.canonical_start, metadata.operand_names)
+```
 
 ### `engine.apply_directive(directive)`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.9.0dev9"
+version = "0.9.0dev10"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/context_compiler/grammar.py
+++ b/src/context_compiler/grammar.py
@@ -54,16 +54,31 @@ class InvalidDirectiveSyntax:
 @dataclass(frozen=True, slots=True)
 class _DirectiveSpec:
     kind: DirectiveKind
+    canonical_start: str
     operand_names: tuple[str, ...]
     exact_text: str | None
     renderer: Callable[[MappingProxyType[str, str]], str]
 
 
-_SET_PREMISE_PREFIX = "set premise "
-_CHANGE_PREMISE_PREFIX = "change premise to "
-_USE_PREFIX = "use "
-_PROHIBIT_PREFIX = "prohibit "
-_REMOVE_POLICY_PREFIX = "remove policy "
+@dataclass(frozen=True, slots=True)
+class DirectiveMetadata:
+    """Describe one canonical directive family without exposing parser internals."""
+
+    kind: DirectiveKind
+    canonical_start: str
+    operand_names: tuple[str, ...]
+
+
+_SET_PREMISE_START = "set premise"
+_CHANGE_PREMISE_START = "change premise to"
+_USE_START = "use"
+_PROHIBIT_START = "prohibit"
+_REMOVE_POLICY_START = "remove policy"
+_SET_PREMISE_PREFIX = f"{_SET_PREMISE_START} "
+_CHANGE_PREMISE_PREFIX = f"{_CHANGE_PREMISE_START} "
+_USE_PREFIX = f"{_USE_START} "
+_PROHIBIT_PREFIX = f"{_PROHIBIT_START} "
+_REMOVE_POLICY_PREFIX = f"{_REMOVE_POLICY_START} "
 _CLEAR_PREMISE_TEXT = "clear premise"
 _RESET_POLICIES_TEXT = "reset policies"
 _CLEAR_STATE_TEXT = "clear state"
@@ -79,39 +94,6 @@ _PROHIBIT_RE = re.compile(r"(?i)^prohibit[ \t]+(?P<item>.+)$")
 _REMOVE_POLICY_RE = re.compile(r"(?i)^remove[ \t]+policy[ \t]+(?P<item>.+)$")
 _REPLACE_RE = re.compile(
     r"(?i)^use[ \t]+(?P<new_item>.*?)[ \t]+instead[ \t]+of[ \t]+(?P<old_item>.+)$"
-)
-
-_PREFIX_DIRECTIVE_STARTS: tuple[tuple[str, bool], ...] = (
-    (_CHANGE_PREMISE_PREFIX.removesuffix(" "), True),
-    (_SET_PREMISE_PREFIX.removesuffix(" "), True),
-    (_REMOVE_POLICY_PREFIX.removesuffix(" "), True),
-    (_PROHIBIT_PREFIX.removesuffix(" "), True),
-    (_USE_PREFIX.removesuffix(" "), True),
-)
-
-_EXACT_DIRECTIVE_STARTS: tuple[tuple[str, bool], ...] = (
-    (_RESET_POLICIES_TEXT, False),
-    (_CLEAR_PREMISE_TEXT, False),
-    (_CLEAR_STATE_TEXT, False),
-)
-
-_CANONICAL_DIRECTIVE_STARTS: tuple[tuple[str, bool], ...] = (
-    _PREFIX_DIRECTIVE_STARTS[0],
-    _PREFIX_DIRECTIVE_STARTS[1],
-    _PREFIX_DIRECTIVE_STARTS[2],
-    _EXACT_DIRECTIVE_STARTS[0],
-    _EXACT_DIRECTIVE_STARTS[1],
-    _EXACT_DIRECTIVE_STARTS[2],
-    _PREFIX_DIRECTIVE_STARTS[3],
-    _PREFIX_DIRECTIVE_STARTS[4],
-)
-
-_DIRECTIVE_FAMILY_STARTS: tuple[tuple[str, bool], ...] = (
-    (_CHANGE_PREMISE_FAMILY, True),
-    _PREFIX_DIRECTIVE_STARTS[1],
-    _PREFIX_DIRECTIVE_STARTS[2],
-    *_EXACT_DIRECTIVE_STARTS,
-    *_PREFIX_DIRECTIVE_STARTS[3:],
 )
 
 
@@ -140,59 +122,126 @@ _DIRECTIVE_SPECS = MappingProxyType(
     {
         DirectiveKind.SET_PREMISE: _DirectiveSpec(
             kind=DirectiveKind.SET_PREMISE,
+            canonical_start=_SET_PREMISE_START,
             operand_names=("value",),
             exact_text=None,
             renderer=_render_with_prefix(_SET_PREMISE_PREFIX, "value"),
         ),
         DirectiveKind.CHANGE_PREMISE: _DirectiveSpec(
             kind=DirectiveKind.CHANGE_PREMISE,
+            canonical_start=_CHANGE_PREMISE_START,
             operand_names=("value",),
             exact_text=None,
             renderer=_render_with_prefix(_CHANGE_PREMISE_PREFIX, "value"),
         ),
         DirectiveKind.USE_ITEM: _DirectiveSpec(
             kind=DirectiveKind.USE_ITEM,
+            canonical_start=_USE_START,
             operand_names=("item",),
             exact_text=None,
             renderer=_render_with_prefix(_USE_PREFIX, "item"),
         ),
         DirectiveKind.PROHIBIT_ITEM: _DirectiveSpec(
             kind=DirectiveKind.PROHIBIT_ITEM,
+            canonical_start=_PROHIBIT_START,
             operand_names=("item",),
             exact_text=None,
             renderer=_render_with_prefix(_PROHIBIT_PREFIX, "item"),
         ),
         DirectiveKind.REMOVE_POLICY: _DirectiveSpec(
             kind=DirectiveKind.REMOVE_POLICY,
+            canonical_start=_REMOVE_POLICY_START,
             operand_names=("item",),
             exact_text=None,
             renderer=_render_with_prefix(_REMOVE_POLICY_PREFIX, "item"),
         ),
         DirectiveKind.REPLACE_USE: _DirectiveSpec(
             kind=DirectiveKind.REPLACE_USE,
+            canonical_start=_USE_START,
             operand_names=("new_item", "old_item"),
             exact_text=None,
             renderer=_render_replace_use,
         ),
         DirectiveKind.CLEAR_PREMISE: _DirectiveSpec(
             kind=DirectiveKind.CLEAR_PREMISE,
+            canonical_start=_CLEAR_PREMISE_TEXT,
             operand_names=(),
             exact_text=_CLEAR_PREMISE_TEXT,
             renderer=_render_exact(_CLEAR_PREMISE_TEXT),
         ),
         DirectiveKind.RESET_POLICIES: _DirectiveSpec(
             kind=DirectiveKind.RESET_POLICIES,
+            canonical_start=_RESET_POLICIES_TEXT,
             operand_names=(),
             exact_text=_RESET_POLICIES_TEXT,
             renderer=_render_exact(_RESET_POLICIES_TEXT),
         ),
         DirectiveKind.CLEAR_STATE: _DirectiveSpec(
             kind=DirectiveKind.CLEAR_STATE,
+            canonical_start=_CLEAR_STATE_TEXT,
             operand_names=(),
             exact_text=_CLEAR_STATE_TEXT,
             renderer=_render_exact(_CLEAR_STATE_TEXT),
         ),
     }
+)
+
+
+def _starts_with_descriptor(spec: _DirectiveSpec) -> tuple[str, bool]:
+    return (spec.canonical_start, bool(spec.operand_names))
+
+
+def _unique_start_descriptors(specs: tuple[_DirectiveSpec, ...]) -> tuple[tuple[str, bool], ...]:
+    descriptors: list[tuple[str, bool]] = []
+    seen: set[tuple[str, bool]] = set()
+    for spec in specs:
+        descriptor = _starts_with_descriptor(spec)
+        if descriptor not in seen:
+            seen.add(descriptor)
+            descriptors.append(descriptor)
+    return tuple(descriptors)
+
+
+_CANONICAL_START_ORDER = (
+    DirectiveKind.CHANGE_PREMISE,
+    DirectiveKind.SET_PREMISE,
+    DirectiveKind.REMOVE_POLICY,
+    DirectiveKind.RESET_POLICIES,
+    DirectiveKind.CLEAR_PREMISE,
+    DirectiveKind.CLEAR_STATE,
+    DirectiveKind.PROHIBIT_ITEM,
+    DirectiveKind.USE_ITEM,
+)
+
+_CANONICAL_DIRECTIVE_STARTS = _unique_start_descriptors(
+    tuple(_DIRECTIVE_SPECS[kind] for kind in _CANONICAL_START_ORDER)
+)
+
+_DIRECTIVE_FAMILY_STARTS = (
+    (_CHANGE_PREMISE_FAMILY, True),
+    *_unique_start_descriptors(
+        tuple(
+            _DIRECTIVE_SPECS[kind]
+            for kind in (
+                DirectiveKind.SET_PREMISE,
+                DirectiveKind.REMOVE_POLICY,
+                DirectiveKind.RESET_POLICIES,
+                DirectiveKind.CLEAR_PREMISE,
+                DirectiveKind.CLEAR_STATE,
+                DirectiveKind.PROHIBIT_ITEM,
+                DirectiveKind.USE_ITEM,
+            )
+        )
+    ),
+)
+
+_PUBLIC_DIRECTIVE_METADATA = tuple(
+    DirectiveMetadata(
+        kind=spec.kind,
+        canonical_start=spec.canonical_start,
+        operand_names=spec.operand_names,
+    )
+    for spec in _DIRECTIVE_SPECS.values()
 )
 
 
@@ -533,6 +582,12 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
     return _invalid_directive_syntax(DirectiveSyntaxFailure.MALFORMED_DIRECTIVE)
 
 
+def get_directive_metadata() -> tuple[DirectiveMetadata, ...]:
+    """Return immutable public directive metadata derived from internal specs."""
+
+    return _PUBLIC_DIRECTIVE_METADATA
+
+
 def _render_directive(kind: DirectiveKind | str, /, **operands: str) -> str:
     """Produce canonical directive text from a semantic kind and operands."""
     try:
@@ -572,7 +627,9 @@ def _render_directive(kind: DirectiveKind | str, /, **operands: str) -> str:
 __all__ = [
     "DirectiveKind",
     "DirectiveSyntaxFailure",
+    "DirectiveMetadata",
     "CanonicalDirective",
     "InvalidDirectiveSyntax",
+    "get_directive_metadata",
     "decompose_directive",
 ]

--- a/tests/_api_contract_harness.py
+++ b/tests/_api_contract_harness.py
@@ -80,6 +80,17 @@ def assert_shape(
         )
         return
 
+    if "kind" in shape and shape["kind"] == "directive_metadata_collection":
+        assert value == tuple(
+            grammar.DirectiveMetadata(
+                kind=grammar.DirectiveKind(item["directive_kind"]),
+                canonical_start=item["canonical_start"],
+                operand_names=tuple(item["operand_names"]),
+            )
+            for item in shape["items"]
+        )
+        return
+
     expected_types = shape["type"]
     if isinstance(expected_types, str):
         expected_types = [expected_types]
@@ -399,6 +410,35 @@ def _validate_shape_spec(shape: object, label: str) -> None:
                 _assert_type(shape["directive_kind"], str, f"{label}.directive_kind")
             if "missing_operand" in shape and shape["missing_operand"] is not None:
                 _assert_type(shape["missing_operand"], str, f"{label}.missing_operand")
+            return
+        if kind == "directive_metadata_collection":
+            _assert_closed_keys(shape, {"kind", "items"}, label)
+            _require_fields(shape, {"kind", "items"}, label)
+            items = shape["items"]
+            _assert_type(items, list, f"{label}.items")
+            for index, item in enumerate(items):
+                item_label = f"{label}.items[{index}]"
+                _assert_type(item, dict, item_label)
+                _assert_closed_keys(
+                    item,
+                    {"directive_kind", "canonical_start", "operand_names"},
+                    item_label,
+                )
+                _require_fields(
+                    item,
+                    {"directive_kind", "canonical_start", "operand_names"},
+                    item_label,
+                )
+                _assert_type(item["directive_kind"], str, f"{item_label}.directive_kind")
+                _assert_type(item["canonical_start"], str, f"{item_label}.canonical_start")
+                operand_names = item["operand_names"]
+                _assert_type(operand_names, list, f"{item_label}.operand_names")
+                for operand_index, operand_name in enumerate(operand_names):
+                    _assert_type(
+                        operand_name,
+                        str,
+                        f"{item_label}.operand_names[{operand_index}]",
+                    )
             return
         raise AssertionError(f"{label}.kind has unsupported shape kind {kind!r}")
 

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -6,8 +6,10 @@
     "names": [
       "DirectiveKind",
       "DirectiveSyntaxFailure",
+      "DirectiveMetadata",
       "CanonicalDirective",
       "InvalidDirectiveSyntax",
+      "get_directive_metadata",
       "decompose_directive"
     ],
     "members": {
@@ -17,11 +19,87 @@
       "DirectiveSyntaxFailure": {
         "kind": "class"
       },
+      "DirectiveMetadata": {
+        "kind": "class"
+      },
       "CanonicalDirective": {
         "kind": "class"
       },
       "InvalidDirectiveSyntax": {
         "kind": "class"
+      },
+      "get_directive_metadata": {
+        "kind": "callable",
+        "signature": {
+          "params": []
+        },
+        "shape_probes": [
+          {
+            "return_shape": {
+              "kind": "directive_metadata_collection",
+              "items": [
+                {
+                  "directive_kind": "set_premise",
+                  "canonical_start": "set premise",
+                  "operand_names": [
+                    "value"
+                  ]
+                },
+                {
+                  "directive_kind": "change_premise",
+                  "canonical_start": "change premise to",
+                  "operand_names": [
+                    "value"
+                  ]
+                },
+                {
+                  "directive_kind": "use_item",
+                  "canonical_start": "use",
+                  "operand_names": [
+                    "item"
+                  ]
+                },
+                {
+                  "directive_kind": "prohibit_item",
+                  "canonical_start": "prohibit",
+                  "operand_names": [
+                    "item"
+                  ]
+                },
+                {
+                  "directive_kind": "remove_policy",
+                  "canonical_start": "remove policy",
+                  "operand_names": [
+                    "item"
+                  ]
+                },
+                {
+                  "directive_kind": "replace_use",
+                  "canonical_start": "use",
+                  "operand_names": [
+                    "new_item",
+                    "old_item"
+                  ]
+                },
+                {
+                  "directive_kind": "clear_premise",
+                  "canonical_start": "clear premise",
+                  "operand_names": []
+                },
+                {
+                  "directive_kind": "reset_policies",
+                  "canonical_start": "reset policies",
+                  "operand_names": []
+                },
+                {
+                  "directive_kind": "clear_state",
+                  "canonical_start": "clear state",
+                  "operand_names": []
+                }
+              ]
+            }
+          }
+        ]
       },
       "decompose_directive": {
         "kind": "callable",

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -7,9 +7,11 @@ import context_compiler.grammar as grammar_module
 from context_compiler.grammar import (
     CanonicalDirective,
     DirectiveKind,
+    DirectiveMetadata,
     DirectiveSyntaxFailure,
     InvalidDirectiveSyntax,
     decompose_directive,
+    get_directive_metadata,
 )
 
 
@@ -65,6 +67,18 @@ def test_canonical_directive_is_frozen_and_slotted() -> None:
     assert directive.__slots__ == ("text", "kind", "operands")
     with pytest.raises(FrozenInstanceError):
         directive.kind = DirectiveKind.PROHIBIT_ITEM  # type: ignore[misc]
+
+
+def test_directive_metadata_is_frozen_and_slotted() -> None:
+    metadata = DirectiveMetadata(
+        kind=DirectiveKind.USE_ITEM,
+        canonical_start="use",
+        operand_names=("item",),
+    )
+
+    assert metadata.__slots__ == ("kind", "canonical_start", "operand_names")
+    with pytest.raises(FrozenInstanceError):
+        metadata.kind = DirectiveKind.PROHIBIT_ITEM  # type: ignore[misc]
 
 
 @pytest.mark.parametrize(
@@ -323,16 +337,94 @@ def test_internal_grammar_specs_use_immutable_mapping() -> None:
     spec = specs[DirectiveKind.SET_PREMISE]
     with pytest.raises(FrozenInstanceError):
         spec.kind = DirectiveKind.CHANGE_PREMISE  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        spec.canonical_start = "different"  # type: ignore[misc]
 
 
 def test_public_grammar_all_includes_semantic_surface() -> None:
     assert grammar_module.__all__ == [
         "DirectiveKind",
         "DirectiveSyntaxFailure",
+        "DirectiveMetadata",
         "CanonicalDirective",
         "InvalidDirectiveSyntax",
+        "get_directive_metadata",
         "decompose_directive",
     ]
+
+
+def test_get_directive_metadata_returns_immutable_view_derived_from_specs() -> None:
+    metadata = get_directive_metadata()
+
+    assert metadata == tuple(
+        DirectiveMetadata(
+            kind=spec.kind,
+            canonical_start=spec.canonical_start,
+            operand_names=spec.operand_names,
+        )
+        for spec in grammar_module._DIRECTIVE_SPECS.values()
+    )
+    assert metadata[0] is grammar_module._PUBLIC_DIRECTIVE_METADATA[0]
+    with pytest.raises(AttributeError):
+        metadata.append(  # type: ignore[attr-defined]
+            DirectiveMetadata(
+                kind=DirectiveKind.CLEAR_STATE,
+                canonical_start="clear state",
+                operand_names=(),
+            )
+        )
+    with pytest.raises(FrozenInstanceError):
+        metadata[0].operand_names = ()  # type: ignore[misc]
+
+
+def test_get_directive_metadata_reports_expected_public_fields() -> None:
+    assert get_directive_metadata() == (
+        DirectiveMetadata(
+            kind=DirectiveKind.SET_PREMISE,
+            canonical_start="set premise",
+            operand_names=("value",),
+        ),
+        DirectiveMetadata(
+            kind=DirectiveKind.CHANGE_PREMISE,
+            canonical_start="change premise to",
+            operand_names=("value",),
+        ),
+        DirectiveMetadata(
+            kind=DirectiveKind.USE_ITEM,
+            canonical_start="use",
+            operand_names=("item",),
+        ),
+        DirectiveMetadata(
+            kind=DirectiveKind.PROHIBIT_ITEM,
+            canonical_start="prohibit",
+            operand_names=("item",),
+        ),
+        DirectiveMetadata(
+            kind=DirectiveKind.REMOVE_POLICY,
+            canonical_start="remove policy",
+            operand_names=("item",),
+        ),
+        DirectiveMetadata(
+            kind=DirectiveKind.REPLACE_USE,
+            canonical_start="use",
+            operand_names=("new_item", "old_item"),
+        ),
+        DirectiveMetadata(
+            kind=DirectiveKind.CLEAR_PREMISE,
+            canonical_start="clear premise",
+            operand_names=(),
+        ),
+        DirectiveMetadata(
+            kind=DirectiveKind.RESET_POLICIES,
+            canonical_start="reset policies",
+            operand_names=(),
+        ),
+        DirectiveMetadata(
+            kind=DirectiveKind.CLEAR_STATE,
+            canonical_start="clear state",
+            operand_names=(),
+        ),
+    )
 
 
 def test_decompose_directive_rejects_near_miss_without_required_delimiter() -> None:

--- a/tests/test_public_grammar_root_exports.py
+++ b/tests/test_public_grammar_root_exports.py
@@ -6,8 +6,10 @@ def test_root_does_not_export_public_grammar_surface() -> None:
     for name in (
         "DirectiveKind",
         "DirectiveSyntaxFailure",
+        "DirectiveMetadata",
         "CanonicalDirective",
         "InvalidDirectiveSyntax",
+        "get_directive_metadata",
         "decompose_directive",
     ):
         assert name not in context_compiler.__all__
@@ -17,8 +19,10 @@ def test_root_does_not_export_public_grammar_surface() -> None:
 def test_grammar_submodule_preserves_public_grammar_surface() -> None:
     assert grammar_module.DirectiveKind is not None
     assert grammar_module.DirectiveSyntaxFailure is not None
+    assert grammar_module.DirectiveMetadata is not None
     assert grammar_module.CanonicalDirective is not None
     assert grammar_module.InvalidDirectiveSyntax is not None
+    assert grammar_module.get_directive_metadata is not None
     assert grammar_module.decompose_directive is not None
     assert not hasattr(grammar_module, "render_directive")
     assert not hasattr(grammar_module, "contains_multiple_canonical_directives")

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.9.0.dev9"
+version = "0.9.0.dev10"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- bumped the package development version from `0.9.0dev9` to `0.9.0dev10` in `pyproject.toml`
- updated the editable package version in `uv.lock` to keep repository metadata aligned

## Why

- prepares the repository for the next development iteration with consistent version metadata

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
