### PR TITLE
test: harden portable conformance contract

### DIFF
--- a/tests/_api_contract_harness.py
+++ b/tests/_api_contract_harness.py
@@ -234,6 +234,20 @@ def validate_engine_member_runtime(
     raise AssertionError(f"Unsupported engine member kind {kind!r} for {name}")
 
 
+def validate_engine_member_probes(
+    engine: object, name: str, member_contract: dict[str, Any], contract: dict[str, Any]
+) -> None:
+    callback = getattr(engine, name)
+    for probe in member_contract.get("probes", []):
+        if "raises" in probe:
+            assert_probe_raises(callback, probe, contract)
+            continue
+        args = [resolve_probe_value(value) for value in probe.get("args", [])]
+        kwargs = {key: resolve_probe_value(value) for key, value in probe.get("kwargs", {}).items()}
+        result = callback(*args, **kwargs)
+        assert_shape(result, probe["return_shape"], contract)
+
+
 def _validate_contract(
     contract: object,
     *,
@@ -392,7 +406,7 @@ def _validate_engine_member_spec(
     label: str,
 ) -> None:
     _assert_type(member_spec, dict, label)
-    _assert_closed_keys(member_spec, {"kind", "signature"}, label)
+    _assert_closed_keys(member_spec, {"kind", "signature", "probes"}, label)
     _require_fields(member_spec, {"kind"}, label)
 
     kind = member_spec["kind"]
@@ -404,10 +418,13 @@ def _validate_engine_member_spec(
         if not has_signature:
             raise AssertionError(f"{label} method members require signature")
         _validate_signature_spec(member_spec["signature"], f"{label}.signature")
+        _validate_construction_probes(member_spec.get("probes", []), f"{label}.probes")
         return
 
     if has_signature:
         raise AssertionError(f"{label} property members must not declare signature")
+    if "probes" in member_spec:
+        raise AssertionError(f"{label} property members must not declare probes")
 
 
 def _validate_signature_spec(signature: object, label: str) -> None:

--- a/tests/_decision_test_helpers.py
+++ b/tests/_decision_test_helpers.py
@@ -32,8 +32,10 @@ def decision_observation(decision: Decision) -> dict[str, object]:
     if isinstance(decision, UpdateDecision):
         return {"kind": decision.kind, "changed": decision.changed}
 
-    message = decision.message if isinstance(decision, SemanticErrorDecision) else None
-    observation: dict[str, object] = {"kind": decision.kind, "message": message}
+    if not isinstance(decision, SemanticErrorDecision):
+        return {"kind": decision.kind}
+
+    observation: dict[str, object] = {"kind": decision.kind, "message": decision.message}
     if isinstance(decision, SemanticErrorDecision):
         observation["failure"] = decision.failure
         observation["directive"] = _directive_observation(decision.directive)

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -48,14 +48,15 @@ Then asserts:
 
 The `Decision` payload in this family uses one shared shape:
 
-* `{"kind":"no_directive","message":null}`
+* `{"kind":"no_directive"}`
 * `{"kind":"update","changed":true|false}`
 * `{"kind":"error","failure": ..., "directive": ..., "repairs": [...], "message": ...}`
 
 Semantic errors always include the machine-readable `failure`, the rejected
 canonical `directive`, and an ordered list of advisory canonical `repairs`.
-`message` is derived human-readable text for presentation. Non-error outcomes
-keep the field for structural consistency and use `null`.
+`message` is derived human-readable text for presentation and is exposed only
+on semantic errors. All Decision variants are immutable, including their
+exposed nested directive and repair values.
 
 The current runner enforces a closed fixture shape for this family.
 Unknown top-level and documented nested fields are rejected.
@@ -116,6 +117,8 @@ structured objects or accept caller-owned structured inputs.
 These fixtures define declarative scenarios for:
 
 * update `Decision` isolation
+* immutable `NoDirectiveDecision`, `UpdateDecision`, and
+  `SemanticErrorDecision` results, including covered nested values
 * returned decision isolation
 * `engine.policies` caller-ownership isolation
 * `engine.premise` caller-ownership isolation
@@ -128,6 +131,7 @@ The portable contract for this family is:
 * live semantic reads exposed through public properties must remain caller-owned observations
 * exposed grammar objects covered by fixtures must preserve their observed
   values when callers attempt the fixture-defined mutations
+* Decision instances and their exposed nested values must reject mutation
 
 Legacy mutation-isolation scenarios tied to removed raw-state construction or
 raw-state snapshot APIs are not part of the current supported fixture surface.

--- a/tests/fixtures/conformance/api/public-api-v2.json
+++ b/tests/fixtures/conformance/api/public-api-v2.json
@@ -137,7 +137,33 @@
               "UpdateDecision",
               "SemanticErrorDecision"
             ]
-          }
+          },
+          "probes": [
+            {
+              "args": ["use docker"],
+              "raises": {
+                "type": "AttributeError"
+              }
+            },
+            {
+              "args": [null],
+              "raises": {
+                "type": "AttributeError"
+              }
+            },
+            {
+              "args": [1],
+              "raises": {
+                "type": "AttributeError"
+              }
+            },
+            {
+              "args": [{}],
+              "raises": {
+                "type": "AttributeError"
+              }
+            }
+          ]
         },
         "import_json": {
           "kind": "method",

--- a/tests/fixtures/conformance/controller/controller_replace_error_import_then_yes_no_no_reserved_state.json
+++ b/tests/fixtures/conformance/controller/controller_replace_error_import_then_yes_no_no_reserved_state.json
@@ -44,12 +44,10 @@
         "message": "\"docker\" is not currently in use.\nReplacement requires an active 'use' policy."
       },
       "yes_followup": {
-        "kind": "no_directive",
-        "message": null
+        "kind": "no_directive"
       },
       "no_followup": {
-        "kind": "no_directive",
-        "message": null
+        "kind": "no_directive"
       }
     },
     "equal": [],

