### PR TITLE
test: add public constructor contract coverage

### DIFF
--- a/tests/_api_contract_harness.py
+++ b/tests/_api_contract_harness.py
@@ -208,6 +208,29 @@ def validate_export_kind(name: str, exported: object, expected_kind: str) -> Non
     raise AssertionError(f"Unsupported export kind {expected_kind!r} for {name}")
 
 
+def validate_constructor_contract(
+    exported: object,
+    export_contract: dict[str, Any],
+    contract: dict[str, Any],
+    label: str,
+) -> None:
+    if export_contract["kind"] != "class":
+        return
+
+    if "signature" not in export_contract:
+        return
+
+    assert_signature_matches(exported, export_contract["signature"], f"{label} constructor")
+    for probe in export_contract.get("construction_probes", []):
+        if "raises" in probe:
+            assert_probe_raises(exported, probe, contract)
+            continue
+        args = [resolve_probe_value(value) for value in probe.get("args", [])]
+        kwargs = {key: resolve_probe_value(value) for key, value in probe.get("kwargs", {}).items()}
+        result = exported(*args, **kwargs)
+        assert_shape(result, probe["return_shape"], contract)
+
+
 def _resolve_exception_type(name: str) -> type[BaseException]:
     builtins_obj = __builtins__
     namespace = builtins_obj if isinstance(builtins_obj, dict) else vars(builtins_obj)
@@ -392,7 +415,7 @@ def _validate_export_member_spec(
     if kind == "callable":
         if not has_signature:
             raise AssertionError(f"{label} callable exports require signature")
-    elif has_signature:
+    elif kind != "class" and has_signature:
         raise AssertionError(f"{label} non-callable exports must not declare signature")
 
     if kind == "constant":

--- a/tests/fixtures/conformance/api/public-api-v2.json
+++ b/tests/fixtures/conformance/api/public-api-v2.json
@@ -76,6 +76,9 @@
       },
       "NoDirectiveDecision": {
         "kind": "class",
+        "signature": {
+          "params": []
+        },
         "construction_probes": [
           {
             "return_shape": {
@@ -83,11 +86,26 @@
               "type": "NoDirectiveDecision",
               "required_attributes": ["kind"]
             }
+          },
+          {
+            "args": ["unexpected"],
+            "raises": {"type": "TypeError"}
+          },
+          {
+            "kwargs": {"value": "unexpected"},
+            "raises": {"type": "TypeError"}
           }
         ]
       },
       "SemanticErrorDecision": {
         "kind": "class",
+        "signature": {
+          "params": [
+            {"name": "failure", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false},
+            {"name": "directive", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false},
+            {"name": "repairs", "kind": "POSITIONAL_OR_KEYWORD", "has_default": true}
+          ]
+        },
         "construction_probes": [
           {
             "kwargs": {
@@ -105,6 +123,29 @@
                 "message"
               ]
             }
+          },
+          {
+            "args": [
+              {"fixture": "item_prohibited_failure"},
+              {"fixture": "use_docker_directive"}
+            ],
+            "return_shape": {
+              "kind": "decision_variant",
+              "type": "SemanticErrorDecision",
+              "required_attributes": ["kind", "failure", "directive", "repairs", "message"]
+            }
+          },
+          {
+            "args": [],
+            "raises": {"type": "TypeError"}
+          },
+          {
+            "kwargs": {
+              "failure": {"fixture": "item_prohibited_failure"},
+              "directive": {"fixture": "use_docker_directive"},
+              "unexpected": true
+            },
+            "raises": {"type": "TypeError"}
           }
         ]
       },
