### PR TITLE
test: strengthen grammar conformance contract

### DIFF
--- a/tests/_api_contract_harness.py
+++ b/tests/_api_contract_harness.py
@@ -106,7 +106,20 @@ def assert_shape(
         return
 
     if "kind" in shape and shape["kind"] == "canonical_directive":
-        assert value == grammar.decompose_directive(shape["text"])
+        assert isinstance(value, grammar.CanonicalDirective)
+        assert value.text == shape["text"]
+        assert value.kind.value == shape["directive_kind"]
+        assert dict(value.operands) == shape["operands"]
+        return
+
+    if "kind" in shape and shape["kind"] == "directive_metadata":
+        assert isinstance(value, grammar.DirectiveMetadata)
+        observed_kind = (
+            value.kind.value if isinstance(value.kind, grammar.DirectiveKind) else value.kind
+        )
+        assert observed_kind == shape["directive_kind"]
+        assert value.canonical_start == shape["canonical_start"]
+        assert list(value.operand_names) == shape["operand_names"]
         return
 
     if "kind" in shape and shape["kind"] == "invalid_directive_syntax":
@@ -532,6 +545,23 @@ def _validate_shape_spec(shape: object, label: str) -> None:
             _assert_string_keyed_dict(shape["operands"], f"{label}.operands")
             for operand_name, operand_value in shape["operands"].items():
                 _assert_type(operand_value, str, f"{label}.operands[{operand_name!r}]")
+            return
+        if kind == "directive_metadata":
+            _assert_closed_keys(
+                shape,
+                {"kind", "directive_kind", "canonical_start", "operand_names"},
+                label,
+            )
+            _require_fields(
+                shape,
+                {"kind", "directive_kind", "canonical_start", "operand_names"},
+                label,
+            )
+            _assert_type(shape["directive_kind"], str, f"{label}.directive_kind")
+            _assert_type(shape["canonical_start"], str, f"{label}.canonical_start")
+            _assert_type(shape["operand_names"], list, f"{label}.operand_names")
+            for index, operand_name in enumerate(shape["operand_names"]):
+                _assert_type(operand_name, str, f"{label}.operand_names[{index}]")
             return
         if kind == "invalid_directive_syntax":
             _assert_closed_keys(

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -119,11 +119,15 @@ These fixtures define declarative scenarios for:
 * returned decision isolation
 * `engine.policies` caller-ownership isolation
 * `engine.premise` caller-ownership isolation
+* `CanonicalDirective.operands` mutation isolation
+* covered `DirectiveMetadata` field mutation isolation
 
 The portable contract for this family is:
 
 * no public API return value may provide a mutation path into authoritative engine state
 * live semantic reads exposed through public properties must remain caller-owned observations
+* exposed grammar objects covered by fixtures must preserve their observed
+  values when callers attempt the fixture-defined mutations
 
 Legacy mutation-isolation scenarios tied to removed raw-state construction or
 raw-state snapshot APIs are not part of the current supported fixture surface.

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -20,7 +20,26 @@
         "kind": "class"
       },
       "DirectiveMetadata": {
-        "kind": "class"
+        "kind": "class",
+        "construction_probes": [
+          {
+            "kwargs": {
+              "kind": "use_item",
+              "canonical_start": "use",
+              "operand_names": [
+                "item"
+              ]
+            },
+            "return_shape": {
+              "kind": "directive_metadata",
+              "directive_kind": "use_item",
+              "canonical_start": "use",
+              "operand_names": [
+                "item"
+              ]
+            }
+          }
+        ]
       },
       "CanonicalDirective": {
         "kind": "class",
@@ -146,6 +165,28 @@
               "operands": {
                 "new_item": "podman instead of nerdctl",
                 "old_item": "docker"
+              }
+            },
+            "raises": {
+              "type": "ValueError"
+            }
+          },
+          {
+            "kwargs": {
+              "kind": "use_item",
+              "operands": {
+                "item": "instead of"
+              }
+            },
+            "raises": {
+              "type": "ValueError"
+            }
+          },
+          {
+            "kwargs": {
+              "kind": "use_item",
+              "operands": {
+                "item": "docker prohibit peanuts"
               }
             },
             "raises": {

--- a/tests/fixtures/conformance/mutation-isolation/010_canonical_directive_operands_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/010_canonical_directive_operands_isolation.json
@@ -1,0 +1,48 @@
+{
+  "id": "010_canonical_directive_operands_isolation",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "operation": {
+    "fn": "canonical_directive.operands",
+    "kind": "use_item",
+    "operands": {
+      "item": "docker"
+    },
+    "result_handle": "operands"
+  },
+  "handles": {
+    "operands": {
+      "kind": "immutable_or_defensive_snapshot"
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "operands",
+      "path": [
+        "item"
+      ],
+      "op": "set",
+      "value": "prohibit peanuts"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "caller_owned_observations": {
+      "operands_after_mutation": {
+        "target_handle": "operands",
+        "path": [
+          "item"
+        ],
+        "value": "docker"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/mutation-isolation/011_directive_metadata_isolation.json
+++ b/tests/fixtures/conformance/mutation-isolation/011_directive_metadata_isolation.json
@@ -1,0 +1,49 @@
+{
+  "id": "011_directive_metadata_isolation",
+  "kind": "mutation_isolation",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "operation": {
+    "fn": "directive_metadata",
+    "kind": "use_item",
+    "canonical_start": "use",
+    "operand_names": [
+      "item"
+    ],
+    "result_handle": "metadata"
+  },
+  "handles": {
+    "metadata": {
+      "kind": "immutable_or_defensive_snapshot"
+    }
+  },
+  "mutations": [
+    {
+      "target_handle": "metadata",
+      "path": [
+        "kind"
+      ],
+      "op": "set",
+      "value": "prohibit_item"
+    }
+  ],
+  "expected": {
+    "authoritative_state": {
+      "premise": null,
+      "policies": {},
+      "version": 2
+    },
+    "caller_owned_observations": {
+      "metadata_kind_after_mutation": {
+        "target_handle": "metadata",
+        "path": [
+          "kind"
+        ],
+        "value": "use_item"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/mutation-isolation/README.md
+++ b/tests/fixtures/conformance/mutation-isolation/README.md
@@ -6,7 +6,8 @@ TypeScript.
 
 ## Contract
 
-The contract captured here is **authority isolation**, not immutability.
+The contract captured here is authority isolation plus the covered public
+mutation behavior of exposed grammar objects.
 
 Returned objects may remain mutable as long as:
 
@@ -14,6 +15,11 @@ Returned objects may remain mutable as long as:
 * caller-owned envelopes remain caller-owned
 * helper accessors preserve or avoid identity only where the public contract
   says they should
+
+For the grammar-object fixtures, exposed `CanonicalDirective.operands` and the
+covered `DirectiveMetadata` fields must preserve mutation isolation: a caller
+mutation either is rejected or does not change the exposed value observed after
+the mutation.
 
 ## Fixture shape
 
@@ -39,6 +45,8 @@ Examples:
 * `engine.step`
 * `engine.policies`
 * `engine.premise`
+* `canonical_directive.operands`
+* `directive_metadata`
 For the current corpus, `operation` uses a closed per-function field set.
 Unknown operation fields are invalid.
 
@@ -66,8 +74,9 @@ Each mutation describes:
 The mutation language stays language-neutral and avoids embedding Python or
 TypeScript syntax into the fixtures.
 
-The current Python runner supports string-key dict paths only. List traversal is
-outside the scope of this fixture family for now.
+The mutation language supports string-key dict or mapping paths and public
+attribute paths. List traversal is outside the scope of this fixture family for
+now.
 
 ### `expected`
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -65,13 +66,33 @@ def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id:
 
     operation = fixture["operation"]
     assert isinstance(operation, dict), fixture_id
-    _assert_allowed_keys(
-        operation, {"fn", "input", "result_handle"} & set(operation), fixture_id, "operation"
-    )
-    assert operation["fn"] in {"engine.step", "engine.policies", "engine.premise"}, fixture_id
+    assert isinstance(operation, dict), fixture_id
+    assert operation["fn"] in {
+        "engine.step",
+        "engine.policies",
+        "engine.premise",
+        "canonical_directive.operands",
+        "directive_metadata",
+    }, fixture_id
     if operation["fn"] == "engine.step":
         _assert_allowed_keys(operation, {"fn", "input", "result_handle"}, fixture_id, "operation")
         assert isinstance(operation["input"], str), fixture_id
+    elif operation["fn"] == "canonical_directive.operands":
+        _assert_allowed_keys(
+            operation, {"fn", "kind", "operands", "result_handle"}, fixture_id, "operation"
+        )
+        assert isinstance(operation["kind"], str), fixture_id
+        assert isinstance(operation["operands"], dict), fixture_id
+    elif operation["fn"] == "directive_metadata":
+        _assert_allowed_keys(
+            operation,
+            {"fn", "kind", "canonical_start", "operand_names", "result_handle"},
+            fixture_id,
+            "operation",
+        )
+        assert isinstance(operation["kind"], str), fixture_id
+        assert isinstance(operation["canonical_start"], str), fixture_id
+        _assert_str_list(operation["operand_names"], fixture_id, "operation.operand_names")
     else:
         _assert_allowed_keys(operation, {"fn", "result_handle"}, fixture_id, "operation")
     assert isinstance(operation["result_handle"], str), fixture_id
@@ -381,8 +402,7 @@ def _state_observation(engine: object) -> dict[str, object]:
 def _resolve_handle_path(root: object, path: list[str]) -> object:
     current = root
     for key in path:
-        assert isinstance(current, dict)
-        current = current[key]
+        current = current[key] if isinstance(current, Mapping) else getattr(current, key)
     return current
 
 
@@ -390,10 +410,11 @@ def _apply_handle_mutation(root: object, path: list[str], value: object) -> None
     assert path
     current = root
     for key in path[:-1]:
-        assert isinstance(current, dict)
-        current = current[key]
-    assert isinstance(current, dict)
-    current[path[-1]] = value
+        current = current[key] if isinstance(current, Mapping) else getattr(current, key)
+    if isinstance(current, Mapping):
+        current[path[-1]] = value
+    else:
+        setattr(current, path[-1], value)
 
 
 def test_step_fixtures() -> None:
@@ -546,15 +567,26 @@ def test_mutation_isolation_fixtures() -> None:
             handles = {operation["result_handle"]: engine.step(operation["input"])}
         elif fn == "engine.policies":
             handles = {operation["result_handle"]: engine.policies}
-        else:
-            assert fn == "engine.premise", fixture_id
+        elif fn == "engine.premise":
             handles = {operation["result_handle"]: {"value": engine.premise}}
+        elif fn == "canonical_directive.operands":
+            directive = CanonicalDirective(kind=operation["kind"], operands=operation["operands"])
+            handles = {operation["result_handle"]: directive.operands}
+        else:
+            assert fn == "directive_metadata", fixture_id
+            handles = {
+                operation["result_handle"]: grammar_module.DirectiveMetadata(
+                    kind=operation["kind"],
+                    canonical_start=operation["canonical_start"],
+                    operand_names=tuple(operation["operand_names"]),
+                )
+            }
 
         for mutation in fixture["mutations"]:
             target = handles[mutation["target_handle"]]
             path = mutation["path"]
             assert isinstance(path, list), fixture_id
-            if fn == "engine.step":
+            if fn in {"engine.step", "canonical_directive.operands", "directive_metadata"}:
                 with pytest.raises((AssertionError, AttributeError, TypeError)):
                     _apply_handle_mutation(target, path, mutation["value"])
             else:

--- a/tests/test_grammar_api_contract_fixture.py
+++ b/tests/test_grammar_api_contract_fixture.py
@@ -53,6 +53,16 @@ def test_public_grammar_contract_matches_surface() -> None:
                 assert_shape(result, probe["return_shape"])
 
 
+def test_public_grammar_contract_exposes_directive_metadata_kind() -> None:
+    metadata = grammar.DirectiveMetadata(
+        kind=grammar.DirectiveKind.USE_ITEM,
+        canonical_start="use",
+        operand_names=("item",),
+    )
+
+    assert metadata.kind is grammar.DirectiveKind.USE_ITEM
+
+
 def test_public_grammar_contract_has_unique_entries() -> None:
     contract = _load_contract()
     export_names = contract["exports"]["names"]


### PR DESCRIPTION
## Strengthen grammar conformance contract

## What changed

- Added grammar API conformance coverage for `CanonicalDirective` and `DirectiveMetadata`.
- Added public API checks for `DirectiveMetadata.kind`.
- Added mutation isolation fixtures for grammar objects:
  - `CanonicalDirective.operands`
  - `DirectiveMetadata`
- Added fixture coverage for existing operand constraint behavior.
- Updated conformance fixture documentation to describe the expanded mutation isolation contract.

## Why

- Strengthen the cross-language contract before TypeScript parity work.
- Ensure consumers cannot diverge on grammar object behavior or exposed API shape.
- Make observable grammar behavior explicit in fixtures rather than relying on implementation details.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)