### PR TITLE
fix: use Unicode case folding for policy identity

### DIFF
--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -650,7 +650,7 @@ Policy identity currently uses:
 
 - Unicode NFKC normalization: yes
 - apostrophe-character normalization (for example `’` to `'`): yes
-- case folding: yes
+- Unicode default full case folding: yes
 - internal whitespace collapse: yes
 - article removal: no
 - spelling correction: no
@@ -658,6 +658,16 @@ Policy identity currently uses:
 - rewriting `dont` to `don't`: no
 - synonym matching: no
 - natural-language equivalence: no
+
+Normalization order for policy identity is:
+
+1. Unicode NFKC normalization
+2. apostrophe-character normalization
+3. Unicode default full case folding
+4. internal whitespace collapse
+
+For Python implementations, Step 3 corresponds to `str.casefold()`.
+Ordinary lowercasing is not sufficient.
 
 The `yes` entries above are representation canonicalization. They do not
 authorize natural-language interpretation of different wordings as the same

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.9.0dev11"
+version = "0.9.0dev12"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/context_compiler/engine.py
+++ b/src/context_compiler/engine.py
@@ -312,7 +312,7 @@ def _sanitize_premise_value(value: str) -> str:
 def _normalize_item(value: str) -> str:
     normalized = unicode_normalize("NFKC", value)
     normalized = normalized.replace("’", "'").replace("`", "'")
-    normalized = normalized.lower()
+    normalized = normalized.casefold()
     normalized = re.sub(r"\s+", " ", normalized).strip()
     return normalized
 

--- a/tests/fixtures/conformance/apply-directive/apply_directive_use_item_unicode_casefold_idempotent_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_use_item_unicode_casefold_idempotent_update.json
@@ -1,0 +1,28 @@
+{
+  "id": "apply_directive_use_item_unicode_casefold_idempotent_update",
+  "kind": "apply_directive",
+  "initial_state": {
+    "premise": null,
+    "policies": {
+      "strasse": "use"
+    },
+    "version": 2
+  },
+  "action": {
+    "fn": "apply_directive",
+    "text": "use STRASSE"
+  },
+  "expected": {
+    "decision": {
+      "kind": "update",
+      "message": null
+    },
+    "state": {
+      "premise": null,
+      "policies": {
+        "strasse": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/state-json/state_json_import_json_unicode_casefold_policy_collision_rejected_atomically.json
+++ b/tests/fixtures/conformance/state-json/state_json_import_json_unicode_casefold_policy_collision_rejected_atomically.json
@@ -1,0 +1,29 @@
+{
+  "id": "state_json_import_json_unicode_casefold_policy_collision_rejected_atomically",
+  "kind": "state_json",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "prelude": [
+    "use kubectl"
+  ],
+  "action": {
+    "fn": "import_json",
+    "payload": "{\"premise\":null,\"policies\":{\"Straße\":\"use\",\"STRASSE\":\"prohibit\"},\"version\":2}"
+  },
+  "expected": {
+    "error": {
+      "type": "ValueError",
+      "message_contains": "Invalid state payload"
+    },
+    "state": {
+      "premise": null,
+      "policies": {
+        "kubectl": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_policy_identity_unicode_casefold_contradiction_error.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_unicode_casefold_contradiction_error.json
@@ -1,0 +1,26 @@
+{
+  "id": "step_policy_identity_unicode_casefold_contradiction_error",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "prelude": [
+    "use Straße"
+  ],
+  "input": "prohibit STRASSE",
+  "expected": {
+    "decision": {
+      "kind": "error",
+      "message": "\"strasse\" is currently in use.\nRemove or replace it before prohibiting it."
+    },
+    "state": {
+      "premise": null,
+      "policies": {
+        "strasse": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1265,6 +1265,31 @@ def test_remove_policy_uses_normalized_item_matching() -> None:
     _assert_observations(engine, premise=None, policies={})
 
 
+def test_unicode_casefold_policy_identity_makes_strasse_idempotent() -> None:
+    engine = Engine()
+
+    first = engine.step("use Straße")
+    second = engine.step("use STRASSE")
+
+    assert first == {"kind": DECISION_UPDATE, "message": None}
+    assert second == {"kind": DECISION_UPDATE, "message": None}
+    _assert_observations(engine, premise=None, policies={"strasse": "use"})
+
+
+def test_unicode_casefold_policy_identity_detects_strasse_contradiction() -> None:
+    engine = Engine()
+
+    first = engine.step("use Straße")
+    second = engine.step("prohibit STRASSE")
+
+    assert first == {"kind": DECISION_UPDATE, "message": None}
+    assert second == {
+        "kind": DECISION_ERROR,
+        "message": ('"strasse" is currently in use.\nRemove or replace it before prohibiting it.'),
+    }
+    _assert_observations(engine, premise=None, policies={"strasse": "use"})
+
+
 def test_use_and_prohibit_article_variants_remain_distinct_policies() -> None:
     engine = Engine()
 
@@ -1343,6 +1368,25 @@ def test_import_json_preserves_distinct_dont_and_dont_apostrophe_policy_keys() -
         premise=None,
         policies={"don't": "use", "dont": "prohibit"},
     )
+
+
+def test_import_json_rejects_unicode_casefold_policy_key_collisions_atomically() -> None:
+    engine = Engine()
+    engine.step("use kubectl")
+    before = _observations(engine)
+
+    with pytest.raises(ValueError, match="Invalid state payload"):
+        engine.import_json(
+            json.dumps(
+                {
+                    "premise": None,
+                    "policies": {"Straße": "use", "STRASSE": "prohibit"},
+                    "version": 2,
+                }
+            )
+        )
+
+    assert _observations(engine) == before
 
 
 def test_export_import_round_trip_preserves_distinct_normalized_policy_keys() -> None:

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -38,7 +38,7 @@ def _run_sequence(inputs: list[str]) -> tuple[object, dict[str, object]]:
 def _normalize_item_like_engine(value: str) -> str:
     normalized = unicode_normalize("NFKC", value)
     normalized = normalized.replace("’", "'").replace("`", "'")
-    normalized = normalized.lower()
+    normalized = normalized.casefold()
     normalized = re.sub(r"\s+", " ", normalized).strip()
     return normalized
 

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.9.0.dev11"
+version = "0.9.0.dev12"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- Changed policy identity normalization from ordinary lowercasing to Unicode default full case folding.
- Added public behavior and portable conformance coverage for non-ASCII case-equivalent policy identities, including `Straße` / `STRASSE`.
- Covered case-folded identity across step, apply-directive, and state import/collision behavior.
- Preserved the existing distinction between representation normalization and linguistic repair, including `dont` vs `don't`.
- Clarified the normative grammar spec to define Unicode default full case folding and the required normalization order.
- Bumped the package version to `0.9.0dev12`.

## Why

The 0.9 grammar contract specifies case folding for policy identity, but the Python implementation was using ordinary lowercasing.

Unicode case folding provides the intended representation-level caseless identity semantics and avoids cross-port divergence for non-ASCII policy values while keeping language-specific interpretation outside core.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)