### PR TITLE
doc: Fix typo in README regarding docker and podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ use podman instead of docker
 
 - Without explicit state transition rules: behavior depends on host/model handling
 - Context Compiler: applies the deterministic resulting transition when
-  `docker` is absent and `use podman` is otherwise valid; other semantic
+  `docker` is present and `use podman` is otherwise valid; other semantic
   conflicts may still error
 
 ### Lifecycle enforcement


### PR DESCRIPTION
## What changed

- Corrected the replacement behavior example to reflect that a replacement succeeds when the source item is present.

## Why

- Align the README example with the correct replacement semantics.

## Checklist

- [ ] pre-commit run (`uv run pre-commit run --all-files`)
- [ ] tests pass (`uv run pytest`)