### PR TITLE
test: align test assertions with claimed behavior

### DIFF
--- a/tests/test_compound_directive_properties.py
+++ b/tests/test_compound_directive_properties.py
@@ -4,11 +4,10 @@ from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 from context_compiler import (
-    DECISION_ERROR,
     DECISION_NO_DIRECTIVE,
-    DECISION_UPDATE,
     Engine,
 )
+from context_compiler.grammar import InvalidDirectiveSyntax, decompose_directive
 
 CANONICAL_SECOND_DIRECTIVES = [
     "set premise concise",
@@ -57,7 +56,9 @@ def _assert_compound_no_directive(user_input: str) -> None:
     second=st.sampled_from(CANONICAL_SECOND_DIRECTIVES),
 )
 def test_compound_separator_robustness(separator: str, second: str) -> None:
-    _assert_compound_no_directive(f"use docker{separator}{second}")
+    user_input = f"use docker{separator}{second}"
+    assert isinstance(decompose_directive(user_input), InvalidDirectiveSyntax)
+    _assert_compound_no_directive(user_input)
 
 
 @settings(max_examples=50)
@@ -74,7 +75,9 @@ def test_compound_arbitrary_intervening_text(chunks: list[str], second: str) -> 
     lowered = intervening.lower()
     assume(all(token not in lowered for token in CANONICAL_STARTS))
 
-    _assert_compound_no_directive(f"use docker {intervening} {second}")
+    user_input = f"use docker {intervening} {second}"
+    assert isinstance(decompose_directive(user_input), InvalidDirectiveSyntax)
+    _assert_compound_no_directive(user_input)
 
 
 @settings(max_examples=50)