@@ -113,6 +154,11 @@
       },
       "UpdateDecision": {
         "kind": "class",
+        "signature": {
+          "params": [
+            {"name": "changed", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false}
+          ]
+        },
         "construction_probes": [
           {
             "kwargs": {"changed": true},
@@ -121,6 +167,22 @@
               "type": "UpdateDecision",
               "required_attributes": ["kind", "changed"]
             }
+          },
+          {
+            "args": [true],
+            "return_shape": {
+              "kind": "decision_variant",
+              "type": "UpdateDecision",
+              "required_attributes": ["kind", "changed"]
+            }
+          },
+          {
+            "args": [],
+            "raises": {"type": "TypeError"}
+          },
+          {
+            "kwargs": {"value": true},
+            "raises": {"type": "TypeError"}
           }
         ]
       },
@@ -137,7 +199,23 @@
         "value": "update"
       },
       "Engine": {
-        "kind": "class"
+        "kind": "class",
+        "signature": {
+          "params": []
+        },
+        "construction_probes": [
+          {
+            "return_shape": {"kind": "engine_instance"}
+          },
+          {
+            "args": ["unexpected"],
+            "raises": {"type": "TypeError"}
+          },
+          {
+            "kwargs": {"state": {}},
+            "raises": {"type": "TypeError"}
+          }
+        ]
       },
       "POLICY_PROHIBIT": {
         "kind": "constant",

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -21,6 +21,13 @@
       },
       "DirectiveMetadata": {
         "kind": "class",
+        "signature": {
+          "params": [
+            {"name": "kind", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false},
+            {"name": "canonical_start", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false},
+            {"name": "operand_names", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false}
+          ]
+        },
         "construction_probes": [
           {
             "kwargs": {
@@ -38,11 +45,43 @@
                 "item"
               ]
             }
+          },
+          {
+            "args": [
+              "use_item",
+              "use",
+              ["item"]
+            ],
+            "return_shape": {
+              "kind": "directive_metadata",
+              "directive_kind": "use_item",
+              "canonical_start": "use",
+              "operand_names": ["item"]
+            }
+          },
+          {
+            "args": [],
+            "raises": {"type": "TypeError"}
+          },
+          {
+            "kwargs": {
+              "kind": "use_item",
+              "canonical_start": "use",
+              "operand_names": ["item"],
+              "unexpected": true
+            },
+            "raises": {"type": "TypeError"}
           }
         ]
       },
       "CanonicalDirective": {
         "kind": "class",
+        "signature": {
+          "params": [
+            {"name": "kind", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false},
+            {"name": "operands", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false}
+          ]
+        },
         "construction_probes": [
           {
             "kwargs": {
@@ -192,11 +231,57 @@
             "raises": {
               "type": "ValueError"
             }
+          },
+          {
+            "args": [],
+            "raises": {"type": "TypeError"}
+          },
+          {
+            "kwargs": {
+              "kind": "use_item",
+              "operands": {"item": "docker"},
+              "unexpected": true
+            },
+            "raises": {"type": "TypeError"}
           }
         ]
       },
       "InvalidDirectiveSyntax": {
-        "kind": "class"
+        "kind": "class",
+        "signature": {
+          "params": [
+            {"name": "failure", "kind": "POSITIONAL_OR_KEYWORD", "has_default": true},
+            {"name": "directive_kind", "kind": "POSITIONAL_OR_KEYWORD", "has_default": true},
+            {"name": "missing_operand", "kind": "POSITIONAL_OR_KEYWORD", "has_default": true}
+          ]
+        },
+        "construction_probes": [
+          {
+            "return_shape": {
+              "kind": "invalid_directive_syntax",
+              "failure": "malformed_directive",
+              "directive_kind": null,
+              "missing_operand": null
+            }
+          },
+          {
+            "args": [
+              "missing_required_operand",
+              "use_item",
+              "item"
+            ],
+            "return_shape": {
+              "kind": "invalid_directive_syntax",
+              "failure": "missing_required_operand",
+              "directive_kind": "use_item",
+              "missing_operand": "item"
+            }
+          },
+          {
+            "kwargs": {"unexpected": true},
+            "raises": {"type": "TypeError"}
+          }
+        ]
       },
       "get_directive_metadata": {
         "kind": "callable",

--- a/tests/test_api_contract_fixture.py
+++ b/tests/test_api_contract_fixture.py
@@ -6,6 +6,7 @@ from _api_contract_harness import (
     assert_signature_matches,
     load_api_contract,
     resolve_probe_value,
+    validate_constructor_contract,
     validate_engine_member_probes,
     validate_engine_member_runtime,
     validate_export_kind,
@@ -45,7 +46,7 @@ def test_api_contract_fixture_matches_python_public_surface() -> None:
         validate_export_kind(name, exported, export_contract["kind"])
         if "value" in export_contract:
             assert exported == export_contract["value"], name
-        if "signature" in export_contract:
+        if "signature" in export_contract and export_contract["kind"] == "callable":
             assert_signature_matches(exported, export_contract["signature"], name)
         for probe in export_contract.get("shape_probes", []):
             args = [resolve_probe_value(value) for value in probe.get("args", [])]
@@ -54,6 +55,7 @@ def test_api_contract_fixture_matches_python_public_surface() -> None:
             }
             result = exported(*args, **kwargs)
             assert_shape(result, probe["return_shape"], contract)
+        validate_constructor_contract(exported, export_contract, contract, name)
 
     engine = context_compiler.Engine()
     engine_contract = contract["engine"]["public_members"]
@@ -125,6 +127,9 @@ def test_api_contract_fixture_has_unique_entries() -> None:
         assert kind in {"callable", "constant", "type_alias", "type", "class"}, export_name
         if kind == "callable":
             assert "signature" in export_contract, export_name
+        elif kind == "class":
+            if "signature" in export_contract:
+                assert "construction_probes" in export_contract, export_name
         else:
             assert "signature" not in export_contract, export_name
 

--- a/tests/test_api_contract_fixture.py
+++ b/tests/test_api_contract_fixture.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from _api_contract_harness import (
     assert_shape,
     assert_signature_matches,
@@ -17,6 +18,8 @@ import context_compiler
 _CONTRACT_PATH = (
     Path(__file__).resolve().parent / "fixtures" / "conformance" / "api" / "public-api-v2.json"
 )
+
+pytestmark = pytest.mark.contract
 
 
 def _load_contract() -> dict[str, object]:

--- a/tests/test_grammar_api_contract_fixture.py
+++ b/tests/test_grammar_api_contract_fixture.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
 from _api_contract_harness import (
-    assert_probe_raises,
     assert_shape,
     assert_signature_matches,
     load_api_contract,
+    validate_constructor_contract,
     validate_export_kind,
 )
 
@@ -45,12 +45,7 @@ def test_public_grammar_contract_matches_surface() -> None:
                 result = exported(*probe.get("args", []), **probe.get("kwargs", {}))
                 assert_shape(result, probe["return_shape"])
         if member["kind"] == "class":
-            for probe in member.get("construction_probes", []):
-                if "raises" in probe:
-                    assert_probe_raises(exported, probe)
-                    continue
-                result = exported(*probe.get("args", []), **probe.get("kwargs", {}))
-                assert_shape(result, probe["return_shape"])
+            validate_constructor_contract(exported, member, contract, name)
 
 
 def test_public_grammar_contract_exposes_directive_metadata_kind() -> None:


### PR DESCRIPTION
## What changed

- Added constructor contract coverage for all public instantiable classes.
- Added probes for:
  - `Engine`
  - `NoDirectiveDecision`
  - `UpdateDecision`
  - `SemanticErrorDecision`
  - `DirectiveMetadata`
  - `CanonicalDirective`
  - `InvalidDirectiveSyntax`
- Encoded constructor signatures, supported invocation forms, defaults, required arguments, and rejection of unsupported arguments.
- Updated API contract fixtures and harness validation for constructor behavior.
- Marked public API contract tests with the contract pytest marker so they participate in existing contract coverage gates.

## Why

- Ensure constructor shape is part of the cross-language public API contract.
- Prevent TypeScript or other implementations from exposing incompatible initialization behavior while matching methods and fields.
- Strengthen parity validation before consumer migrations.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
