### PR TITLE
fix: make premise operands opaque

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ set premise concise replies
 - Base model: silently accepts / rewrites
 - Context Compiler: applies a repeatable state update
 
-### Single-directive grammar
+### Compound directive rejection
 
 ```text
 use docker and prohibit peanuts
@@ -458,7 +458,8 @@ User: reset policies
 User: clear state
 ```
 
-Grammar invariant: one input may contain at most one canonical directive.
+Grammar invariant: a single input never applies more than one canonical
+directive.
 Directive-shaped invalid input is outside the canonical language, and
 `error` is reserved for canonical directives that later fail semantic
 evaluation against authoritative state.
@@ -482,9 +483,14 @@ clear state
 
 Invalid:
 use docker and prohibit peanuts
-set premise vegetarian and use docker
 clear state then set premise new project
+
+Premise payload (opaque):
+set premise vegetarian and use docker
 ```
+
+Policy compounds such as `use docker and prohibit peanuts` remain invalid;
+premise `VALUE` is opaque and may contain directive-like words.
 
 Quote behavior follows the current grammar literally:
 
@@ -494,6 +500,8 @@ Passthrough:
 
 Invalid:
 use "docker and prohibit peanuts"
+
+Canonical directive:
 set premise "use docker and prohibit peanuts"
 ```
 

--- a/docs/DirectiveGrammarSpec.md
+++ b/docs/DirectiveGrammarSpec.md
@@ -325,9 +325,11 @@ Rules:
 
 - must contain at least one non-whitespace character;
 - may contain spaces and punctuation;
+- is opaque payload: directive keywords, conjunctions, and multiple sentences
+  inside `VALUE` are not inspected as embedded directives;
 - has no quote-aware or escape-aware subgrammar;
-- is rejected if the full input would otherwise constitute a compound attempt
-  under Section 7.5.
+- a separate canonical directive beginning on a new line is still rejected as
+  a compound attempt under Section 7.5.
 
 Canonical meaning:
 
@@ -445,21 +447,23 @@ contains more than one attempted directive clause. This includes inputs such
 as:
 
 - `use docker and prohibit peanuts`
-- `set premise vegetarian and use docker`
+- `set premise vegetarian and use docker` is one premise directive; `VALUE` is
+  opaque and may contain policy words or conjunctions.
 - `clear state then set premise new project`
 
 This rule is lexical and grammar-level. It is not a semantic conflict rule.
 
-The grammar does not define quoting or escaping syntax to protect embedded
-directive text inside operands. Therefore, if raw input both begins like a
-directive attempt and later contains another directive attempt, the full input
-is outside the canonical language.
+Premise `VALUE` is payload rather than a policy identity. The grammar does not
+inspect embedded directive words, conjunctions, or sentence boundaries inside
+it. A separate canonical directive beginning on a new line is still treated as
+a compound attempt. `ITEM` operands retain the compound-detection behavior
+described above.
 
 Examples:
 
 - no_directive: `"use docker and prohibit peanuts"`
 - directive-shaped invalid: `use "docker and prohibit peanuts"`
-- directive-shaped invalid: `set premise "use docker and prohibit peanuts"`
+- canonical directive: `set premise "use docker and prohibit peanuts"`
 
 ## 8. Parsed Meaning and Semantic Boundary
 
@@ -761,7 +765,7 @@ source material for later conformance fixtures.
 | `use docker and prohibit peanuts` | directive-shaped invalid input | none | compound attempt |
 | `clear state then set premise project` | directive-shaped invalid input | none | compound attempt |
 | `use "docker and prohibit peanuts"` | directive-shaped invalid input | none | quotes do not protect embedded directive text |
-| `set premise "use docker and prohibit peanuts"` | directive-shaped invalid input | none | quotes do not protect embedded directive text |
+| `set premise "use docker and prohibit peanuts"` | canonical directive | set premise | premise `VALUE` is opaque payload, including quote characters |
 
 ## 12. Invariants
 

--- a/src/context_compiler/grammar.py
+++ b/src/context_compiler/grammar.py
@@ -352,6 +352,18 @@ def _contains_multiple_canonical_directives(text: str) -> bool:
     return False
 
 