@@ -89,10 +92,13 @@ def test_embedded_canonical_tokens_do_not_trigger_compound_detection(
     engine = Engine()
     before = _observations(engine)
 
-    decision = engine.step(f"use docker {prefix}{token}{suffix}")
+    user_input = f"use docker {prefix}{token}{suffix}"
+    parsed = decompose_directive(user_input)
+    decision = engine.step(user_input)
 
-    assert decision["kind"] != DECISION_ERROR or decision["message"] != ""
-    assert decision["kind"] == DECISION_UPDATE
+    assert parsed is not None
+    assert not isinstance(parsed, InvalidDirectiveSyntax)
+    assert decision == {"kind": "update", "message": None}
     assert _observations(engine) != before
 
 
@@ -131,7 +137,9 @@ def test_case_mutated_second_directive_does_not_trigger_compound_detection(
     engine = Engine()
     before = _observations(engine)
 
-    decision = engine.step(f"use docker {second_start}")
+    user_input = f"use docker {second_start}"
+    assert isinstance(decompose_directive(user_input), InvalidDirectiveSyntax)
+    decision = engine.step(user_input)
 
     assert decision == {"kind": DECISION_NO_DIRECTIVE, "message": None}
     assert _observations(engine) == before
@@ -151,7 +159,9 @@ def test_case_mutated_second_directive_does_not_trigger_compound_detection(
 def test_quotes_do_not_create_protected_region_after_first_directive(
     quote: str, payload: str, closing: str, second: str
 ) -> None:
-    _assert_compound_no_directive(f"use {quote}{payload}{closing} {second}")
+    user_input = f"use {quote}{payload}{closing} {second}"
+    assert isinstance(decompose_directive(user_input), InvalidDirectiveSyntax)
+    _assert_compound_no_directive(user_input)
 
 
 @settings(max_examples=20)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -15,6 +15,8 @@ from context_compiler.engine import (
 from context_compiler.grammar import (
     CanonicalDirective,
     DirectiveKind,
+    DirectiveSyntaxFailure,
+    InvalidDirectiveSyntax,
     decompose_directive,
 )
 
@@ -250,17 +252,41 @@ def test_step_routes_canonical_directives_through_apply_directive(
     assert seen == [parsed]
 
 
-def test_decompose_directive_rejects_invalid_and_nondirective_inputs() -> None:
-    assert not isinstance(decompose_directive("set premise"), CanonicalDirective)
-    assert not isinstance(decompose_directive("change premise to"), CanonicalDirective)
-    assert not isinstance(decompose_directive("use"), CanonicalDirective)
-    assert not isinstance(decompose_directive("prohibit"), CanonicalDirective)
-    assert not isinstance(decompose_directive("remove policy"), CanonicalDirective)
-    assert not isinstance(decompose_directive("use instead of docker"), CanonicalDirective)
-    assert not isinstance(
-        decompose_directive("use docker and prohibit peanuts"), CanonicalDirective
+def test_decompose_directive_distinguishes_invalid_directive_syntax_from_no_directive() -> None:
+    assert decompose_directive("set premise") == InvalidDirectiveSyntax(
+        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
+        directive_kind=DirectiveKind.SET_PREMISE,
+        missing_operand="value",
     )
-    assert not isinstance(decompose_directive("hello there"), CanonicalDirective)
+    assert decompose_directive("change premise to") == InvalidDirectiveSyntax(
+        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
+        directive_kind=DirectiveKind.CHANGE_PREMISE,
+        missing_operand="value",
+    )
+    assert decompose_directive("use") == InvalidDirectiveSyntax(
+        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
+        directive_kind=DirectiveKind.USE_ITEM,
+        missing_operand="item",
+    )
+    assert decompose_directive("prohibit") == InvalidDirectiveSyntax(
+        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
+        directive_kind=DirectiveKind.PROHIBIT_ITEM,
+        missing_operand="item",
+    )
+    assert decompose_directive("remove policy") == InvalidDirectiveSyntax(
+        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
+        directive_kind=DirectiveKind.REMOVE_POLICY,
+        missing_operand="item",
+    )
+    assert decompose_directive("use instead of docker") == InvalidDirectiveSyntax(
+        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
+        directive_kind=DirectiveKind.REPLACE_USE,
+        missing_operand="new_item",
+    )
+    assert decompose_directive("use docker and prohibit peanuts") == InvalidDirectiveSyntax(
+        failure=DirectiveSyntaxFailure.COMPOUND_DIRECTIVE,
+    )
+    assert decompose_directive("hello there") is None
 
 
 def test_initial_state_and_engine_properties() -> None:

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -49,6 +49,65 @@ def _assert_str_list(value: object, fixture_id: object, label: str) -> None:
     assert all(isinstance(item, str) for item in value), f"{fixture_id}: invalid {label}"
 
 
+def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id: object) -> None:
+    _assert_allowed_keys(
+        fixture,
+        {"id", "kind", "initial_state", "operation", "handles", "mutations", "expected"},
+        fixture_id,
+        "fixture",
+    )
+    assert fixture["kind"] == "mutation_isolation", fixture_id
+    assert isinstance(fixture["initial_state"], dict), fixture_id
+
+    operation = fixture["operation"]
+    assert isinstance(operation, dict), fixture_id
+    _assert_allowed_keys(
+        operation, {"fn", "input", "result_handle"} & set(operation), fixture_id, "operation"
+    )
+    assert operation["fn"] in {"engine.step", "engine.policies", "engine.premise"}, fixture_id
+    if operation["fn"] == "engine.step":
+        _assert_allowed_keys(operation, {"fn", "input", "result_handle"}, fixture_id, "operation")
+        assert isinstance(operation["input"], str), fixture_id
+    else:
+        _assert_allowed_keys(operation, {"fn", "result_handle"}, fixture_id, "operation")
+    assert isinstance(operation["result_handle"], str), fixture_id
+
+    handles = fixture["handles"]
+    assert isinstance(handles, dict), fixture_id
+    assert operation["result_handle"] in handles, fixture_id
+    for handle_name, handle_meta in handles.items():
+        assert isinstance(handle_name, str), fixture_id
+        assert isinstance(handle_meta, dict), fixture_id
+        _assert_allowed_keys(handle_meta, {"kind"}, fixture_id, f"handles.{handle_name}")
+        assert isinstance(handle_meta["kind"], str), fixture_id
+
+    mutations = fixture["mutations"]
+    assert isinstance(mutations, list), fixture_id
+    for index, mutation in enumerate(mutations):
+        assert isinstance(mutation, dict), fixture_id
+        _assert_allowed_keys(
+            mutation,
+            {"target_handle", "path", "op", "value"},
+            fixture_id,
+            f"mutations[{index}]",
+        )
+        assert mutation["target_handle"] in handles, fixture_id
+        _assert_str_list(mutation["path"], fixture_id, f"mutations[{index}].path")
+        assert mutation["op"] == "set", fixture_id
+
+    expected = fixture["expected"]
+    assert isinstance(expected, dict), fixture_id
+    _assert_allowed_keys(
+        expected,
+        {"authoritative_state"} | ({"caller_owned_observations"} & set(expected)),
+        fixture_id,
+        "expected",
+    )
+    assert isinstance(expected["authoritative_state"], dict), fixture_id
+    if "caller_owned_observations" in expected:
+        assert isinstance(expected["caller_owned_observations"], dict), fixture_id
+
+
 def _validate_public_decision(decision: dict[str, object], fixture_id: object, label: str) -> None:
     _assert_allowed_keys(decision, {"kind", "message"}, fixture_id, label)
     kind = decision.get("kind")
@@ -195,6 +254,24 @@ def _state_observation(engine: object) -> dict[str, object]:
         "policies": dict(engine.policies),
         "version": 2,
     }
+
+
+def _resolve_handle_path(root: object, path: list[str]) -> object:
+    current = root
+    for key in path:
+        assert isinstance(current, dict)
+        current = current[key]
+    return current
+
+
+def _apply_handle_mutation(root: object, path: list[str], value: object) -> None:
+    assert path
+    current = root
+    for key in path[:-1]:
+        assert isinstance(current, dict)
+        current = current[key]
+    assert isinstance(current, dict)
+    current[path[-1]] = value
 
 
 def test_step_fixtures() -> None:
@@ -352,6 +429,7 @@ def test_mutation_isolation_fixtures() -> None:
     for path in _json_files(_MUTATION_ISOLATION_FIXTURES_DIR):
         fixture = _load(path)
         fixture_id = fixture["id"]
+        _validate_mutation_isolation_fixture(fixture, fixture_id)
         operation = fixture["operation"]
         fn = operation["fn"]
         engine = Engine()
@@ -359,23 +437,32 @@ def test_mutation_isolation_fixtures() -> None:
             json.dumps(fixture["initial_state"], sort_keys=True, separators=(",", ":"))
         )
 
+        handles: dict[str, object]
         if fn == "engine.step":
-            decision = engine.step(operation["input"])
-            decision["message"] = "mutated note"
-            assert _state_observation(engine) == fixture["expected"]["authoritative_state"], (
-                fixture_id
-            )
+            handles = {operation["result_handle"]: engine.step(operation["input"])}
+        elif fn == "engine.policies":
+            handles = {operation["result_handle"]: engine.policies}
+        else:
+            assert fn == "engine.premise", fixture_id
+            handles = {operation["result_handle"]: {"value": engine.premise}}
+
+        for mutation in fixture["mutations"]:
+            target = handles[mutation["target_handle"]]
+            path = mutation["path"]
+            assert isinstance(path, list), fixture_id
+            _apply_handle_mutation(target, path, mutation["value"])
+
+        expected = fixture["expected"]
+        assert _state_observation(engine) == expected["authoritative_state"], fixture_id
+
+        observations = expected.get("caller_owned_observations")
+        if observations is None:
             continue
 
-        if fn == "engine.policies":
-            policies = engine.policies
-            policies["docker"] = "prohibit"
-            assert _state_observation(engine) == fixture["expected"]["authoritative_state"], (
-                fixture_id
-            )
-            continue
-
-        assert fn == "engine.premise", fixture_id
-        premise_box = {"value": engine.premise}
-        premise_box["value"] = "mutated premise"
-        assert _state_observation(engine) == fixture["expected"]["authoritative_state"], fixture_id
+        assert isinstance(observations, dict), fixture_id
+        for label, observation in observations.items():
+            assert isinstance(observation, dict), fixture_id
+            _assert_allowed_keys(observation, {"target_handle", "path", "value"}, fixture_id, label)
+            target = handles[observation["target_handle"]]
+            observed = _resolve_handle_path(target, observation["path"])
+            assert observed == observation["value"], fixture_id

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1007,11 +1007,15 @@ def test_replacement_near_misses_never_parse_as_canonical_or_mutate_state(text: 
 
 @given(
     st.one_of(
-        VALID_NONEMPTY_ITEM_TEXT.map(lambda old_item: (f"use instead of {old_item}", "new_item")),
-        VALID_USE_ITEM_TEXT.map(lambda new_item: (f"use {new_item} instead of", "old_item")),
+        CANONICAL_GRAMMAR_ITEM_TEXT.map(
+            lambda old_item: (f"use instead of {old_item}", "new_item")
+        ),
+        CANONICAL_GRAMMAR_ITEM_TEXT.map(
+            lambda new_item: (f"use {new_item} instead of", "old_item")
+        ),
     )
 )
-def test_incomplete_replacement_forms_report_replace_use_family(
+def test_incomplete_replacement_forms_report_replace_use_missing_operand(
     case: tuple[str, str],
 ) -> None:
     text, missing_operand = case
@@ -1019,9 +1023,5 @@ def test_incomplete_replacement_forms_report_replace_use_family(
 
     assert isinstance(parsed, InvalidDirectiveSyntax)
     assert parsed.failure is DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND
-    assert parsed.directive_kind in {DirectiveKind.REPLACE_USE, DirectiveKind.USE_ITEM}
-    if parsed.directive_kind is DirectiveKind.USE_ITEM:
-        assert missing_operand == "new_item"
-        assert parsed.missing_operand == "item"
-    else:
-        assert parsed.missing_operand == missing_operand
+    assert parsed.directive_kind is DirectiveKind.REPLACE_USE
+    assert parsed.missing_operand == missing_operand

--- a/tests/test_structured_regression.py
+++ b/tests/test_structured_regression.py
@@ -125,13 +125,7 @@ def test_structured_regression_scenarios() -> None:
             assert expected_turn["input"] == user_input, f"{context} input_mismatch"
 
             expected_decision = expected_turn["decision"]
-            assert decision["kind"] == expected_decision["kind"], (
-                f"{context} decision_kind_mismatch"
-            )
-            if decision["kind"] == "error":
-                assert decision["message"] == expected_decision["message"], (
-                    f"{context} message_mismatch"
-                )
+            assert decision == expected_decision, f"{context} decision_mismatch"
 
             expected_state = expected_turn["state"]
             if state != expected_state:


### PR DESCRIPTION
## What changed

- Made structured regression tests compare the full `decision` object on every turn.
- Updated mutation-isolation fixtures to execute their declarative operation/handle/mutation protocol instead of hardcoded mutations.
- Moved compound-directive grammar assertions to `decompose_directive(...)` where the tests are actually about grammar behavior.
- Split invalid directive syntax from true no-directive cases in engine tests.
- Tightened incomplete replacement property coverage to the contract-defined `replace_use` cases and narrowed the generator accordingly.

## Why

The test audit found several cases where tests or fixture runners were weaker than their names or documentation implied.

These changes make the tests prove the behavior they claim to cover, reducing false confidence in grammar, engine, and cross-port conformance behavior without changing production semantics.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)