### PR TITLE
refactor: make CanonicalDirective a validated value object

### DIFF
--- a/src/context_compiler/grammar.py
+++ b/src/context_compiler/grammar.py
@@ -1,7 +1,7 @@
 """Immutable canonical grammar helpers for Context Compiler directives."""
 
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from types import MappingProxyType
@@ -39,6 +39,12 @@ class CanonicalDirective:
 
     kind: DirectiveKind
     operands: MappingProxyType[str, str]
+
+    def __post_init__(self) -> None:
+        normalized_kind = _normalize_directive_kind(self.kind)
+        normalized_operands = _normalize_canonical_operands(normalized_kind, self.operands)
+        object.__setattr__(self, "kind", normalized_kind)
+        object.__setattr__(self, "operands", MappingProxyType(normalized_operands))
 
     @property
     def text(self) -> str:
@@ -387,6 +393,72 @@ def _invalid_directive_syntax(
     )
 
 
+def _normalize_directive_kind(kind: DirectiveKind | str) -> DirectiveKind:
+    try:
+        return kind if isinstance(kind, DirectiveKind) else DirectiveKind(kind)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported directive kind: {kind!r}") from exc
+
+
+def _normalize_canonical_operands(
+    kind: DirectiveKind,
+    operands: Mapping[str, str],
+) -> dict[str, str]:
+    spec = _DIRECTIVE_SPECS[kind]
+    expected_names = set(spec.operand_names)
+    actual_names = set(operands)
+    unexpected_names = actual_names - expected_names
+    missing_names = expected_names - actual_names
+    if missing_names:
+        missing = ", ".join(sorted(missing_names))
+        raise ValueError(f"Missing required operands for {kind.value}: {missing}")
+    if unexpected_names:
+        unexpected = ", ".join(sorted(unexpected_names))
+        raise ValueError(f"Unexpected operands for {kind.value}: {unexpected}")
+
+    normalized_operands: dict[str, str] = {}
+    for name in spec.operand_names:
+        raw_value = operands[name]
+        if not isinstance(raw_value, str):
+            raise ValueError(f"Operand {name!r} for {kind.value} must be a string.")
+        if not _operand_has_content(raw_value):
+            raise ValueError(f"Operand {name!r} for {kind.value} cannot be empty.")
+        normalized_operands[name] = raw_value
+
+    _validate_operand_constraints(kind, normalized_operands)
+    _validate_rendered_canonical_shape(kind, normalized_operands)
+    return normalized_operands
+
+
+def _validate_operand_constraints(kind: DirectiveKind, operands: Mapping[str, str]) -> None:
+    if kind is DirectiveKind.SET_PREMISE:
+        value = operands["value"]
+        if _operand_starts_with_token(value, "to"):
+            raise ValueError(f"Operands do not produce a canonical {kind.value} directive.")
+        return
+
+    if kind is DirectiveKind.USE_ITEM:
+        item = operands["item"]
+        normalized_item = _normalized_for_matching(item)
+        if _INSTEAD_OF_DELIMITER in normalized_item:
+            raise ValueError(f"Operands do not produce a canonical {kind.value} directive.")
+        return
+
+    if kind is DirectiveKind.REPLACE_USE:
+        new_item = operands["new_item"]
+        old_item = operands["old_item"]
+        if _INSTEAD_OF_DELIMITER in _normalized_for_matching(
+            new_item
+        ) or _INSTEAD_OF_DELIMITER in _normalized_for_matching(old_item):
+            raise ValueError(f"Operands do not produce a canonical {kind.value} directive.")
+
+
+def _validate_rendered_canonical_shape(kind: DirectiveKind, operands: Mapping[str, str]) -> None:
+    rendered = _serialize_canonical_directive(kind, MappingProxyType(dict(operands)))
+    if _contains_multiple_canonical_directives(rendered):
+        raise ValueError(f"Operands do not produce a canonical {kind.value} directive.")
+
+
 def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSyntax | None:
     """Parse one canonical directive into its semantic kind and operands.
 
@@ -585,49 +657,19 @@ def _serialize_canonical_directive(
     kind: DirectiveKind | str, operands: MappingProxyType[str, str]
 ) -> str:
     """Serialize a validated semantic directive without reparsing it."""
-    try:
-        normalized_kind = kind if isinstance(kind, DirectiveKind) else DirectiveKind(kind)
-        spec = _DIRECTIVE_SPECS[normalized_kind]
-    except (KeyError, ValueError) as exc:
-        raise ValueError(f"Unsupported directive kind: {kind!r}") from exc
+    normalized_kind = _normalize_directive_kind(kind)
+    spec = _DIRECTIVE_SPECS[normalized_kind]
 
     return spec.renderer(operands)
 
 
 def _render_directive(kind: DirectiveKind | str, /, **operands: str) -> str:
     """Produce canonical directive text from a semantic kind and operands."""
-    try:
-        normalized_kind = kind if isinstance(kind, DirectiveKind) else DirectiveKind(kind)
-        spec = _DIRECTIVE_SPECS[normalized_kind]
-    except (KeyError, ValueError) as exc:
-        raise ValueError(f"Unsupported directive kind: {kind!r}") from exc
-
-    expected_names = set(spec.operand_names)
-    actual_names = set(operands)
-    unexpected_names = actual_names - expected_names
-    missing_names = expected_names - actual_names
-    if missing_names:
-        missing = ", ".join(sorted(missing_names))
-        raise ValueError(f"Missing required operands for {normalized_kind.value}: {missing}")
-    if unexpected_names:
-        unexpected = ", ".join(sorted(unexpected_names))
-        raise ValueError(f"Unexpected operands for {normalized_kind.value}: {unexpected}")
-
-    normalized_operands: dict[str, str] = {}
-    for name in spec.operand_names:
-        raw_value = operands[name]
-        if not isinstance(raw_value, str):
-            raise ValueError(f"Operand {name!r} for {normalized_kind.value} must be a string.")
-        if raw_value.strip() == "":
-            raise ValueError(f"Operand {name!r} for {normalized_kind.value} cannot be empty.")
-        normalized_operands[name] = raw_value
-
-    operand_view = MappingProxyType(normalized_operands)
-    rendered = _serialize_canonical_directive(normalized_kind, operand_view)
-    decomposed = decompose_directive(rendered)
-    if not isinstance(decomposed, CanonicalDirective) or decomposed.kind is not normalized_kind:
-        raise ValueError(f"Operands do not produce a canonical {normalized_kind.value} directive.")
-    return rendered
+    normalized_kind = _normalize_directive_kind(kind)
+    return CanonicalDirective(
+        kind=normalized_kind,
+        operands=MappingProxyType(dict(operands)),
+    ).text
 
 
 __all__ = [

--- a/tests/_api_contract_harness.py
+++ b/tests/_api_contract_harness.py
@@ -50,6 +50,28 @@ def resolve_probe_value(value: object) -> object:
     raise AssertionError(f"Unknown probe fixture: {fixture!r}")
 
 
+def assert_probe_raises(
+    callback: Any,
+    probe: dict[str, Any],
+    contract: dict[str, Any] | None = None,
+) -> None:
+    args = [resolve_probe_value(value) for value in probe.get("args", [])]
+    kwargs = {key: resolve_probe_value(value) for key, value in probe.get("kwargs", {}).items()}
+
+    raises = probe["raises"]
+    expected_exception = _resolve_exception_type(raises["type"])
+
+    try:
+        callback(*args, **kwargs)
+    except Exception as exc:  # noqa: BLE001
+        assert isinstance(exc, expected_exception)
+        if "shape" in raises:
+            assert_shape(exc, raises["shape"], contract)
+        return
+
+    raise AssertionError(f"Expected {raises['type']} to be raised")
+
+
 def assert_shape(
     value: object, shape: dict[str, Any], contract: dict[str, Any] | None = None
 ) -> None:
@@ -89,6 +111,10 @@ def assert_shape(
             )
             for item in shape["items"]
         )
+        return
+
+    if "kind" in shape and shape["kind"] == "exception":
+        assert isinstance(value, _resolve_exception_type(shape["type"]))
         return
 
     expected_types = shape["type"]
@@ -141,6 +167,15 @@ def validate_export_kind(name: str, exported: object, expected_kind: str) -> Non
         assert inspect.isclass(exported), name
         return
     raise AssertionError(f"Unsupported export kind {expected_kind!r} for {name}")
+
+
+def _resolve_exception_type(name: str) -> type[BaseException]:
+    builtins_obj = __builtins__
+    namespace = builtins_obj if isinstance(builtins_obj, dict) else vars(builtins_obj)
+    resolved = namespace.get(name)
+    if not isinstance(resolved, type) or not issubclass(resolved, BaseException):
+        raise AssertionError(f"Unsupported exception type {name!r}")
+    return resolved
 
 
 def validate_engine_member_runtime(
@@ -273,7 +308,11 @@ def _validate_export_member_spec(
     label: str,
 ) -> None:
     _assert_type(member_spec, dict, label)
-    _assert_closed_keys(member_spec, {"kind", "value", "signature", "shape_probes"}, label)
+    _assert_closed_keys(
+        member_spec,
+        {"kind", "value", "signature", "shape_probes", "construction_probes"},
+        label,
+    )
     _require_fields(member_spec, {"kind"}, label)
 
     kind = member_spec["kind"]
@@ -300,6 +339,11 @@ def _validate_export_member_spec(
 
     probes = member_spec.get("shape_probes", [])
     _validate_shape_probes(probes, f"{label}.shape_probes")
+
+    construction_probes = member_spec.get("construction_probes", [])
+    if kind != "class" and construction_probes:
+        raise AssertionError(f"{label} only class exports may declare construction_probes")
+    _validate_construction_probes(construction_probes, f"{label}.construction_probes")
 
 
 def _validate_engine_member_spec(
@@ -354,6 +398,12 @@ def _validate_shape_probes(probes: object, label: str) -> None:
         _validate_shape_probe_spec(probe, f"{label}[{index}]")
 
 
+def _validate_construction_probes(probes: object, label: str) -> None:
+    _assert_type(probes, list, label)
+    for index, probe in enumerate(probes):
+        _validate_construction_probe_spec(probe, f"{label}[{index}]")
+
+
 def _validate_shape_probe_spec(probe: object, label: str) -> None:
     _assert_type(probe, dict, label)
     _assert_closed_keys(probe, {"args", "kwargs", "return_shape"}, label)
@@ -372,11 +422,47 @@ def _validate_shape_probe_spec(probe: object, label: str) -> None:
     _validate_shape_spec(probe["return_shape"], f"{label}.return_shape")
 
 
+def _validate_construction_probe_spec(probe: object, label: str) -> None:
+    _assert_type(probe, dict, label)
+    _assert_closed_keys(probe, {"args", "kwargs", "return_shape", "raises"}, label)
+
+    has_return = "return_shape" in probe
+    has_raises = "raises" in probe
+    if has_return == has_raises:
+        raise AssertionError(f"{label} must declare exactly one of return_shape or raises")
+
+    args = probe.get("args", [])
+    kwargs = probe.get("kwargs", {})
+    _assert_type(args, list, f"{label}.args")
+    _assert_string_keyed_dict(kwargs, f"{label}.kwargs")
+
+    for index, value in enumerate(args):
+        _validate_probe_value(value, f"{label}.args[{index}]")
+    for key, value in kwargs.items():
+        _validate_probe_value(value, f"{label}.kwargs[{key!r}]")
+
+    if has_return:
+        _validate_shape_spec(probe["return_shape"], f"{label}.return_shape")
+        return
+
+    _validate_exception_shape_spec(probe["raises"], f"{label}.raises")
+
+
 def _validate_probe_value(value: object, label: str) -> None:
     if not isinstance(value, dict) or "fixture" not in value:
         return
     _assert_closed_keys(value, {"fixture"}, label)
     _assert_equal(value["fixture"], "empty_engine", f"{label}.fixture")
+
+
+def _validate_exception_shape_spec(raises: object, label: str) -> None:
+    _assert_type(raises, dict, label)
+    _assert_closed_keys(raises, {"type", "shape"}, label)
+    _require_fields(raises, {"type"}, label)
+    _assert_type(raises["type"], str, f"{label}.type")
+    _resolve_exception_type(raises["type"])
+    if "shape" in raises:
+        _validate_shape_spec(raises["shape"], f"{label}.shape")
 
 
 def _validate_shape_spec(shape: object, label: str) -> None:
@@ -439,6 +525,12 @@ def _validate_shape_spec(shape: object, label: str) -> None:
                         str,
                         f"{item_label}.operand_names[{operand_index}]",
                     )
+            return
+        if kind == "exception":
+            _assert_closed_keys(shape, {"kind", "type"}, label)
+            _require_fields(shape, {"kind", "type"}, label)
+            _assert_type(shape["type"], str, f"{label}.type")
+            _resolve_exception_type(shape["type"])
             return
         raise AssertionError(f"{label}.kind has unsupported shape kind {kind!r}")
 

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -43,6 +43,52 @@
           },
           {
             "kwargs": {
+              "kind": "clear_state",
+              "operands": {}
+            },
+            "return_shape": {
+              "kind": "canonical_directive",
+              "text": "clear state",
+              "directive_kind": "clear_state",
+              "operands": {}
+            }
+          },
+          {
+            "kwargs": {
+              "kind": "set_premise",
+              "operands": {
+                "value": "concise replies"
+              }
+            },
+            "return_shape": {
+              "kind": "canonical_directive",
+              "text": "set premise concise replies",
+              "directive_kind": "set_premise",
+              "operands": {
+                "value": "concise replies"
+              }
+            }
+          },
+          {
+            "kwargs": {
+              "kind": "replace_use",
+              "operands": {
+                "new_item": "podman",
+                "old_item": "docker"
+              }
+            },
+            "return_shape": {
+              "kind": "canonical_directive",
+              "text": "use podman instead of docker",
+              "directive_kind": "replace_use",
+              "operands": {
+                "new_item": "podman",
+                "old_item": "docker"
+              }
+            }
+          },
+          {
+            "kwargs": {
               "kind": "not_a_directive_kind",
               "operands": {
                 "item": "docker"

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -23,7 +23,67 @@
         "kind": "class"
       },
       "CanonicalDirective": {
-        "kind": "class"
+        "kind": "class",
+        "construction_probes": [
+          {
+            "kwargs": {
+              "kind": "use_item",
+              "operands": {
+                "item": "docker"
+              }
+            },
+            "return_shape": {
+              "kind": "canonical_directive",
+              "text": "use docker",
+              "directive_kind": "use_item",
+              "operands": {
+                "item": "docker"
+              }
+            }
+          },
+          {
+            "kwargs": {
+              "kind": "not_a_directive_kind",
+              "operands": {
+                "item": "docker"
+              }
+            },
+            "raises": {
+              "type": "ValueError"
+            }
+          },
+          {
+            "kwargs": {
+              "kind": "use_item",
+              "operands": {}
+            },
+            "raises": {
+              "type": "ValueError"
+            }
+          },
+          {
+            "kwargs": {
+              "kind": "clear_state",
+              "operands": {
+                "item": "docker"
+              }
+            },
+            "raises": {
+              "type": "ValueError"
+            }
+          },
+          {
+            "kwargs": {
+              "kind": "set_premise",
+              "operands": {
+                "value": 123
+              }
+            },
+            "raises": {
+              "type": "ValueError"
+            }
+          }
+        ]
       },
       "InvalidDirectiveSyntax": {
         "kind": "class"

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -128,6 +128,29 @@
             "raises": {
               "type": "ValueError"
             }
+          },
+          {
+            "kwargs": {
+              "kind": "set_premise",
+              "operands": {
+                "value": "to concise replies"
+              }
+            },
+            "raises": {
+              "type": "ValueError"
+            }
+          },
+          {
+            "kwargs": {
+              "kind": "replace_use",
+              "operands": {
+                "new_item": "podman instead of nerdctl",
+                "old_item": "docker"
+              }
+            },
+            "raises": {
+              "type": "ValueError"
+            }
           }
         ]
       },

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,5 @@
 import json
 from collections.abc import Mapping
-from types import MappingProxyType
 
 import pytest
 
@@ -41,11 +40,10 @@ def _import_state(engine: object, payload: dict[str, object]) -> None:
 
 
 def _canonical_directive(
-    text: str,
     kind: DirectiveKind,
     **operands: str,
 ) -> CanonicalDirective:
-    return CanonicalDirective(kind=kind, operands=MappingProxyType(operands))
+    return CanonicalDirective(kind=kind, operands=operands)
 
 
 @pytest.mark.parametrize(
@@ -53,7 +51,6 @@ def _canonical_directive(
     [
         (
             _canonical_directive(
-                "set premise concise replies",
                 DirectiveKind.SET_PREMISE,
                 value="concise replies",
             ),
@@ -63,7 +60,6 @@ def _canonical_directive(
         ),
         (
             _canonical_directive(
-                "change premise to concise replies",
                 DirectiveKind.CHANGE_PREMISE,
                 value="concise replies",
             ),
@@ -72,20 +68,19 @@ def _canonical_directive(
             (("concise replies"), {}),
         ),
         (
-            _canonical_directive("use docker", DirectiveKind.USE_ITEM, item="docker"),
+            _canonical_directive(DirectiveKind.USE_ITEM, item="docker"),
             None,
             {"kind": DECISION_UPDATE, "message": None},
             (None, {"docker": "use"}),
         ),
         (
-            _canonical_directive("prohibit peanuts", DirectiveKind.PROHIBIT_ITEM, item="peanuts"),
+            _canonical_directive(DirectiveKind.PROHIBIT_ITEM, item="peanuts"),
             None,
             {"kind": DECISION_UPDATE, "message": None},
             (None, {"peanuts": "prohibit"}),
         ),
         (
             _canonical_directive(
-                "remove policy docker",
                 DirectiveKind.REMOVE_POLICY,
                 item="docker",
             ),
@@ -95,7 +90,6 @@ def _canonical_directive(
         ),
         (
             _canonical_directive(
-                "use podman instead of docker",
                 DirectiveKind.REPLACE_USE,
                 new_item="podman",
                 old_item="docker",
@@ -105,19 +99,19 @@ def _canonical_directive(
             (None, {"podman": "use"}),
         ),
         (
-            _canonical_directive("clear premise", DirectiveKind.CLEAR_PREMISE),
+            _canonical_directive(DirectiveKind.CLEAR_PREMISE),
             {"premise": "concise replies", "policies": {"docker": "use"}, "version": 2},
             {"kind": DECISION_UPDATE, "message": None},
             (None, {"docker": "use"}),
         ),
         (
-            _canonical_directive("reset policies", DirectiveKind.RESET_POLICIES),
+            _canonical_directive(DirectiveKind.RESET_POLICIES),
             {"premise": "concise replies", "policies": {"docker": "use"}, "version": 2},
             {"kind": DECISION_UPDATE, "message": None},
             ("concise replies", {}),
         ),
         (
-            _canonical_directive("clear state", DirectiveKind.CLEAR_STATE),
+            _canonical_directive(DirectiveKind.CLEAR_STATE),
             {"premise": "concise replies", "policies": {"docker": "use"}, "version": 2},
             {"kind": DECISION_UPDATE, "message": None},
             (None, {}),
@@ -145,7 +139,6 @@ def test_apply_directive_accepts_all_canonical_directive_kinds(
     [
         (
             _canonical_directive(
-                "set premise concise replies",
                 DirectiveKind.SET_PREMISE,
                 value="concise replies",
             ),
@@ -158,7 +151,6 @@ def test_apply_directive_accepts_all_canonical_directive_kinds(
         ),
         (
             _canonical_directive(
-                "change premise to concise replies",
                 DirectiveKind.CHANGE_PREMISE,
                 value="concise replies",
             ),
@@ -170,7 +162,7 @@ def test_apply_directive_accepts_all_canonical_directive_kinds(
             (None, {}),
         ),
         (
-            _canonical_directive("use docker", DirectiveKind.USE_ITEM, item="docker"),
+            _canonical_directive(DirectiveKind.USE_ITEM, item="docker"),
             {"premise": None, "policies": {"docker": "prohibit"}, "version": 2},
             {
                 "kind": DECISION_ERROR,
@@ -181,7 +173,7 @@ def test_apply_directive_accepts_all_canonical_directive_kinds(
             (None, {"docker": "prohibit"}),
         ),
         (
-            _canonical_directive("prohibit docker", DirectiveKind.PROHIBIT_ITEM, item="docker"),
+            _canonical_directive(DirectiveKind.PROHIBIT_ITEM, item="docker"),
             {"premise": None, "policies": {"docker": "use"}, "version": 2},
             {
                 "kind": DECISION_ERROR,
@@ -193,7 +185,6 @@ def test_apply_directive_accepts_all_canonical_directive_kinds(
         ),
         (
             _canonical_directive(
-                "use docker instead of kubectl",
                 DirectiveKind.REPLACE_USE,
                 new_item="docker",
                 old_item="kubectl",

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -61,10 +61,11 @@ def test_directive_syntax_failure_members_and_values() -> None:
 def test_canonical_directive_is_frozen_and_slotted() -> None:
     directive = CanonicalDirective(
         kind=DirectiveKind.USE_ITEM,
-        operands=MappingProxyType({"item": "docker"}),
+        operands={"item": "docker"},
     )
     assert directive.__slots__ == ("kind", "operands")
     assert directive.text == "use docker"
+    assert isinstance(directive.operands, MappingProxyType)
     with pytest.raises(FrozenInstanceError):
         directive.kind = DirectiveKind.PROHIBIT_ITEM  # type: ignore[misc]
 
@@ -105,7 +106,7 @@ def test_decompose_directive_accepts_each_canonical_family(
     decomposed = decompose_directive(text)
     assert decomposed == CanonicalDirective(
         kind=expected_kind,
-        operands=MappingProxyType(expected_operands),
+        operands=expected_operands,
     )
 
 
@@ -269,21 +270,21 @@ def test_equivalent_accepted_inputs_share_canonical_text(
         (
             CanonicalDirective(
                 kind=DirectiveKind.USE_ITEM,
-                operands=MappingProxyType({"item": "docker"}),
+                operands={"item": "docker"},
             ),
             "use docker",
         ),
         (
             CanonicalDirective(
                 kind=DirectiveKind.CHANGE_PREMISE,
-                operands=MappingProxyType({"value": "formal tone"}),
+                operands={"value": "formal tone"},
             ),
             "change premise to formal tone",
         ),
         (
             CanonicalDirective(
                 kind=DirectiveKind.REPLACE_USE,
-                operands=MappingProxyType({"new_item": "podman", "old_item": "docker"}),
+                operands={"new_item": "podman", "old_item": "docker"},
             ),
             "use podman instead of docker",
         ),
@@ -507,44 +508,43 @@ def test_serialize_canonical_directive_rejects_unsupported_kind() -> None:
         )
 
 
-def test_render_directive_uses_decompose_directive_as_authoritative_round_trip(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        grammar_module,
-        "decompose_directive",
-        lambda _: CanonicalDirective(
-            kind=DirectiveKind.USE_ITEM,
-            operands=MappingProxyType({"item": "docker"}),
+@pytest.mark.parametrize(
+    ("kind", "operands", "message"),
+    [
+        (DirectiveKind.SET_PREMISE, {}, "Missing required operands"),
+        (DirectiveKind.REPLACE_USE, {"new_item": "podman"}, "Missing required operands"),
+        (DirectiveKind.CLEAR_STATE, {"item": "docker"}, "Unexpected operands"),
+        (DirectiveKind.USE_ITEM, {"value": "docker"}, "Missing required operands"),
+        (DirectiveKind.USE_ITEM, {"item": "docker", "old_item": "podman"}, "Unexpected operands"),
+        (DirectiveKind.SET_PREMISE, {"value": ""}, "cannot be empty"),
+        (DirectiveKind.SET_PREMISE, {"value": "   "}, "cannot be empty"),
+        (
+            DirectiveKind.USE_ITEM,
+            {"item": "docker and prohibit peanuts"},
+            "canonical use_item directive",
         ),
-    )
+        (
+            DirectiveKind.SET_PREMISE,
+            {"value": "use docker and prohibit peanuts"},
+            "canonical set_premise directive",
+        ),
+        (
+            DirectiveKind.USE_ITEM,
+            {"item": "docker instead of podman"},
+            "canonical use_item directive",
+        ),
+        ("not_a_directive_kind", {"item": "docker"}, "Unsupported directive kind"),
+    ],
+)
+def test_canonical_directive_rejects_invalid_construction(
+    kind: DirectiveKind | str, operands: dict[str, str], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        CanonicalDirective(kind=kind, operands=operands)  # type: ignore[arg-type]
 
+
+def test_render_directive_builds_text_from_validated_canonical_directive() -> None:
     assert grammar_module._render_directive(DirectiveKind.USE_ITEM, item="docker") == "use docker"
-
-
-def test_render_directive_rejects_when_decompose_directive_disagrees_with_rendered_kind(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        grammar_module,
-        "decompose_directive",
-        lambda _: CanonicalDirective(
-            kind=DirectiveKind.PROHIBIT_ITEM,
-            operands=MappingProxyType({"item": "docker"}),
-        ),
-    )
-
-    with pytest.raises(ValueError, match="canonical use_item directive"):
-        grammar_module._render_directive(DirectiveKind.USE_ITEM, item="docker")
-
-
-def test_render_directive_rejects_when_decompose_directive_returns_noncanonical_result(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(grammar_module, "decompose_directive", lambda _: InvalidDirectiveSyntax())
-
-    with pytest.raises(ValueError, match="canonical use_item directive"):
-        grammar_module._render_directive(DirectiveKind.USE_ITEM, item="docker")
 
 
 def test_invalid_directive_syntax_is_frozen_and_slotted() -> None:

--- a/tests/test_grammar_api_contract_fixture.py
+++ b/tests/test_grammar_api_contract_fixture.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from _api_contract_harness import (
+    assert_probe_raises,
     assert_shape,
     assert_signature_matches,
     load_api_contract,
@@ -41,6 +42,13 @@ def test_public_grammar_contract_matches_surface() -> None:
         if member["kind"] == "callable":
             assert_signature_matches(exported, member["signature"], name)
             for probe in member.get("shape_probes", []):
+                result = exported(*probe.get("args", []), **probe.get("kwargs", {}))
+                assert_shape(result, probe["return_shape"])
+        if member["kind"] == "class":
+            for probe in member.get("construction_probes", []):
+                if "raises" in probe:
+                    assert_probe_raises(exported, probe)
+                    continue
                 result = exported(*probe.get("args", []), **probe.get("kwargs", {}))
                 assert_shape(result, probe["return_shape"])
 


### PR DESCRIPTION
## What changed

- Refactored `CanonicalDirective` into a validated immutable value object.
- Removed constructor support for caller-provided `text`; `text` is now always derived from `kind` and `operands`.
- Added construction-time validation for:
  - directive kind validity
  - required operands
  - unexpected operands
  - operand type/grammar constraints
- Kept grammar ownership of directive structure and canonical serialization.
- Updated grammar tests and helpers to construct only valid canonical directives.
- Added conformance coverage for `CanonicalDirective` construction:
  - valid construction across directive shape categories
  - invalid construction failures for malformed objects

## Why

`CanonicalDirective` is now a public grammar API object. It should represent a valid canonical directive by definition rather than allowing invalid states to reach consumers or the engine.

This keeps the boundary clear:

- grammar owns structural validity;
- engine owns semantic/state transitions.

## Validation

- [x] `uv run pytest`
- [x] `uv run pre-commit run --all-files`