+def _contains_multiple_premise_directives(text: str) -> bool:
+    """Report premise compounds without inspecting opaque premise payload text."""
+    first_start = _match_canonical_directive_start(text, 0)
+    if first_start is None:
+        return False
+
+    for index, character in enumerate(text[first_start:], start=first_start):
+        if character == "\n" and _match_canonical_directive_start(text, index + 1) is not None:
+            return True
+    return False
+
+
 def _starts_with_directive_family(text: str) -> bool:
     for token, require_space_or_end in _DIRECTIVE_FAMILY_STARTS:
         if (
@@ -460,7 +472,12 @@ def _validate_operand_constraints(kind: DirectiveKind, operands: Mapping[str, st
 
 def _validate_rendered_canonical_shape(kind: DirectiveKind, operands: Mapping[str, str]) -> None:
     rendered = _serialize_canonical_directive(kind, MappingProxyType(dict(operands)))
-    if _contains_multiple_canonical_directives(rendered):
+    contains_compound = (
+        _contains_multiple_premise_directives(rendered)
+        if kind in {DirectiveKind.SET_PREMISE, DirectiveKind.CHANGE_PREMISE}
+        else _contains_multiple_canonical_directives(rendered)
+    )
+    if contains_compound:
         raise ValueError(f"Operands do not produce a canonical {kind.value} directive.")
 
 
@@ -479,7 +496,15 @@ def decompose_directive(text: str) -> CanonicalDirective | InvalidDirectiveSynta
         return None
     if not _starts_with_directive_family(trimmed_text):
         return None
-    if _contains_multiple_canonical_directives(trimmed_text):
+    premise_directive = _match_directive_token(
+        trimmed_text, 0, _SET_PREMISE_START, require_space_or_end=True
+    ) or _match_directive_token(trimmed_text, 0, _CHANGE_PREMISE_START, require_space_or_end=True)
+    contains_compound = (
+        _contains_multiple_premise_directives(trimmed_text)
+        if premise_directive is not None
+        else _contains_multiple_canonical_directives(trimmed_text)
+    )
+    if contains_compound:
         return _invalid_directive_syntax(DirectiveSyntaxFailure.COMPOUND_DIRECTIVE)
 
     normalized = _normalized_for_matching(trimmed_text)

--- a/tests/fixtures/conformance/grammar/grammar_decompose_opaque_premise_conjunction.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_opaque_premise_conjunction.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_opaque_premise_conjunction",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "set premise vegetarian and use docker"
+  },
+  "expected": {
+    "directive": {
+      "text": "set premise vegetarian and use docker",
+      "kind": "set_premise",
+      "operands": {
+        "value": "vegetarian and use docker"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_opaque_premise_multi_sentence.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_opaque_premise_multi_sentence.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_opaque_premise_multi_sentence",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "set premise The system uses legacy tooling. Migration is planned."
+  },
+  "expected": {
+    "directive": {
+      "text": "set premise The system uses legacy tooling. Migration is planned.",
+      "kind": "set_premise",
+      "operands": {
+        "value": "The system uses legacy tooling. Migration is planned."
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_opaque_premise_prohibit.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_opaque_premise_prohibit.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_opaque_premise_prohibit",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "set premise users may prohibit unsafe operations"
+  },
+  "expected": {
+    "directive": {
+      "text": "set premise users may prohibit unsafe operations",
+      "kind": "set_premise",
+      "operands": {
+        "value": "users may prohibit unsafe operations"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/grammar/grammar_decompose_opaque_premise_use.json
+++ b/tests/fixtures/conformance/grammar/grammar_decompose_opaque_premise_use.json
@@ -1,0 +1,17 @@
+{
+  "id": "grammar_decompose_opaque_premise_use",
+  "kind": "grammar",
+  "action": {
+    "fn": "decompose_directive",
+    "text": "set premise we must use gaap"
+  },
+  "expected": {
+    "directive": {
+      "text": "set premise we must use gaap",
+      "kind": "set_premise",
+      "operands": {
+        "value": "we must use gaap"
+      }
+    }
+  }
+}

--- a/tests/fixtures/conformance/step/step_compound_set_premise_and_use_invalid_boundary.json
+++ b/tests/fixtures/conformance/step/step_compound_set_premise_and_use_invalid_boundary.json
@@ -9,10 +9,11 @@
   "input": "set premise vegetarian and use docker",
   "expected": {
     "decision": {
-      "kind": "no_directive"
+      "kind": "update",
+      "changed": true
     },
     "state": {
-      "premise": null,
+      "premise": "vegetarian and use docker",
       "policies": {},
       "version": 2
     }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1493,14 +1493,6 @@ def test_export_import_round_trip_preserves_distinct_normalized_policy_keys() ->
             {"premise": None, "policies": {}, "version": 2},
         ),
         (
-            "set premise vegetarian curry and prohibit peanuts",
-            {"premise": None, "policies": {}, "version": 2},
-        ),
-        (
-            "change premise to vegan curry or use docker",
-            {"premise": "baseline", "policies": {}, "version": 2},
-        ),
-        (
             "remove policy docker and use podman",
             {"premise": None, "policies": {"docker": "use"}, "version": 2},
         ),
@@ -1522,10 +1514,6 @@ def test_export_import_round_trip_preserves_distinct_normalized_policy_keys() ->
         ),
         (
             'use "docker and prohibit peanuts"',
-            {"premise": None, "policies": {}, "version": 2},
-        ),
-        (
-            'set premise "use docker and prohibit peanuts"',
             {"premise": None, "policies": {}, "version": 2},
         ),
         (

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -517,6 +517,7 @@ def test_apply_directive_fixtures() -> None:
         assert _state_observation(engine) == expected["state"], fixture_id
 
 
+@pytest.mark.contract
 def test_grammar_fixtures() -> None:
     for path in _json_files(_GRAMMAR_FIXTURES_DIR):
         fixture = _load(path)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -86,6 +86,31 @@ def test_directive_metadata_is_frozen_and_slotted() -> None:
     ("text", "expected_kind", "expected_operands"),
     [
         ("set premise concise replies", DirectiveKind.SET_PREMISE, {"value": "concise replies"}),
+        (
+            "set premise we must use gaap",
+            DirectiveKind.SET_PREMISE,
+            {"value": "we must use gaap"},
+        ),
+        (
+            "set premise users may prohibit unsafe operations",
+            DirectiveKind.SET_PREMISE,
+            {"value": "users may prohibit unsafe operations"},
+        ),
+        (
+            "set premise vegetarian and use docker",
+            DirectiveKind.SET_PREMISE,
+            {"value": "vegetarian and use docker"},
+        ),
+        (
+            "set premise The system uses legacy tooling. Migration is planned.",
+            DirectiveKind.SET_PREMISE,
+            {"value": "The system uses legacy tooling. Migration is planned."},
+        ),
+        (
+            "change premise to use docker for compatibility",
+            DirectiveKind.CHANGE_PREMISE,
+            {"value": "use docker for compatibility"},
+        ),
         ("change premise to formal tone", DirectiveKind.CHANGE_PREMISE, {"value": "formal tone"}),
         ("use docker", DirectiveKind.USE_ITEM, {"item": "docker"}),
         ("prohibit peanuts", DirectiveKind.PROHIBIT_ITEM, {"item": "peanuts"}),
@@ -380,11 +405,6 @@ def test_render_directive_outputs_exact_canonical_syntax(
             "canonical use_item directive",
         ),
         (
-            DirectiveKind.SET_PREMISE,
-            {"value": "use docker and prohibit peanuts"},
-            "canonical set_premise directive",
-        ),
-        (
             DirectiveKind.USE_ITEM,
             {"item": "docker instead of podman"},
             "canonical use_item directive",
@@ -543,11 +563,6 @@ def test_serialize_canonical_directive_rejects_unsupported_kind() -> None:
             DirectiveKind.USE_ITEM,
             {"item": "docker and prohibit peanuts"},
             "canonical use_item directive",
-        ),
-        (
-            DirectiveKind.SET_PREMISE,
-            {"value": "use docker and prohibit peanuts"},
-            "canonical set_premise directive",
         ),
         (
             DirectiveKind.USE_ITEM,

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -673,6 +673,10 @@ def test_internal_contains_multiple_canonical_directives_reports_compound_detect
     assert grammar_module._contains_multiple_canonical_directives(text) is expected
 
 
+def test_internal_contains_multiple_premise_directives_ignores_non_directive_text() -> None:
+    assert grammar_module._contains_multiple_premise_directives("hello there") is False
+
+
 def test_parse_replace_use_rejects_blank_new_item() -> None:
     assert grammar_module._parse_replace_use("use \t instead of docker") is None
 


### PR DESCRIPTION
## What changed

- Make premise `VALUE` operands opaque to compound directive detection.
- Preserve policy `ITEM` compound detection.
- Add grammar/conformance coverage and update README/spec wording.

## Why

Premise payloads can contain directive-like words, conjunctions, and multiple sentences without being misclassified as compound policy directives.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)