### PR TITLE
fix: align invalid directive syntax fixtures

### DIFF
--- a/tests/_api_contract_harness.py
+++ b/tests/_api_contract_harness.py
@@ -586,7 +586,11 @@ def _validate_shape_spec(shape: object, label: str) -> None:
                 {"kind", "failure", "directive_kind", "missing_operand"},
                 label,
             )
-            _require_fields(shape, {"kind", "failure"}, label)
+            _require_fields(
+                shape,
+                {"kind", "failure", "directive_kind", "missing_operand"},
+                label,
+            )
             _assert_type(shape["failure"], str, f"{label}.failure")
             if "directive_kind" in shape and shape["directive_kind"] is not None:
                 _assert_type(shape["directive_kind"], str, f"{label}.directive_kind")

--- a/tests/fixtures/conformance/grammar/grammar_decompose_compound_rejected.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_compound_rejected.json
@@ -8,7 +8,9 @@
   "expected": {
     "directive": {
       "kind": "invalid_directive_syntax",
-      "failure": "compound_directive"
+      "failure": "compound_directive",
+      "directive_kind": null,
+      "missing_operand": null
     }
   }
 }

--- a/tests/fixtures/conformance/grammar/grammar_decompose_invalid_compound_use_and_prohibit_rejected.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_invalid_compound_use_and_prohibit_rejected.json
@@ -8,7 +8,9 @@
   "expected": {
     "directive": {
       "kind": "invalid_directive_syntax",
-      "failure": "compound_directive"
+      "failure": "compound_directive",
+      "directive_kind": null,
+      "missing_operand": null
     }
   }
 }

--- a/tests/fixtures/conformance/grammar/grammar_decompose_invalid_newline_compound_rejected.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_invalid_newline_compound_rejected.json
@@ -8,7 +8,9 @@
   "expected": {
     "directive": {
       "kind": "invalid_directive_syntax",
-      "failure": "compound_directive"
+      "failure": "compound_directive",
+      "directive_kind": null,
+      "missing_operand": null
     }
   }
 }

--- a/tests/fixtures/conformance/grammar/grammar_decompose_invalid_quoted_compound_rejected.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_invalid_quoted_compound_rejected.json
@@ -8,7 +8,9 @@
   "expected": {
     "directive": {
       "kind": "invalid_directive_syntax",
-      "failure": "compound_directive"
+      "failure": "compound_directive",
+      "directive_kind": null,
+      "missing_operand": null
     }
   }
 }

--- a/tests/fixtures/conformance/grammar/grammar_decompose_invalid_set_premise_to_rejected.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_invalid_set_premise_to_rejected.json
@@ -9,7 +9,8 @@
     "directive": {
       "kind": "invalid_directive_syntax",
       "failure": "malformed_directive",
-      "directive_kind": "set_premise"
+      "directive_kind": "set_premise",
+      "missing_operand": null
     }
   }
 }

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -300,6 +300,16 @@ def _validate_grammar_fixture(fixture: dict[str, object], fixture_id: object) ->
         _assert_allowed_keys(action, {"fn", "text"}, fixture_id, "action")
         assert isinstance(action["text"], str), fixture_id
         _assert_allowed_keys(expected, {"directive"}, fixture_id, "expected")
+        directive = expected["directive"]
+        if isinstance(directive, dict) and directive.get("kind") == "invalid_directive_syntax":
+            _assert_allowed_keys(
+                directive,
+                {"kind", "failure", "directive_kind", "missing_operand"},
+                fixture_id,
+                "expected.directive",
+            )
+            assert "directive_kind" in directive, fixture_id
+            assert "missing_operand" in directive, fixture_id
     else:
         _assert_allowed_keys(action, {"fn", "kind", "operands"}, fixture_id, "action")
         assert isinstance(action["kind"], str), fixture_id


### PR DESCRIPTION
## What changed

- Require explicit `directive_kind` and `missing_operand` fields in Python-authored invalid-directive contract validators.
- Add explicit `null` fields to the five affected grammar conformance fixtures.

## Why

- Keeps grammar conformance fixtures aligned with the strengthened portable `InvalidDirectiveSyntax` contract without changing grammar API behavior or consumer harnesses.

## Checklist

- [x] pre-commit run (all hooks passed; temporary writable uv cache used)
- [x] tests pass (`uv run pytest`; 501 passed)
