### PR TITLE
test: add Unicode casefold identity fixtures

### DIFF
--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -566,6 +566,10 @@ Observable consequences:
 
 - policy comparison is case-insensitive;
 - repeated internal whitespace does not create a distinct policy identity;
+- canonical-equivalent or compatibility-equivalent Unicode forms that produce
+  the same NFKC value do not create a distinct policy identity;
+- accent differences that remain after NFKC, such as `cafe` and `café`, remain
+  distinct policy identities;
 - equivalent apostrophe characters normalized by Section 10.1 do not create a
   distinct policy identity.
 

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -570,6 +570,8 @@ Observable consequences:
   the same NFKC value do not create a distinct policy identity;
 - accent differences that remain after NFKC, such as `cafe` and `café`, remain
   distinct policy identities;
+- Unicode casefold mappings are applied, including `ſ` with `s`, `ß` with
+  `ss`, and Greek final sigma `ς` with `σ`;
 - equivalent apostrophe characters normalized by Section 10.1 do not create a
   distinct policy identity.
 

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -70,7 +70,9 @@ Shared `step` fixtures intentionally cover representative engine-observable
 parser/no_directive outcomes. Direct grammar classification belongs to the
 `conformance/grammar/` fixture family. The step fixtures do not attempt to
 freeze every ambiguous natural-language edge case as part of the cross-language
-contract.
+contract. Policy-identity fixtures in this family cover semantic normalization
+after grammar parsing; they do not authorize grammar-layer keyword or operand
+rewriting.
 
 ## Grammar fixtures
 

--- a/tests/fixtures/conformance/grammar/grammar_decompose_casefold_operand_preserved.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_casefold_operand_preserved.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_casefold_operand_preserved",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "use ſtraße"
+  },
+  "expected": {
+    "directive": {
+      "text": "use ſtraße",
+      "kind": "use_item",
+      "operands": {
+        "item": "ſtraße"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_unicode_casefold_set_keyword_rejected.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_unicode_casefold_set_keyword_rejected.json
@@ -1,0 +1,11 @@
+{
+  "id": "grammar_decompose_unicode_casefold_set_keyword_rejected",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "ſet premise concise"
+  },
+  "expected": {
+    "directive": null
+  }
+}

--- a/tests/fixtures/conformance/step/step_policy_identity_accent_distinct_update.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_accent_distinct_update.json
@@ -1,0 +1,27 @@
+{
+  "id": "step_policy_identity_accent_distinct_update",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "prelude": [
+    "use cafe"
+  ],
+  "input": "use café",
+  "expected": {
+    "decision": {
+      "kind": "update",
+      "changed": true
+    },
+    "state": {
+      "premise": null,
+      "policies": {
+        "cafe": "use",
+        "café": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_policy_identity_composed_decomposed_equivalent_noop_update.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_composed_decomposed_equivalent_noop_update.json
@@ -1,0 +1,26 @@
+{
+  "id": "step_policy_identity_composed_decomposed_equivalent_noop_update",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "prelude": [
+    "use café"
+  ],
+  "input": "use café",
+  "expected": {
+    "decision": {
+      "kind": "update",
+      "changed": false
+    },
+    "state": {
+      "premise": null,
+      "policies": {
+        "café": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_policy_identity_final_sigma_casefold_noop_update.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_final_sigma_casefold_noop_update.json
@@ -1,0 +1,26 @@
+{
+  "id": "step_policy_identity_final_sigma_casefold_noop_update",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "prelude": [
+    "use ς"
+  ],
+  "input": "use σ",
+  "expected": {
+    "decision": {
+      "kind": "update",
+      "changed": false
+    },
+    "state": {
+      "premise": null,
+      "policies": {
+        "σ": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_policy_identity_long_s_casefold_noop_update.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_long_s_casefold_noop_update.json
@@ -1,0 +1,26 @@
+{
+  "id": "step_policy_identity_long_s_casefold_noop_update",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "prelude": [
+    "use ſ"
+  ],
+  "input": "use s",
+  "expected": {
+    "decision": {
+      "kind": "update",
+      "changed": false
+    },
+    "state": {
+      "premise": null,
+      "policies": {
+        "s": "use"
+      },
+      "version": 2
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_policy_identity_sharp_s_casefold_noop_update.json
+++ b/tests/fixtures/conformance/step/step_policy_identity_sharp_s_casefold_noop_update.json
@@ -1,0 +1,26 @@
+{
+  "id": "step_policy_identity_sharp_s_casefold_noop_update",
+  "kind": "step",
+  "initial_state": {
+    "premise": null,
+    "policies": {},
+    "version": 2
+  },
+  "prelude": [
+    "use ß"
+  ],
+  "input": "use ss",
+  "expected": {
+    "decision": {
+      "kind": "update",
+      "changed": false
+    },
+    "state": {
+      "premise": null,
+      "policies": {
+        "ss": "use"
+      },
+      "version": 2
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- Add portable grammar coverage proving casefold-like keyword variants remain rejected while operand spelling is preserved.
- Add semantic identity fixtures for Python casefold equivalences: long s (`ſ`/`s`), sharp s (`ß`/`ss`), and Greek final sigma (`ς`/`σ`).
- Clarify the policy identity contract in the grammar specification.

## Why

- Ensure TypeScript ports match Python semantic identity behavior without applying Unicode casefolding to directive keyword matching or grammar operands.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
