### PR TITLE
test: align portable decision and grammar contracts

### DIFF
--- a/src/context_compiler/grammar.py
+++ b/src/context_compiler/grammar.py
@@ -316,7 +316,10 @@ def _match_directive_token(
             token_index += 1
             continue
 
-        if text[index].casefold() != token_char:
+        character = text[index]
+        if "A" <= character <= "Z":
+            character = chr(ord(character) + (ord("a") - ord("A")))
+        if character != token_char:
             return None
         index += 1
         token_index += 1

--- a/tests/_decision_test_helpers.py
+++ b/tests/_decision_test_helpers.py
@@ -27,7 +27,10 @@ def assert_decision(decision: Decision, expected: Mapping[str, object]) -> None:
 
 
 def decision_observation(decision: Decision) -> dict[str, object]:
-    """Adapt a domain result for existing fixture assertions."""
+    """Return the portable observation shape for a domain decision."""
+
+    if isinstance(decision, UpdateDecision):
+        return {"kind": decision.kind, "changed": decision.changed}
 
     message = decision.message if isinstance(decision, SemanticErrorDecision) else None
     observation: dict[str, object] = {"kind": decision.kind, "message": message}

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -49,7 +49,7 @@ Then asserts:
 The `Decision` payload in this family uses one shared shape:
 
 * `{"kind":"no_directive","message":null}`
-* `{"kind":"update","message":null}`
+* `{"kind":"update","changed":true|false}`
 * `{"kind":"error","failure": ..., "directive": ..., "repairs": [...], "message": ...}`
 
 Semantic errors always include the machine-readable `failure`, the rejected

--- a/tests/fixtures/conformance/apply-directive/apply_directive_change_premise_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_change_premise_update.json
@@ -13,7 +13,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": "concise replies",

--- a/tests/fixtures/conformance/apply-directive/apply_directive_clear_premise_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_clear_premise_update.json
@@ -15,7 +15,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_clear_state_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_clear_state_update.json
@@ -16,7 +16,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_prohibit_item_idempotent_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_prohibit_item_idempotent_update.json
@@ -15,7 +15,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_prohibit_item_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_prohibit_item_update.json
@@ -13,7 +13,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_remove_policy_missing_idempotent_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_remove_policy_missing_idempotent_update.json
@@ -15,7 +15,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_remove_policy_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_remove_policy_update.json
@@ -16,7 +16,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_replace_use_normalized_equivalent_apostrophe_noop_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_replace_use_normalized_equivalent_apostrophe_noop_update.json
@@ -15,7 +15,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_replace_use_normalized_equivalent_noop_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_replace_use_normalized_equivalent_noop_update.json
@@ -15,7 +15,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_replace_use_normalized_equivalent_whitespace_noop_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_replace_use_normalized_equivalent_whitespace_noop_update.json
@@ -15,7 +15,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_replace_use_valid_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_replace_use_valid_update.json
@@ -16,7 +16,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": "concise replies",

--- a/tests/fixtures/conformance/apply-directive/apply_directive_reset_policies_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_reset_policies_update.json
@@ -16,7 +16,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": "concise replies",

--- a/tests/fixtures/conformance/apply-directive/apply_directive_set_premise_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_set_premise_update.json
@@ -13,7 +13,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": "concise replies",

--- a/tests/fixtures/conformance/apply-directive/apply_directive_use_item_idempotent_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_use_item_idempotent_update.json
@@ -15,7 +15,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_use_item_unicode_casefold_idempotent_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_use_item_unicode_casefold_idempotent_update.json
@@ -15,7 +15,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/apply-directive/apply_directive_use_item_update.json
+++ b/tests/fixtures/conformance/apply-directive/apply_directive_use_item_update.json
@@ -13,7 +13,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/controller/controller_step_apply_equivalence_change_premise.json
+++ b/tests/fixtures/conformance/controller/controller_step_apply_equivalence_change_premise.json
@@ -38,11 +38,11 @@
     "observations": {
       "step_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "apply_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       }
     },
     "equal": [

--- a/tests/fixtures/conformance/controller/controller_step_apply_equivalence_clear_premise.json
+++ b/tests/fixtures/conformance/controller/controller_step_apply_equivalence_clear_premise.json
@@ -40,11 +40,11 @@
     "observations": {
       "step_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "apply_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       }
     },
     "equal": [

--- a/tests/fixtures/conformance/controller/controller_step_apply_equivalence_clear_state.json
+++ b/tests/fixtures/conformance/controller/controller_step_apply_equivalence_clear_state.json
@@ -40,11 +40,11 @@
     "observations": {
       "step_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "apply_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       }
     },
     "equal": [

--- a/tests/fixtures/conformance/controller/controller_step_apply_equivalence_prohibit_item.json
+++ b/tests/fixtures/conformance/controller/controller_step_apply_equivalence_prohibit_item.json
@@ -38,11 +38,11 @@
     "observations": {
       "step_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "apply_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       }
     },
     "equal": [

--- a/tests/fixtures/conformance/controller/controller_step_apply_equivalence_remove_policy.json
+++ b/tests/fixtures/conformance/controller/controller_step_apply_equivalence_remove_policy.json
@@ -40,11 +40,11 @@
     "observations": {
       "step_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "apply_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       }
     },
     "equal": [

--- a/tests/fixtures/conformance/controller/controller_step_apply_equivalence_replace_use.json
+++ b/tests/fixtures/conformance/controller/controller_step_apply_equivalence_replace_use.json
@@ -40,11 +40,11 @@
     "observations": {
       "step_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "apply_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       }
     },
     "equal": [

--- a/tests/fixtures/conformance/controller/controller_step_apply_equivalence_reset_policies.json
+++ b/tests/fixtures/conformance/controller/controller_step_apply_equivalence_reset_policies.json
@@ -40,11 +40,11 @@
     "observations": {
       "step_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "apply_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       }
     },
     "equal": [

--- a/tests/fixtures/conformance/controller/controller_step_apply_equivalence_set_premise.json
+++ b/tests/fixtures/conformance/controller/controller_step_apply_equivalence_set_premise.json
@@ -38,11 +38,11 @@
     "observations": {
       "step_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "apply_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       }
     },
     "equal": [

--- a/tests/fixtures/conformance/controller/controller_step_apply_equivalence_use_item.json
+++ b/tests/fixtures/conformance/controller/controller_step_apply_equivalence_use_item.json
@@ -38,11 +38,11 @@
     "observations": {
       "step_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "apply_decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       }
     },
     "equal": [

--- a/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_change_premise.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_change_premise.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_ascii_case_change_premise",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "CHANGE PREMISE TO formal tone"
+  },
+  "expected": {
+    "directive": {
+      "text": "change premise to formal tone",
+      "kind": "change_premise",
+      "operands": {
+        "value": "formal tone"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_clear_premise.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_clear_premise.json
@@ -1,0 +1,15 @@
+{
+  "id": "grammar_decompose_ascii_case_clear_premise",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "CLEAR PREMISE"
+  },
+  "expected": {
+    "directive": {
+      "text": "clear premise",
+      "kind": "clear_premise",
+      "operands": {}
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_clear_state.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_clear_state.json
@@ -1,0 +1,15 @@
+{
+  "id": "grammar_decompose_ascii_case_clear_state",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "CLEAR STATE"
+  },
+  "expected": {
+    "directive": {
+      "text": "clear state",
+      "kind": "clear_state",
+      "operands": {}
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_prohibit_item.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_prohibit_item.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_ascii_case_prohibit_item",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "PROHIBIT peanuts"
+  },
+  "expected": {
+    "directive": {
+      "text": "prohibit peanuts",
+      "kind": "prohibit_item",
+      "operands": {
+        "item": "peanuts"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_remove_policy.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_remove_policy.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_ascii_case_remove_policy",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "REMOVE POLICY docker"
+  },
+  "expected": {
+    "directive": {
+      "text": "remove policy docker",
+      "kind": "remove_policy",
+      "operands": {
+        "item": "docker"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_replace_use.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_replace_use.json
@@ -1,0 +1,18 @@
+{
+  "id": "grammar_decompose_ascii_case_replace_use",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "USE podman INSTEAD OF docker"
+  },
+  "expected": {
+    "directive": {
+      "text": "use podman instead of docker",
+      "kind": "replace_use",
+      "operands": {
+        "new_item": "podman",
+        "old_item": "docker"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_reset_policies.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_reset_policies.json
@@ -1,0 +1,15 @@
+{
+  "id": "grammar_decompose_ascii_case_reset_policies",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "RESET POLICIES"
+  },
+  "expected": {
+    "directive": {
+      "text": "reset policies",
+      "kind": "reset_policies",
+      "operands": {}
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_set_premise.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_ascii_case_set_premise.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_ascii_case_set_premise",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "SET PREMISE concise replies"
+  },
+  "expected": {
+    "directive": {
+      "text": "set premise concise replies",
+      "kind": "set_premise",
+      "operands": {
+        "value": "concise replies"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_unicode_casefold_keyword_rejected.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_unicode_casefold_keyword_rejected.json
@@ -1,0 +1,11 @@
+{
+  "id": "grammar_decompose_unicode_casefold_keyword_rejected",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "uſe docker"
+  },
+  "expected": {
+    "directive": null
+  }
+}

--- a/tests/fixtures/conformance/step/step_boundary_whitespace_trim_clear_premise_update.json
+++ b/tests/fixtures/conformance/step/step_boundary_whitespace_trim_clear_premise_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_boundary_whitespace_trim_clear_state_update.json
+++ b/tests/fixtures/conformance/step/step_boundary_whitespace_trim_clear_state_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_boundary_whitespace_trim_reset_policies_update.json
+++ b/tests/fixtures/conformance/step/step_boundary_whitespace_trim_reset_policies_update.json
@@ -13,7 +13,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": "concise replies",

--- a/tests/fixtures/conformance/step/step_boundary_whitespace_trim_use_update.json
+++ b/tests/fixtures/conformance/step/step_boundary_whitespace_trim_use_update.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_change_premise_update.json
+++ b/tests/fixtures/conformance/step/step_change_premise_update.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": "concise replies",

--- a/tests/fixtures/conformance/step/step_clear_premise_already_null_update.json
+++ b/tests/fixtures/conformance/step/step_clear_premise_already_null_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_clear_premise_populated_update.json
+++ b/tests/fixtures/conformance/step/step_clear_premise_populated_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_clear_state_already_empty_update.json
+++ b/tests/fixtures/conformance/step/step_clear_state_already_empty_update.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_clear_state_populated_update.json
+++ b/tests/fixtures/conformance/step/step_clear_state_populated_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_embedded_canonical_token_inside_word_is_not_compound.json
+++ b/tests/fixtures/conformance/step/step_embedded_canonical_token_inside_word_is_not_compound.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_exact_prefix_no_directive_leading_space.json
+++ b/tests/fixtures/conformance/step/step_exact_prefix_no_directive_leading_space.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": "concise",

--- a/tests/fixtures/conformance/step/step_keyword_case_normalization_use_update.json
+++ b/tests/fixtures/conformance/step/step_keyword_case_normalization_use_update.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_policy_identity_case_remove_policy_update.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_case_remove_policy_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_policy_identity_internal_whitespace_remove_policy_update.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_internal_whitespace_remove_policy_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_policy_identity_no_article_removal_distinct_update.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_no_article_removal_distinct_update.json
@@ -13,7 +13,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_policy_identity_no_dont_rewrite_distinct_update.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_no_dont_rewrite_distinct_update.json
@@ -13,7 +13,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_prohibit_item_update.json
+++ b/tests/fixtures/conformance/step/step_prohibit_item_update.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_remove_policy_missing_idempotent_update.json
+++ b/tests/fixtures/conformance/step/step_remove_policy_missing_idempotent_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_remove_policy_present_update.json
+++ b/tests/fixtures/conformance/step/step_remove_policy_present_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_replace_use_identical_normalized_identity_update.json
+++ b/tests/fixtures/conformance/step/step_replace_use_identical_normalized_identity_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_replace_use_update.json
+++ b/tests/fixtures/conformance/step/step_replace_use_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_reset_policies_already_empty_update.json
+++ b/tests/fixtures/conformance/step/step_reset_policies_already_empty_update.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": false
     },
     "state": {
       "premise": "concise replies",

--- a/tests/fixtures/conformance/step/step_reset_policies_populated_update.json
+++ b/tests/fixtures/conformance/step/step_reset_policies_populated_update.json
@@ -13,7 +13,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": "concise replies",

--- a/tests/fixtures/conformance/step/step_set_premise_update.json
+++ b/tests/fixtures/conformance/step/step_set_premise_update.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": "concise replies",

--- a/tests/fixtures/conformance/step/step_tab_separator_remove_policy_update.json
+++ b/tests/fixtures/conformance/step/step_tab_separator_remove_policy_update.json
@@ -12,7 +12,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_tab_separator_use_update.json
+++ b/tests/fixtures/conformance/step/step_tab_separator_use_update.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_use_item_normalization.json
+++ b/tests/fixtures/conformance/step/step_use_item_normalization.json
@@ -10,7 +10,7 @@
   "expected": {
     "decision": {
       "kind": "update",
-      "message": null
+      "changed": true
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/engine-regression/structured/README.md
+++ b/tests/fixtures/engine-regression/structured/README.md
@@ -45,7 +45,8 @@ regressions are visible in:
 
 ## Prompt Matching
 
-`decision.message` is matched exactly, including `null` for non-error turns.
+Update observations expose `changed`; error observations expose
+`decision.message` and match it exactly.
 
 ## Adding a Scenario
 

--- a/tests/fixtures/engine-regression/structured/expected/contradiction_error.json
+++ b/tests/fixtures/engine-regression/structured/expected/contradiction_error.json
@@ -11,7 +11,7 @@
       },
       "decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "input": "use docker"
     },

--- a/tests/fixtures/engine-regression/structured/expected/premise_lifecycle.json
+++ b/tests/fixtures/engine-regression/structured/expected/premise_lifecycle.json
@@ -9,7 +9,7 @@
       },
       "decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "input": "set premise concise replies"
     },
@@ -50,7 +50,7 @@
       },
       "decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "input": "change premise to concise bullet points"
     },
@@ -62,7 +62,7 @@
       },
       "decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "input": "clear premise"
     },

--- a/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_new_error.json
+++ b/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_new_error.json
@@ -11,7 +11,7 @@
       },
       "decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "input": "use docker"
     },
@@ -26,7 +26,7 @@
       },
       "decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "input": "prohibit kubectl"
     },

--- a/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_old_error.json
+++ b/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_old_error.json
@@ -11,7 +11,7 @@
       },
       "decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "input": "prohibit docker"
     },
@@ -26,7 +26,7 @@
       },
       "decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "input": "use pytest"
     },

--- a/tests/fixtures/engine-regression/structured/expected/replacement_error_followup_independence.json
+++ b/tests/fixtures/engine-regression/structured/expected/replacement_error_followup_independence.json
@@ -27,7 +27,7 @@
       "input": "use docker",
       "decision": {
         "kind": "update",
-        "message": null
+        "changed": true
       },
       "state": {
         "premise": null,

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -137,9 +137,14 @@ def _validate_public_decision(decision: dict[str, object], fixture_id: object, l
     kind = decision.get("kind")
     assert isinstance(kind, str), fixture_id
 
-    if kind in {"no_directive", "update"}:
+    if kind == "no_directive":
         _assert_allowed_keys(decision, {"kind", "message"}, fixture_id, label)
         assert decision["message"] is None, fixture_id
+        return
+
+    if kind == "update":
+        _assert_allowed_keys(decision, {"kind", "changed"}, fixture_id, label)
+        assert isinstance(decision["changed"], bool), fixture_id
         return
 
     assert kind == "error", fixture_id

--- a/tests/test_structured_regression.py
+++ b/tests/test_structured_regression.py
@@ -69,6 +69,10 @@ def _validate_structured_expected_fixture(expected: dict[str, object], fixture_i
                 fixture_id,
                 "expected.turn.decision",
             )
+        elif decision.get("kind") == "update":
+            _assert_allowed_keys(
+                decision, {"kind", "changed"}, fixture_id, "expected.turn.decision"
+            )
         else:
             _assert_allowed_keys(
                 decision, {"kind", "message"}, fixture_id, "expected.turn.decision"
@@ -76,6 +80,8 @@ def _validate_structured_expected_fixture(expected: dict[str, object], fixture_i
         assert isinstance(decision["kind"], str), fixture_id
         if decision["kind"] == "error":
             assert isinstance(decision["message"], str), fixture_id
+        elif decision["kind"] == "update":
+            assert isinstance(decision["changed"], bool), fixture_id
         else:
             assert decision["message"] is None, fixture_id
 


### PR DESCRIPTION
## Strengthen conformance contract for cross-language parity

## What changed

- Updated portable `UpdateDecision` observations to use `{kind, changed}` instead of `{kind, message}`.
- Added grammar conformance coverage for `CanonicalDirective` and `DirectiveMetadata`.
- Added mutation isolation fixtures for:
  - `CanonicalDirective.operands`
  - `DirectiveMetadata`
- Added public API coverage for `DirectiveMetadata.kind`.
- Added ASCII-only keyword case-insensitivity conformance coverage.
- Added regression coverage ensuring Unicode casefold equivalents (for example `uſe`) are not accepted as directive keywords.
- Updated grammar keyword matching to enforce ASCII-only case-insensitivity.

## Why

- Strengthen the portable contract before TypeScript parity work.
- Ensure cross-language implementations match the intended observable API and grammar behavior.
- Prevent accidental divergence from Python implementation details that are not part of the contract.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)