### PR TITLE
test: finalize 0.9 conformance coverage

### DIFF
--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -671,13 +671,12 @@ input value and silently discarding the other.
 If a future version intentionally introduces broader policy-identity semantics,
 that behavior must be specified explicitly.
 
-Repository drift note:
+Acquisition-layer note:
 
-- the current runtime implementation still performs additional item-key
-  rewrites beyond the normative boundary above, including leading-article
-  removal and `dont` to `don't` rewriting;
-- those behaviors are current implementation details and test-backed runtime
-  behavior, but they are not frozen here as the intended core semantic contract.
+- language-specific or semantic normalization beyond the representation-level
+  rules above belongs outside core;
+- examples include leading-article removal, rewriting `dont` to `don't`, and
+  other broader human-input interpretation behaviors.
 
 ### 11.2 Premise-value sanitation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.9.0dev10"
+version = "0.9.0dev11"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -63,9 +63,11 @@ Unknown top-level and documented nested fields are rejected.
 `prelude` simulates prior user inputs to reach states through the public engine
 surface before the main fixture input runs.
 
-Shared `step` fixtures intentionally cover representative parser and no_directive
-boundaries. They do not attempt to freeze every ambiguous natural-language edge
-case as part of the cross-language contract.
+Shared `step` fixtures intentionally cover representative engine-observable
+parser/no_directive outcomes. Direct grammar classification belongs to the
+`conformance/grammar/` fixture family. The step fixtures do not attempt to
+freeze every ambiguous natural-language edge case as part of the cross-language
+contract.
 
 ## Apply-directive fixtures
 

