### PR TITLE
chore: bump version to dev14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,13 @@ jobs:
         if: matrix.python-version == '3.12'
         run: uv run pytest --cov=context_compiler --cov-report=term --cov-report=xml:coverage.xml --cov-report=html:htmlcov
 
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+
       - name: Pytest
         if: matrix.python-version != '3.12'
         run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/context-compiler)](https://pypi.org/project/context-compiler/)
 [![Python versions](https://img.shields.io/pypi/pyversions/context-compiler)](https://pypi.org/project/context-compiler/)
 [![License](https://img.shields.io/pypi/l/context-compiler)](https://pypi.org/project/context-compiler/)
+[![codecov](https://codecov.io/gh/rlippmann/context-compiler/branch/main/graph/badge.svg)](https://codecov.io/gh/rlippmann/context-compiler)
 
 Context Compiler is a deterministic conversational state authority for LLM applications.
 It handles canonical directive execution, semantic validation, terminal error
@@ -250,6 +251,10 @@ uv sync --dev
 uv run pytest
 ```
 
+CI enforces 100% coverage for the core `src/context_compiler` package. The
+coverage badge represents that authoritative core-package target, not the
+entire repository.
+
 ## Decision API
 
 Each user message produces one immutable `Decision` variant. Use concrete
@@ -495,13 +500,13 @@ premise `VALUE` is opaque and may contain directive-like words.
 Quote behavior follows the current grammar literally:
 
 ```text
-Passthrough:
+Passthrough (`no_directive`):
 "use docker and prohibit peanuts"
 
-Invalid:
+Invalid directive:
 use "docker and prohibit peanuts"
 
-Canonical directive:
+Canonical directive (`set premise`):
 set premise "use docker and prohibit peanuts"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.9.0dev13"
+version = "0.9.0dev14"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.9.0.dev13"
+version = "0.9.0.dev14"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- Bump the package version from `0.9.0dev13` to `0.9.0dev14`.
- Synchronize `uv.lock` with the new package version.

## Why

Prepare the repository metadata for the `0.9.0dev14` development release.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)