--- a/tests/fixtures/conformance/mutation-isolation/012_no_directive_decision_immutable.json
+++ b/tests/fixtures/conformance/mutation-isolation/012_no_directive_decision_immutable.json
@@ -1,5 +1,5 @@
 {
-  "id": "mutation_isolation_update_decision",
+  "id": "012_no_directive_decision_immutable",
   "kind": "mutation_isolation",
   "initial_state": {
     "premise": null,
@@ -8,30 +8,26 @@
   },
   "operation": {
     "fn": "engine.step",
-    "input": "use docker",
+    "input": "hello there",
     "result_handle": "decision"
   },
   "handles": {
     "decision": {
-      "kind": "independently_constructed_result"
+      "kind": "immutable_result"
     }
   },
   "mutations": [
     {
       "target_handle": "decision",
-      "path": [
-        "changed"
-      ],
+      "path": ["kind"],
       "op": "set",
-      "value": false
+      "value": "update"
     }
   ],
   "expected": {
     "authoritative_state": {
       "premise": null,
-      "policies": {
-        "docker": "use"
-      },
+      "policies": {},
       "version": 2
     }
   }

--- a/tests/fixtures/conformance/mutation-isolation/013_semantic_error_decision_immutable.json
+++ b/tests/fixtures/conformance/mutation-isolation/013_semantic_error_decision_immutable.json
@@ -1,5 +1,5 @@
 {
-  "id": "mutation_isolation_update_decision",
+  "id": "013_semantic_error_decision_immutable",
   "kind": "mutation_isolation",
   "initial_state": {
     "premise": null,
@@ -8,22 +8,27 @@
   },
   "operation": {
     "fn": "engine.step",
-    "input": "use docker",
+    "input": "prohibit docker",
     "result_handle": "decision"
   },
+  "prelude": ["use docker"],
   "handles": {
     "decision": {
-      "kind": "independently_constructed_result"
+      "kind": "immutable_result_with_nested_values"
     }
   },
   "mutations": [
     {
       "target_handle": "decision",
-      "path": [
-        "changed"
-      ],
+      "path": ["failure"],
       "op": "set",
-      "value": false
+      "value": "premise_not_set"
+    },
+    {
+      "target_handle": "decision",
+      "path": ["directive", "operands", "item"],
+      "op": "set",
+      "value": "peanuts"
     }
   ],
   "expected": {

--- a/tests/fixtures/conformance/mutation-isolation/README.md
+++ b/tests/fixtures/conformance/mutation-isolation/README.md
@@ -9,12 +9,15 @@ TypeScript.
 The contract captured here is authority isolation plus the covered public
 mutation behavior of exposed grammar objects.
 
-Returned objects may remain mutable as long as:
+Returned state snapshots remain caller-owned, while public `Decision` variants
+are immutable. The contract requires:
 
 * mutating them cannot mutate authoritative engine state
 * caller-owned envelopes remain caller-owned
 * helper accessors preserve or avoid identity only where the public contract
   says they should
+* mutating any covered Decision field or nested exposed value is rejected and
+  does not change the observed value
 
 For the grammar-object fixtures, exposed `CanonicalDirective.operands` and the
 covered `DirectiveMetadata` fields must preserve mutation isolation: a caller
@@ -88,7 +91,7 @@ now.
 
 ## Scope boundary
 
-These fixtures cover only the shared API surface for Python 0.9 and the
+These fixtures cover only the shared API surface for Python and the
 unsynchronized TypeScript port.
 
 They intentionally do **not** include:

--- a/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_normalized_token.json
+++ b/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_normalized_token.json
@@ -12,8 +12,7 @@
   "input": "  YES!!!  ",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_phrase_token.json
+++ b/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_phrase_token.json
@@ -12,8 +12,7 @@
   "input": "yes please",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_punctuation_token.json
+++ b/tests/fixtures/conformance/step/step_affirmative_followup_no_directive_punctuation_token.json
@@ -12,8 +12,7 @@
   "input": " okay!!! ",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_change_premise_missing_operand_no_directive.json
+++ b/tests/fixtures/conformance/step/step_change_premise_missing_operand_no_directive.json
@@ -9,8 +9,7 @@
   "input": "change premise to",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": "baseline",

--- a/tests/fixtures/conformance/step/step_compound_clear_state_then_set_premise_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_clear_state_then_set_premise_invalid_boundary.json
@@ -11,8 +11,7 @@
   "input": "clear state then set premise project",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": "baseline",

--- a/tests/fixtures/conformance/step/step_compound_intervening_text_second_directive_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_intervening_text_second_directive_invalid_boundary.json
@@ -9,8 +9,7 @@
   "input": "use docker for development prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_compound_remove_policy_and_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_remove_policy_and_prohibit_invalid_boundary.json
@@ -11,8 +11,7 @@
   "input": "remove policy docker and prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_compound_set_premise_and_use_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_set_premise_and_use_invalid_boundary.json
@@ -9,8 +9,7 @@
   "input": "set premise vegetarian and use docker",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_compound_set_premise_newline_use_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_set_premise_newline_use_invalid_boundary.json
@@ -9,8 +9,7 @@
   "input": "set premise new project\nuse docker",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_compound_use_and_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_use_and_prohibit_invalid_boundary.json
@@ -9,8 +9,7 @@
   "input": "use docker and prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_compound_use_newline_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_use_newline_prohibit_invalid_boundary.json
@@ -9,8 +9,7 @@
   "input": "use docker\nprohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_compound_use_or_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_use_or_prohibit_invalid_boundary.json
@@ -9,8 +9,7 @@
   "input": "use docker or prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_compound_use_punctuation_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_use_punctuation_prohibit_invalid_boundary.json
@@ -9,8 +9,7 @@
   "input": "use docker. prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_compound_use_xor_prohibit_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_use_xor_prohibit_invalid_boundary.json
@@ -9,8 +9,7 @@
   "input": "use docker xor prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_independent_followup_no_directive_after_replace_update.json
+++ b/tests/fixtures/conformance/step/step_independent_followup_no_directive_after_replace_update.json
@@ -12,8 +12,7 @@
   "input": "sounds good",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_leading_non_directive_text_disables_compound_detection.json
+++ b/tests/fixtures/conformance/step/step_leading_non_directive_text_disables_compound_detection.json
@@ -9,8 +9,7 @@
   "input": "note use docker prohibit peanuts",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_natural_language_request_no_directive.json
+++ b/tests/fixtures/conformance/step/step_natural_language_request_no_directive.json
@@ -9,8 +9,7 @@
   "input": "please use docker",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_near_miss_change_premise_missing_to.json
+++ b/tests/fixtures/conformance/step/step_near_miss_change_premise_missing_to.json
@@ -9,8 +9,7 @@
   "input": "change premise concise",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_near_miss_set_premise_to.json
+++ b/tests/fixtures/conformance/step/step_near_miss_set_premise_to.json
@@ -9,8 +9,7 @@
   "input": "set premise to concise",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_negative_followup_no_directive_normalized_token.json
+++ b/tests/fixtures/conformance/step/step_negative_followup_no_directive_normalized_token.json
@@ -12,8 +12,7 @@
   "input": "no thanks.",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_negative_followup_no_directive_punctuation_token.json
+++ b/tests/fixtures/conformance/step/step_negative_followup_no_directive_punctuation_token.json
@@ -12,8 +12,7 @@
   "input": " NOPE?? ",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_non_directive_input_no_directive.json
+++ b/tests/fixtures/conformance/step/step_non_directive_input_no_directive.json
@@ -9,8 +9,7 @@
   "input": "hello there",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_prohibit_missing_operand_no_directive.json
+++ b/tests/fixtures/conformance/step/step_prohibit_missing_operand_no_directive.json
@@ -9,8 +9,7 @@
   "input": "prohibit",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_quoted_leading_directive_text_no_directive.json
+++ b/tests/fixtures/conformance/step/step_quoted_leading_directive_text_no_directive.json
@@ -9,8 +9,7 @@
   "input": "\"use docker and prohibit peanuts\"",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_quoted_payload_compound_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_quoted_payload_compound_invalid_boundary.json
@@ -9,8 +9,7 @@
   "input": "use \"docker and prohibit peanuts\"",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_remove_policy_missing_operand_no_directive.json
+++ b/tests/fixtures/conformance/step/step_remove_policy_missing_operand_no_directive.json
@@ -9,8 +9,7 @@
   "input": "remove policy",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_replace_missing_new_operand_no_directive.json
+++ b/tests/fixtures/conformance/step/step_replace_missing_new_operand_no_directive.json
@@ -9,8 +9,7 @@
   "input": "use instead of docker",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_replace_missing_old_operand_no_directive.json
+++ b/tests/fixtures/conformance/step/step_replace_missing_old_operand_no_directive.json
@@ -9,8 +9,7 @@
   "input": "use podman instead of",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_replace_newline_missing_new_operand_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_replace_newline_missing_new_operand_invalid_boundary.json
@@ -9,8 +9,7 @@
   "input": "use\ninstead of docker",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_set_premise_missing_operand_no_directive.json
+++ b/tests/fixtures/conformance/step/step_set_premise_missing_operand_no_directive.json
@@ -9,8 +9,7 @@
   "input": "set premise",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/conformance/step/step_use_missing_operand_no_directive.json
+++ b/tests/fixtures/conformance/step/step_use_missing_operand_no_directive.json
@@ -9,8 +9,7 @@
   "input": "use",
   "expected": {
     "decision": {
-      "kind": "no_directive",
-      "message": null
+      "kind": "no_directive"
     },
     "state": {
       "premise": null,

--- a/tests/fixtures/engine-regression/structured/README.md
+++ b/tests/fixtures/engine-regression/structured/README.md
@@ -28,13 +28,13 @@ Each expected turn uses:
 
 * `input`
 * `decision.kind`
-* `decision.message`
+* `decision.message` for semantic errors only
 * `state`
 
 State is intentionally stored separately in each turn artifact rather than on
 the `Decision`.
-`decision.message` is only semantically meaningful for `error`; non-error turns
-store `null` for structural consistency.
+`decision.message` is exposed only for `error`; no-directive observations are
+the portable shape `{"kind":"no_directive"}`.
 
 ## Why Store State Every Turn
 
@@ -59,7 +59,7 @@ Update observations expose `changed`; error observations expose
 
 These fixtures validate **deterministic engine behavior only**:
 
-* `engine.step(...)` outputs (`Decision.kind`, `Decision.message`)
+* `engine.step(...)` outputs (`Decision.kind`, and `Decision.message` for errors)
 * post-turn authoritative state snapshot
 
 They do **not** cover:

--- a/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_new_error.json
+++ b/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_new_error.json
@@ -81,8 +81,7 @@
         "version": 2
       },
       "decision": {
-        "kind": "no_directive",
-        "message": null
+        "kind": "no_directive"
       },
       "input": "no"
     }

--- a/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_old_error.json
+++ b/tests/fixtures/engine-regression/structured/expected/prohibited_replacement_old_error.json
@@ -65,8 +65,7 @@
         "version": 2
       },
       "decision": {
-        "kind": "no_directive",
-        "message": null
+        "kind": "no_directive"
       },
       "input": "yes"
     }

--- a/tests/fixtures/engine-regression/structured/expected/replacement_error_followup_independence.json
+++ b/tests/fixtures/engine-regression/structured/expected/replacement_error_followup_independence.json
@@ -40,8 +40,7 @@
     {
       "input": "yes",
       "decision": {
-        "kind": "no_directive",
-        "message": null
+        "kind": "no_directive"
       },
       "state": {
         "premise": null,

--- a/tests/test_api_contract_fixture.py
+++ b/tests/test_api_contract_fixture.py
@@ -5,6 +5,7 @@ from _api_contract_harness import (
     assert_signature_matches,
     load_api_contract,
     resolve_probe_value,
+    validate_engine_member_probes,
     validate_engine_member_runtime,
     validate_export_kind,
 )
@@ -64,6 +65,7 @@ def test_api_contract_fixture_matches_python_public_surface() -> None:
     for name, member_contract in expected_members.items():
         assert hasattr(engine, name), name
         validate_engine_member_runtime(engine_type, engine, name, member_contract)
+        validate_engine_member_probes(engine, name, member_contract, contract)
 
 
 def test_api_contract_fixture_forbidden_exports_are_not_present() -> None:

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -57,12 +57,15 @@ def _assert_str_list(value: object, fixture_id: object, label: str) -> None:
 def _validate_mutation_isolation_fixture(fixture: dict[str, object], fixture_id: object) -> None:
     _assert_allowed_keys(
         fixture,
-        {"id", "kind", "initial_state", "operation", "handles", "mutations", "expected"},
+        {"id", "kind", "initial_state", "operation", "handles", "mutations", "expected"}
+        | ({"prelude"} & set(fixture)),
         fixture_id,
         "fixture",
     )
     assert fixture["kind"] == "mutation_isolation", fixture_id
     assert isinstance(fixture["initial_state"], dict), fixture_id
+    if "prelude" in fixture:
+        _assert_str_list(fixture["prelude"], fixture_id, "prelude")
 
     operation = fixture["operation"]
     assert isinstance(operation, dict), fixture_id
@@ -138,8 +141,7 @@ def _validate_public_decision(decision: dict[str, object], fixture_id: object, l
     assert isinstance(kind, str), fixture_id
 
     if kind == "no_directive":
-        _assert_allowed_keys(decision, {"kind", "message"}, fixture_id, label)
-        assert decision["message"] is None, fixture_id
+        _assert_allowed_keys(decision, {"kind"}, fixture_id, label)
         return
 
     if kind == "update":
@@ -566,6 +568,7 @@ def test_mutation_isolation_fixtures() -> None:
         engine.import_json(
             json.dumps(fixture["initial_state"], sort_keys=True, separators=(",", ":"))
         )
+        _apply_prelude(engine, fixture.get("prelude", []))
 
         handles: dict[str, object]
         if fn == "engine.step":

--- a/tests/test_structured_regression.py
+++ b/tests/test_structured_regression.py
@@ -74,16 +74,12 @@ def _validate_structured_expected_fixture(expected: dict[str, object], fixture_i
                 decision, {"kind", "changed"}, fixture_id, "expected.turn.decision"
             )
         else:
-            _assert_allowed_keys(
-                decision, {"kind", "message"}, fixture_id, "expected.turn.decision"
-            )
+            _assert_allowed_keys(decision, {"kind"}, fixture_id, "expected.turn.decision")
         assert isinstance(decision["kind"], str), fixture_id
         if decision["kind"] == "error":
             assert isinstance(decision["message"], str), fixture_id
         elif decision["kind"] == "update":
             assert isinstance(decision["changed"], bool), fixture_id
-        else:
-            assert decision["message"] is None, fixture_id
 
 
 def _state_diff(expected: object, actual: object) -> str:


### PR DESCRIPTION
## What changed

- Updated portable Decision observations to match the public API:
  - `NoDirectiveDecision` now observes `{kind}` only.
  - `UpdateDecision` observes `{kind, changed}`.
- Added Decision immutability conformance coverage across all Decision variants.
- Added `apply_directive` invalid argument conformance probes.
- Updated fixture validators and documentation for the expanded Decision contract.

## Why

- Strengthen the cross-language contract before TypeScript parity work.
- Ensure consumers match the intended public Decision API and boundary behavior.
- Move previously implicit Python behavior into portable conformance coverage.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)