### PR TITLE
test: expand public API contract coverage

### DIFF
--- a/tests/_api_contract_harness.py
+++ b/tests/_api_contract_harness.py
@@ -228,7 +228,30 @@ def validate_constructor_contract(
         args = [resolve_probe_value(value) for value in probe.get("args", [])]
         kwargs = {key: resolve_probe_value(value) for key, value in probe.get("kwargs", {}).items()}
         result = exported(*args, **kwargs)
+        for field in export_contract.get("public_fields", []):
+            assert hasattr(result, field), f"{label}.{field}"
         assert_shape(result, probe["return_shape"], contract)
+
+
+def validate_immutable_definition(
+    exported: object, export_contract: dict[str, Any], label: str
+) -> None:
+    if not export_contract.get("immutable_definition"):
+        return
+
+    member_values = export_contract["member_values"]
+    for member_name, expected_value in member_values.items():
+        member = getattr(exported, member_name)
+        assert member.value == expected_value, f"{label}.{member_name} value changed"
+        try:
+            setattr(exported, member_name, object())
+        except (AttributeError, TypeError):
+            pass
+        else:
+            raise AssertionError(f"{label}.{member_name} can be reassigned")
+        assert getattr(exported, member_name).value == expected_value, (
+            f"{label}.{member_name} value changed"
+        )
 
 
 def _resolve_exception_type(name: str) -> type[BaseException]:
@@ -400,7 +423,16 @@ def _validate_export_member_spec(
     _assert_type(member_spec, dict, label)
     _assert_closed_keys(
         member_spec,
-        {"kind", "value", "signature", "shape_probes", "construction_probes"},
+        {
+            "kind",
+            "value",
+            "signature",
+            "shape_probes",
+            "construction_probes",
+            "public_fields",
+            "immutable_definition",
+            "member_values",
+        },
         label,
     )
     _require_fields(member_spec, {"kind"}, label)
@@ -426,6 +458,23 @@ def _validate_export_member_spec(
 
     if has_signature:
         _validate_signature_spec(member_spec["signature"], f"{label}.signature")
+
+    if "public_fields" in member_spec:
+        _assert_unique_strings(member_spec["public_fields"], f"{label}.public_fields")
+        if kind != "class":
+            raise AssertionError(f"{label}.public_fields only applies to class exports")
+
+    immutable = member_spec.get("immutable_definition", False)
+    if not isinstance(immutable, bool):
+        raise AssertionError(f"{label}.immutable_definition must be boolean")
+    if immutable:
+        if kind != "class":
+            raise AssertionError(f"{label}.immutable_definition only applies to class exports")
+        member_values = member_spec.get("member_values")
+        _assert_type(member_values, dict, f"{label}.member_values")
+        _assert_string_keyed_dict(member_values, f"{label}.member_values")
+    elif "member_values" in member_spec:
+        raise AssertionError(f"{label}.member_values requires immutable_definition")
 
     probes = member_spec.get("shape_probes", [])
     _validate_shape_probes(probes, f"{label}.shape_probes")

--- a/tests/fixtures/conformance/api/public-api-v2.json
+++ b/tests/fixtures/conformance/api/public-api-v2.json
@@ -72,7 +72,13 @@
         "kind": "type_alias"
       },
       "DecisionKind": {
-        "kind": "class"
+        "kind": "class",
+        "immutable_definition": true,
+        "member_values": {
+          "NO_DIRECTIVE": "no_directive",
+          "UPDATE": "update",
+          "ERROR": "error"
+        }
       },
       "NoDirectiveDecision": {
         "kind": "class",
@@ -150,7 +156,17 @@
         ]
       },
       "SemanticFailure": {
-        "kind": "class"
+        "kind": "class",
+        "immutable_definition": true,
+        "member_values": {
+          "PREMISE_ALREADY_SET": "premise_already_set",
+          "PREMISE_NOT_SET": "premise_not_set",
+          "ITEM_PROHIBITED": "item_prohibited",
+          "ITEM_ALREADY_IN_USE": "item_already_in_use",
+          "REPLACEMENT_SOURCE_PROHIBITED": "replacement_source_prohibited",
+          "REPLACEMENT_TARGET_PROHIBITED": "replacement_target_prohibited",
+          "REPLACEMENT_SOURCE_MISSING": "replacement_source_missing"
+        }
       },
       "UpdateDecision": {
         "kind": "class",

--- a/tests/fixtures/conformance/api/public-grammar-v1.json
+++ b/tests/fixtures/conformance/api/public-grammar-v1.json
@@ -14,13 +14,32 @@
     ],
     "members": {
       "DirectiveKind": {
-        "kind": "class"
+        "kind": "class",
+        "immutable_definition": true,
+        "member_values": {
+          "SET_PREMISE": "set_premise",
+          "CHANGE_PREMISE": "change_premise",
+          "USE_ITEM": "use_item",
+          "PROHIBIT_ITEM": "prohibit_item",
+          "REMOVE_POLICY": "remove_policy",
+          "REPLACE_USE": "replace_use",
+          "CLEAR_PREMISE": "clear_premise",
+          "RESET_POLICIES": "reset_policies",
+          "CLEAR_STATE": "clear_state"
+        }
       },
       "DirectiveSyntaxFailure": {
-        "kind": "class"
+        "kind": "class",
+        "immutable_definition": true,
+        "member_values": {
+          "COMPOUND_DIRECTIVE": "compound_directive",
+          "MISSING_REQUIRED_OPERAND": "missing_required_operand",
+          "MALFORMED_DIRECTIVE": "malformed_directive"
+        }
       },
       "DirectiveMetadata": {
         "kind": "class",
+        "public_fields": ["kind", "canonical_start", "operand_names"],
         "signature": {
           "params": [
             {"name": "kind", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false},
@@ -76,6 +95,7 @@
       },
       "CanonicalDirective": {
         "kind": "class",
+        "public_fields": ["kind", "operands", "text"],
         "signature": {
           "params": [
             {"name": "kind", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false},
@@ -248,6 +268,7 @@
       },
       "InvalidDirectiveSyntax": {
         "kind": "class",
+        "public_fields": ["failure", "directive_kind", "missing_operand"],
         "signature": {
           "params": [
             {"name": "failure", "kind": "POSITIONAL_OR_KEYWORD", "has_default": true},

--- a/tests/test_api_contract_fixture.py
+++ b/tests/test_api_contract_fixture.py
@@ -11,6 +11,7 @@ from _api_contract_harness import (
     validate_engine_member_probes,
     validate_engine_member_runtime,
     validate_export_kind,
+    validate_immutable_definition,
 )
 
 import context_compiler
@@ -47,6 +48,7 @@ def test_api_contract_fixture_matches_python_public_surface() -> None:
     for name, export_contract in export_members.items():
         exported = getattr(context_compiler, name)
         validate_export_kind(name, exported, export_contract["kind"])
+        validate_immutable_definition(exported, export_contract, name)
         if "value" in export_contract:
             assert exported == export_contract["value"], name
         if "signature" in export_contract and export_contract["kind"] == "callable":

--- a/tests/test_grammar_api_contract_fixture.py
+++ b/tests/test_grammar_api_contract_fixture.py
@@ -6,6 +6,7 @@ from _api_contract_harness import (
     load_api_contract,
     validate_constructor_contract,
     validate_export_kind,
+    validate_immutable_definition,
 )
 
 import context_compiler.grammar as grammar
@@ -39,6 +40,7 @@ def test_public_grammar_contract_matches_surface() -> None:
     for name, member in members.items():
         exported = getattr(grammar, name)
         validate_export_kind(name, exported, member["kind"])
+        validate_immutable_definition(exported, member, name)
         if member["kind"] == "callable":
             assert_signature_matches(exported, member["signature"], name)
             for probe in member.get("shape_probes", []):


### PR DESCRIPTION
## What changed

- Extend API and grammar conformance fixtures for immutable enum definitions and public class fields.
- Add harness validation for enum immutability and declared public fields.

## Why

- Make the portable public API and grammar contract explicitly verify immutable definitions and exposed fields across implementations.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)