--- a/tests/fixtures/conformance/grammar/grammar_decompose_allow_docker_no_directive.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_allow_docker_no_directive.json
@@ -1,0 +1,11 @@
+{
+  "id": "grammar_decompose_allow_docker_no_directive",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "allow docker"
+  },
+  "expected": {
+    "directive": null
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_boundary_whitespace_trim_clear_premise.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_boundary_whitespace_trim_clear_premise.json
@@ -1,0 +1,15 @@
+{
+  "id": "grammar_decompose_boundary_whitespace_trim_clear_premise",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": " clear premise "
+  },
+  "expected": {
+    "directive": {
+      "kind": "clear_premise",
+      "text": "clear premise",
+      "operands": {}
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_boundary_whitespace_trim_clear_state.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_boundary_whitespace_trim_clear_state.json
@@ -1,0 +1,15 @@
+{
+  "id": "grammar_decompose_boundary_whitespace_trim_clear_state",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": " clear state "
+  },
+  "expected": {
+    "directive": {
+      "kind": "clear_state",
+      "text": "clear state",
+      "operands": {}
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_boundary_whitespace_trim_reset_policies.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_boundary_whitespace_trim_reset_policies.json
@@ -1,0 +1,15 @@
+{
+  "id": "grammar_decompose_boundary_whitespace_trim_reset_policies",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": " reset policies "
+  },
+  "expected": {
+    "directive": {
+      "kind": "reset_policies",
+      "text": "reset policies",
+      "operands": {}
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_phrase_token.json
+++ b/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_phrase_token.json
@@ -1,0 +1,24 @@
+{
+  "id": "step_affirmative_followup_no_directive_phrase_token",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "prelude": [
+    "use kubectl instead of docker"
+  ],
+  "input": "yes please",
+  "expected": {
+    "decision": {
+      "kind": "no_directive",
+      "message": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_boundary_whitespace_trim_clear_premise_update.json
+++ b/tests/fixtures/conformance/step/step_boundary_whitespace_trim_clear_premise_update.json
@@ -1,0 +1,25 @@
+{
+  "id": "step_boundary_whitespace_trim_clear_premise_update",
+  "kind": "step",
+  "initial_state": {
+    "premise": "concise replies",
+    "policies": {
+      "docker": "use"
+    },
+    "version": 2
+  },
+  "input": " clear premise ",
+  "expected": {
+    "decision": {
+      "kind": "update",
+      "message": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {
+        "docker": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_boundary_whitespace_trim_clear_state_update.json
+++ b/tests/fixtures/conformance/step/step_boundary_whitespace_trim_clear_state_update.json
@@ -1,0 +1,23 @@
+{
+  "id": "step_boundary_whitespace_trim_clear_state_update",
+  "kind": "step",
+  "initial_state": {
+    "premise": "concise replies",
+    "policies": {
+      "docker": "use"
+    },
+    "version": 2
+  },
+  "input": " clear state ",
+  "expected": {
+    "decision": {
+      "kind": "update",
+      "message": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_boundary_whitespace_trim_reset_policies_update.json
+++ b/tests/fixtures/conformance/step/step_boundary_whitespace_trim_reset_policies_update.json
@@ -1,0 +1,24 @@
+{
+  "id": "step_boundary_whitespace_trim_reset_policies_update",
+  "kind": "step",
+  "initial_state": {
+    "premise": "concise replies",
+    "policies": {
+      "docker": "use",
+      "kubectl": "prohibit"
+    },
+    "version": 2
+  },
+  "input": " reset policies ",
+  "expected": {
+    "decision": {
+      "kind": "update",
+      "message": null
+    },
+    "state": {
+      "premise": "concise replies",
+      "policies": {},
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_tab_separator_remove_policy_update.json
+++ b/tests/fixtures/conformance/step/step_tab_separator_remove_policy_update.json
@@ -1,0 +1,23 @@
+{
+  "id": "step_tab_separator_remove_policy_update",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {
+      "docker": "use"
+    },
+    "version": 2
+  },
+  "input": "remove policy\tdocker",
+  "expected": {
+    "decision": {
+      "kind": "update",
+      "message": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    }
+  }
+}

--- a/tests/test_04_grammar_edge_cases.py
+++ b/tests/test_04_grammar_edge_cases.py
@@ -10,7 +10,7 @@ def _observations(engine: object) -> tuple[object, object]:
     return engine.premise, dict(engine.policies)
 
 
-def test_parser_trims_leading_space_for_canonical_directive() -> None:
+def test_step_trims_leading_space_for_canonical_directive() -> None:
     engine = Engine()
 
     decision = engine.step(" set premise concise")
@@ -22,7 +22,7 @@ def test_parser_trims_leading_space_for_canonical_directive() -> None:
     assert _observations(engine) == ("concise", {})
 
 
-def test_parser_does_not_accept_conversational_aliases() -> None:
+def test_step_does_not_accept_conversational_aliases() -> None:
     engine = Engine()
 
     for text in [
@@ -105,7 +105,7 @@ def test_remove_policy_missing_or_whitespace_payload_remains_no_directive() -> N
     assert _observations(engine) == before
 
 
-def test_invalid_replacement_does_not_block_following_directives() -> None:
+def test_missing_source_replacement_error_does_not_block_following_directives() -> None:
     engine = Engine()
     first = engine.step("use kubectl instead of docker")
     assert first["kind"] == DECISION_ERROR
@@ -118,7 +118,7 @@ def test_invalid_replacement_does_not_block_following_directives() -> None:
     assert _observations(engine) == ("concise", {})
 
 
-def test_replace_update_independent_followup_is_no_directive() -> None:
+def test_missing_source_replacement_error_independent_followup_is_no_directive() -> None:
     engine = Engine()
     first = engine.step("use kubectl instead of docker")
     second = engine.step("sounds good")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -482,7 +482,7 @@ def test_import_json_accepts_valid_policy_key_and_normalizes_it() -> None:
     _assert_observations(engine, premise=None, policies={"docker": "use"})
 
 
-def test_replace_use_clarifies_when_old_policy_is_not_use_in_invalid_internal_state() -> None:
+def test_replace_use_errors_when_old_policy_is_not_use_in_invalid_internal_state() -> None:
     engine = Engine()
     # Defensive-path coverage for impossible external state values.
     engine._state["policies"]["docker"] = "invalid"  # type: ignore[assignment]  # noqa: SLF001
@@ -1138,7 +1138,7 @@ def test_replace_use_priority_prefers_source_prohibit_error_when_both_prohibit()
     assert dict(engine.policies) == {"docker": "prohibit", "kubectl": "prohibit"}
 
 
-def test_replace_use_invalid_source_state_prohibit_clarifies_without_mutation() -> None:
+def test_replace_use_invalid_source_state_prohibit_errors_without_mutation() -> None:
     engine = Engine()
     engine.step("prohibit docker")
     engine.step("use pytest")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -15,8 +15,6 @@ from context_compiler.engine import (
 from context_compiler.grammar import (
     CanonicalDirective,
     DirectiveKind,
-    DirectiveSyntaxFailure,
-    InvalidDirectiveSyntax,
     decompose_directive,
 )
 
@@ -219,17 +217,6 @@ def test_apply_directive_preserves_state_for_semantic_errors(
     _assert_observations(engine, premise=expected_state[0], policies=expected_state[1])
 
 
-def test_apply_directive_updates_state_from_canonical_directive() -> None:
-    engine = Engine()
-    parsed = decompose_directive("use docker")
-
-    assert isinstance(parsed, CanonicalDirective)
-    decision = engine.apply_directive(parsed)
-
-    assert decision == {"kind": DECISION_UPDATE, "message": None}
-    _assert_observations(engine, premise=None, policies={"docker": "use"})
-
-
 def test_step_routes_canonical_directives_through_apply_directive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -250,43 +237,6 @@ def test_step_routes_canonical_directives_through_apply_directive(
 
     assert decision == {"kind": DECISION_UPDATE, "message": None}
     assert seen == [parsed]
-
-
-def test_decompose_directive_distinguishes_invalid_directive_syntax_from_no_directive() -> None:
-    assert decompose_directive("set premise") == InvalidDirectiveSyntax(
-        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
-        directive_kind=DirectiveKind.SET_PREMISE,
-        missing_operand="value",
-    )
-    assert decompose_directive("change premise to") == InvalidDirectiveSyntax(
-        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
-        directive_kind=DirectiveKind.CHANGE_PREMISE,
-        missing_operand="value",
-    )
-    assert decompose_directive("use") == InvalidDirectiveSyntax(
-        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
-        directive_kind=DirectiveKind.USE_ITEM,
-        missing_operand="item",
-    )
-    assert decompose_directive("prohibit") == InvalidDirectiveSyntax(
-        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
-        directive_kind=DirectiveKind.PROHIBIT_ITEM,
-        missing_operand="item",
-    )
-    assert decompose_directive("remove policy") == InvalidDirectiveSyntax(
-        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
-        directive_kind=DirectiveKind.REMOVE_POLICY,
-        missing_operand="item",
-    )
-    assert decompose_directive("use instead of docker") == InvalidDirectiveSyntax(
-        failure=DirectiveSyntaxFailure.MISSING_REQUIRED_OPERAND,
-        directive_kind=DirectiveKind.REPLACE_USE,
-        missing_operand="new_item",
-    )
-    assert decompose_directive("use docker and prohibit peanuts") == InvalidDirectiveSyntax(
-        failure=DirectiveSyntaxFailure.COMPOUND_DIRECTIVE,
-    )
-    assert decompose_directive("hello there") is None
 
 
 def test_initial_state_and_engine_properties() -> None:

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -622,7 +622,7 @@ def test_no_directive_sequence_preserves_state_and_decision_kind(inputs: list[st
 
 
 @given(st.text(min_size=1, max_size=30))
-def test_contradiction_use_after_prohibit_always_clarifies(item: str) -> None:
+def test_contradiction_use_after_prohibit_always_errors(item: str) -> None:
     assume(not _contains_canonical_start_fragment(item))
     assume(_is_canonical_directive(decompose_directive(f"prohibit {item}")))
     assume(_is_canonical_directive(decompose_directive(f"use {item}")))
@@ -636,7 +636,7 @@ def test_contradiction_use_after_prohibit_always_clarifies(item: str) -> None:
 
 
 @given(st.text(min_size=1, max_size=30))
-def test_contradiction_prohibit_after_use_always_clarifies(item: str) -> None:
+def test_contradiction_prohibit_after_use_always_errors(item: str) -> None:
     assume(" instead of " not in item)
     assume(not item.startswith("instead of "))
     assume(not item.endswith(" instead of"))

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.9.0.dev10"
+version = "0.9.0.dev11"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- Added the remaining portable grammar and `step()` conformance cases identified by the 0.9 audits, including:
  - boundary-whitespace handling for exact-literal directives
  - tab-separated `remove policy`
  - the normative `allow docker` no-directive case
  - phrase-style affirmative follow-up behavior after replacement errors
- Aligned test names and fixture documentation with the behavior they actually exercise and the current 0.9 decision vocabulary.
- Removed two deterministic engine tests that were fully superseded by stronger grammar, parametrized, and portable conformance coverage.
- Updated the grammar spec to remove a stale normalization drift note and clarify that language-specific/semantic normalization belongs in acquisition rather than core.
- Bumped the package version to `0.9.0dev11`.

## Why

The final 0.9 audit passes identified a small number of remaining portable conformance gaps, stale test/documentation terminology, and redundant deterministic coverage.

This change closes those gaps and leaves the Python implementation, normative specification, local tests, and portable cross-language conformance corpus aligned before downstream API-completeness and port validation.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)