### PR TITLE
test: add Unicode grammar conformance coverage

### DIFF
--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -204,6 +204,11 @@ Permitted lexical normalization is limited to:
    between tokens into a single canonical separator;
 4. matching directive keywords case-insensitively.
 
+Directive keyword matching is ASCII-only. Unicode normalization is not applied
+to directive keywords: NFC, NFD, NFKC, and NFKD compatibility or composition
+forms must not turn non-ASCII characters into valid directive keywords. ASCII
+case-insensitivity maps only `A`-`Z` to `a`-`z`.
+
 Additional limits:
 
 1. Keyword case-insensitivity applies only to directive keywords and fixed

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -72,6 +72,17 @@ parser/no_directive outcomes. Direct grammar classification belongs to the
 freeze every ambiguous natural-language edge case as part of the cross-language
 contract.
 
+## Grammar fixtures
+
+For [`conformance/grammar/`](conformance/grammar/):
+
+These fixtures define portable decomposition and rendering behavior for the
+directive grammar. Directive keywords are matched case-insensitively only
+within the ASCII alphabet. Ports must not apply Unicode normalization to
+keywords, including NFC, NFD, NFKC, or NFKD, when deciding whether input is a
+directive. Unicode composition and decomposition in operands remains operand
+text and must not be rewritten by grammar parsing.
+
 ## Apply-directive fixtures
 
 For [`conformance/apply-directive/`](conformance/apply-directive/):

--- a/tests/fixtures/conformance/grammar/grammar_decompose_compatibility_keyword_rejected.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_compatibility_keyword_rejected.json
@@ -1,0 +1,11 @@
+{
+  "id": "grammar_decompose_compatibility_keyword_rejected",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "ⓤⓢⓔ docker"
+  },
+  "expected": {
+    "directive": null
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_composed_operand_preserved.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_composed_operand_preserved.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_composed_operand_preserved",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "use café"
+  },
+  "expected": {
+    "directive": {
+      "text": "use café",
+      "kind": "use_item",
+      "operands": {
+        "item": "café"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_decomposed_keyword_variant_rejected.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_decomposed_keyword_variant_rejected.json
@@ -1,0 +1,11 @@
+{
+  "id": "grammar_decompose_decomposed_keyword_variant_rejected",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "üse docker"
+  },
+  "expected": {
+    "directive": null
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_decomposed_operand_preserved.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_decomposed_operand_preserved.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_decomposed_operand_preserved",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "use café"
+  },
+  "expected": {
+    "directive": {
+      "text": "use café",
+      "kind": "use_item",
+      "operands": {
+        "item": "café"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_fullwidth_keyword_rejected.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_fullwidth_keyword_rejected.json
@@ -1,0 +1,11 @@
+{
+  "id": "grammar_decompose_fullwidth_keyword_rejected",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "ｕｓｅ docker"
+  },
+  "expected": {
+    "directive": null
+  }
+}


### PR DESCRIPTION
## What changed

- Add grammar conformance fixtures for Unicode compatibility and composed/decomposed normalization edge cases.
- Explicitly document ASCII-only directive keyword matching and preserve operand text during grammar parsing.

## Why

- Make the portable grammar contract explicit without broadening keyword acceptance through Unicode normalization.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
