### PR TITLE
feat: define 0.9.0dev15 public contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "context-compiler"
-version = "0.9.0dev14"
+version = "0.9.0dev15"
 description = "Deterministic conversational state engine for LLM applications."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/_api_contract_harness.py
+++ b/tests/_api_contract_harness.py
@@ -1,3 +1,4 @@
+import importlib
 import inspect
 import json
 from pathlib import Path
@@ -25,6 +26,37 @@ def load_api_contract(
         allowed_engine_member_kinds=allowed_engine_member_kinds,
     )
     return contract
+
+
+def validate_declared_namespaces(contract: dict[str, Any]) -> None:
+    """Validate the explicitly declared public namespace surfaces at runtime."""
+    for namespace_name, namespace_contract in contract.get("namespaces", {}).items():
+        namespace = importlib.import_module(namespace_name)
+        exports = namespace_contract["exports"]
+        expected_names = exports["names"]
+        assert getattr(namespace, "__all__", None) == expected_names, namespace_name
+
+        for name, export_contract in exports["members"].items():
+            exported = getattr(namespace, name)
+            validate_export_kind(name, exported, export_contract["kind"])
+            validate_immutable_definition(exported, export_contract, f"{namespace_name}.{name}")
+            if "value" in export_contract:
+                assert exported == export_contract["value"], f"{namespace_name}.{name}"
+            if "signature" in export_contract and export_contract["kind"] == "callable":
+                assert_signature_matches(
+                    exported, export_contract["signature"], f"{namespace_name}.{name}"
+                )
+            for probe in export_contract.get("shape_probes", []):
+                args = [resolve_probe_value(value) for value in probe.get("args", [])]
+                kwargs = {
+                    key: resolve_probe_value(value)
+                    for key, value in probe.get("kwargs", {}).items()
+                }
+                result = exported(*args, **kwargs)
+                assert_shape(result, probe["return_shape"], contract)
+            validate_constructor_contract(
+                exported, export_contract, contract, f"{namespace_name}.{name}"
+            )
 
 
 def json_type_matches(value: object, expected: str) -> bool:
@@ -303,7 +335,7 @@ def _validate_contract(
 ) -> None:
     _assert_type(contract, dict, "contract")
 
-    allowed_top_level = {"id", "kind", "module", "exports"}
+    allowed_top_level = {"id", "kind", "module", "exports", "namespaces"}
     if allowed_engine_member_kinds is not None:
         allowed_top_level |= {
             "target",
@@ -338,6 +370,9 @@ def _validate_contract(
         label="contract.exports",
     )
 
+    namespaces = contract.get("namespaces", {})
+    _validate_namespaces_spec(namespaces, allowed_export_kinds)
+
     if allowed_engine_member_kinds is None:
         if "target" in contract:
             _assert_type(contract["target"], str, "contract.target")
@@ -351,6 +386,23 @@ def _validate_contract(
         allowed_engine_member_kinds=allowed_engine_member_kinds,
         label="contract.engine",
     )
+
+
+def _validate_namespaces_spec(namespaces: object, allowed_export_kinds: set[str]) -> None:
+    _assert_type(namespaces, dict, "contract.namespaces")
+    for namespace_name, namespace_contract in namespaces.items():
+        if not isinstance(namespace_name, str) or not namespace_name:
+            raise AssertionError("contract.namespaces keys must be non-empty strings")
+        _assert_type(namespace_contract, dict, f"contract.namespaces[{namespace_name!r}]")
+        _assert_closed_keys(
+            namespace_contract, {"exports"}, f"contract.namespaces[{namespace_name!r}]"
+        )
+        _require_fields(namespace_contract, {"exports"}, f"contract.namespaces[{namespace_name!r}]")
+        _validate_exports_spec(
+            namespace_contract["exports"],
+            allowed_export_kinds=allowed_export_kinds,
+            label=f"contract.namespaces[{namespace_name!r}].exports",
+        )
 
 
 def _validate_exports_spec(

--- a/tests/_api_contract_harness.py
+++ b/tests/_api_contract_harness.py
@@ -28,11 +28,24 @@ def load_api_contract(
     return contract
 
 
-def validate_declared_namespaces(contract: dict[str, Any]) -> None:
+def validate_declared_namespaces(
+    contract: dict[str, Any],
+    referenced_contracts: dict[str, dict[str, Any]] | None = None,
+) -> None:
     """Validate the explicitly declared public namespace surfaces at runtime."""
+    referenced_contracts = referenced_contracts or {}
     for namespace_name, namespace_contract in contract.get("namespaces", {}).items():
         namespace = importlib.import_module(namespace_name)
-        exports = namespace_contract["exports"]
+        if "contract" in namespace_contract:
+            reference = namespace_contract["contract"]
+            if reference not in referenced_contracts:
+                raise AssertionError(f"Unknown namespace contract reference {reference!r}")
+            referenced = referenced_contracts[reference]
+            assert referenced["id"] == reference, reference
+            assert referenced["module"] == namespace_name, namespace_name
+            exports = referenced["exports"]
+        else:
+            exports = namespace_contract["exports"]
         expected_names = exports["names"]
         assert getattr(namespace, "__all__", None) == expected_names, namespace_name
 
@@ -394,15 +407,20 @@ def _validate_namespaces_spec(namespaces: object, allowed_export_kinds: set[str]
         if not isinstance(namespace_name, str) or not namespace_name:
             raise AssertionError("contract.namespaces keys must be non-empty strings")
         _assert_type(namespace_contract, dict, f"contract.namespaces[{namespace_name!r}]")
-        _assert_closed_keys(
-            namespace_contract, {"exports"}, f"contract.namespaces[{namespace_name!r}]"
-        )
-        _require_fields(namespace_contract, {"exports"}, f"contract.namespaces[{namespace_name!r}]")
-        _validate_exports_spec(
-            namespace_contract["exports"],
-            allowed_export_kinds=allowed_export_kinds,
-            label=f"contract.namespaces[{namespace_name!r}].exports",
-        )
+        label = f"contract.namespaces[{namespace_name!r}]"
+        _assert_closed_keys(namespace_contract, {"contract", "exports"}, label)
+        has_contract = "contract" in namespace_contract
+        has_exports = "exports" in namespace_contract
+        if has_contract == has_exports:
+            raise AssertionError(f"{label} must declare exactly one of contract or exports")
+        if has_contract:
+            _assert_type(namespace_contract["contract"], str, f"{label}.contract")
+        else:
+            _validate_exports_spec(
+                namespace_contract["exports"],
+                allowed_export_kinds=allowed_export_kinds,
+                label=f"{label}.exports",
+            )
 
 
 def _validate_exports_spec(

--- a/tests/fixtures/conformance/api/public-api-v2.json
+++ b/tests/fixtures/conformance/api/public-api-v2.json
@@ -90,16 +90,26 @@
             "return_shape": {
               "kind": "decision_variant",
               "type": "NoDirectiveDecision",
-              "required_attributes": ["kind"]
+              "required_attributes": [
+                "kind"
+              ]
             }
           },
           {
-            "args": ["unexpected"],
-            "raises": {"type": "TypeError"}
+            "args": [
+              "unexpected"
+            ],
+            "raises": {
+              "type": "TypeError"
+            }
           },
           {
-            "kwargs": {"value": "unexpected"},
-            "raises": {"type": "TypeError"}
+            "kwargs": {
+              "value": "unexpected"
+            },
+            "raises": {
+              "type": "TypeError"
+            }
           }
         ]
       },
@@ -107,16 +117,32 @@
         "kind": "class",
         "signature": {
           "params": [
-            {"name": "failure", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false},
-            {"name": "directive", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false},
-            {"name": "repairs", "kind": "POSITIONAL_OR_KEYWORD", "has_default": true}
+            {
+              "name": "failure",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "has_default": false
+            },
+            {
+              "name": "directive",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "has_default": false
+            },
+            {
+              "name": "repairs",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "has_default": true
+            }
           ]
         },
         "construction_probes": [
           {
             "kwargs": {
-              "failure": {"fixture": "item_prohibited_failure"},
-              "directive": {"fixture": "use_docker_directive"}
+              "failure": {
+                "fixture": "item_prohibited_failure"
+              },
+              "directive": {
+                "fixture": "use_docker_directive"
+              }
             },
             "return_shape": {
               "kind": "decision_variant",
@@ -132,26 +158,44 @@
           },
           {
             "args": [
-              {"fixture": "item_prohibited_failure"},
-              {"fixture": "use_docker_directive"}
+              {
+                "fixture": "item_prohibited_failure"
+              },
+              {
+                "fixture": "use_docker_directive"
+              }
             ],
             "return_shape": {
               "kind": "decision_variant",
               "type": "SemanticErrorDecision",
-              "required_attributes": ["kind", "failure", "directive", "repairs", "message"]
+              "required_attributes": [
+                "kind",
+                "failure",
+                "directive",
+                "repairs",
+                "message"
+              ]
             }
           },
           {
             "args": [],
-            "raises": {"type": "TypeError"}
+            "raises": {
+              "type": "TypeError"
+            }
           },
           {
             "kwargs": {
-              "failure": {"fixture": "item_prohibited_failure"},
-              "directive": {"fixture": "use_docker_directive"},
+              "failure": {
+                "fixture": "item_prohibited_failure"
+              },
+              "directive": {
+                "fixture": "use_docker_directive"
+              },
               "unexpected": true
             },
-            "raises": {"type": "TypeError"}
+            "raises": {
+              "type": "TypeError"
+            }
           }
         ]
       },
@@ -172,33 +216,53 @@
         "kind": "class",
         "signature": {
           "params": [
-            {"name": "changed", "kind": "POSITIONAL_OR_KEYWORD", "has_default": false}
+            {
+              "name": "changed",
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "has_default": false
+            }
           ]
         },
         "construction_probes": [
           {
-            "kwargs": {"changed": true},
+            "kwargs": {
+              "changed": true
+            },
             "return_shape": {
               "kind": "decision_variant",
               "type": "UpdateDecision",
-              "required_attributes": ["kind", "changed"]
+              "required_attributes": [
+                "kind",
+                "changed"
+              ]
             }
           },
           {
-            "args": [true],
+            "args": [
+              true
+            ],
             "return_shape": {
               "kind": "decision_variant",
               "type": "UpdateDecision",
-              "required_attributes": ["kind", "changed"]
+              "required_attributes": [
+                "kind",
+                "changed"
+              ]
             }
           },
           {
             "args": [],
-            "raises": {"type": "TypeError"}
+            "raises": {
+              "type": "TypeError"
+            }
           },
           {
-            "kwargs": {"value": true},
-            "raises": {"type": "TypeError"}
+            "kwargs": {
+              "value": true
+            },
+            "raises": {
+              "type": "TypeError"
+            }
           }
         ]
       },
@@ -221,15 +285,25 @@
         },
         "construction_probes": [
           {
-            "return_shape": {"kind": "engine_instance"}
+            "return_shape": {
+              "kind": "engine_instance"
+            }
           },
           {
-            "args": ["unexpected"],
-            "raises": {"type": "TypeError"}
+            "args": [
+              "unexpected"
+            ],
+            "raises": {
+              "type": "TypeError"
+            }
           },
           {
-            "kwargs": {"state": {}},
-            "raises": {"type": "TypeError"}
+            "kwargs": {
+              "state": {}
+            },
+            "raises": {
+              "type": "TypeError"
+            }
           }
         ]
       },
@@ -274,25 +348,33 @@
           },
           "probes": [
             {
-              "args": ["use docker"],
+              "args": [
+                "use docker"
+              ],
               "raises": {
                 "type": "AttributeError"
               }
             },
             {
-              "args": [null],
+              "args": [
+                null
+              ],
               "raises": {
                 "type": "AttributeError"
               }
             },
             {
-              "args": [1],
+              "args": [
+                1
+              ],
               "raises": {
                 "type": "AttributeError"
               }
             },
             {
-              "args": [{}],
+              "args": [
+                {}
+              ],
               "raises": {
                 "type": "AttributeError"
               }
@@ -339,493 +421,7 @@
   },
   "namespaces": {
     "context_compiler.grammar": {
-      "exports": {
-        "names": [
-          "DirectiveKind",
-          "DirectiveSyntaxFailure",
-          "DirectiveMetadata",
-          "CanonicalDirective",
-          "InvalidDirectiveSyntax",
-          "get_directive_metadata",
-          "decompose_directive"
-        ],
-        "members": {
-          "DirectiveKind": {
-            "kind": "class",
-            "immutable_definition": true,
-            "member_values": {
-              "SET_PREMISE": "set_premise",
-              "CHANGE_PREMISE": "change_premise",
-              "USE_ITEM": "use_item",
-              "PROHIBIT_ITEM": "prohibit_item",
-              "REMOVE_POLICY": "remove_policy",
-              "REPLACE_USE": "replace_use",
-              "CLEAR_PREMISE": "clear_premise",
-              "RESET_POLICIES": "reset_policies",
-              "CLEAR_STATE": "clear_state"
-            }
-          },
-          "DirectiveSyntaxFailure": {
-            "kind": "class",
-            "immutable_definition": true,
-            "member_values": {
-              "COMPOUND_DIRECTIVE": "compound_directive",
-              "MISSING_REQUIRED_OPERAND": "missing_required_operand",
-              "MALFORMED_DIRECTIVE": "malformed_directive"
-            }
-          },
-          "DirectiveMetadata": {
-            "kind": "class",
-            "public_fields": [
-              "kind",
-              "canonical_start",
-              "operand_names"
-            ],
-            "signature": {
-              "params": [
-                {
-                  "name": "kind",
-                  "kind": "POSITIONAL_OR_KEYWORD",
-                  "has_default": false
-                },
-                {
-                  "name": "canonical_start",
-                  "kind": "POSITIONAL_OR_KEYWORD",
-                  "has_default": false
-                },
-                {
-                  "name": "operand_names",
-                  "kind": "POSITIONAL_OR_KEYWORD",
-                  "has_default": false
-                }
-              ]
-            },
-            "construction_probes": [
-              {
-                "kwargs": {
-                  "kind": "use_item",
-                  "canonical_start": "use",
-                  "operand_names": [
-                    "item"
-                  ]
-                },
-                "return_shape": {
-                  "kind": "directive_metadata",
-                  "directive_kind": "use_item",
-                  "canonical_start": "use",
-                  "operand_names": [
-                    "item"
-                  ]
-                }
-              },
-              {
-                "args": [
-                  "use_item",
-                  "use",
-                  [
-                    "item"
-                  ]
-                ],
-                "return_shape": {
-                  "kind": "directive_metadata",
-                  "directive_kind": "use_item",
-                  "canonical_start": "use",
-                  "operand_names": [
-                    "item"
-                  ]
-                }
-              },
-              {
-                "args": [],
-                "raises": {
-                  "type": "TypeError"
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "use_item",
-                  "canonical_start": "use",
-                  "operand_names": [
-                    "item"
-                  ],
-                  "unexpected": true
-                },
-                "raises": {
-                  "type": "TypeError"
-                }
-              }
-            ]
-          },
-          "CanonicalDirective": {
-            "kind": "class",
-            "public_fields": [
-              "kind",
-              "operands",
-              "text"
-            ],
-            "signature": {
-              "params": [
-                {
-                  "name": "kind",
-                  "kind": "POSITIONAL_OR_KEYWORD",
-                  "has_default": false
-                },
-                {
-                  "name": "operands",
-                  "kind": "POSITIONAL_OR_KEYWORD",
-                  "has_default": false
-                }
-              ]
-            },
-            "construction_probes": [
-              {
-                "kwargs": {
-                  "kind": "use_item",
-                  "operands": {
-                    "item": "docker"
-                  }
-                },
-                "return_shape": {
-                  "kind": "canonical_directive",
-                  "text": "use docker",
-                  "directive_kind": "use_item",
-                  "operands": {
-                    "item": "docker"
-                  }
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "clear_state",
-                  "operands": {}
-                },
-                "return_shape": {
-                  "kind": "canonical_directive",
-                  "text": "clear state",
-                  "directive_kind": "clear_state",
-                  "operands": {}
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "set_premise",
-                  "operands": {
-                    "value": "concise replies"
-                  }
-                },
-                "return_shape": {
-                  "kind": "canonical_directive",
-                  "text": "set premise concise replies",
-                  "directive_kind": "set_premise",
-                  "operands": {
-                    "value": "concise replies"
-                  }
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "replace_use",
-                  "operands": {
-                    "new_item": "podman",
-                    "old_item": "docker"
-                  }
-                },
-                "return_shape": {
-                  "kind": "canonical_directive",
-                  "text": "use podman instead of docker",
-                  "directive_kind": "replace_use",
-                  "operands": {
-                    "new_item": "podman",
-                    "old_item": "docker"
-                  }
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "not_a_directive_kind",
-                  "operands": {
-                    "item": "docker"
-                  }
-                },
-                "raises": {
-                  "type": "ValueError"
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "use_item",
-                  "operands": {}
-                },
-                "raises": {
-                  "type": "ValueError"
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "clear_state",
-                  "operands": {
-                    "item": "docker"
-                  }
-                },
-                "raises": {
-                  "type": "ValueError"
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "set_premise",
-                  "operands": {
-                    "value": 123
-                  }
-                },
-                "raises": {
-                  "type": "ValueError"
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "set_premise",
-                  "operands": {
-                    "value": "to concise replies"
-                  }
-                },
-                "raises": {
-                  "type": "ValueError"
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "replace_use",
-                  "operands": {
-                    "new_item": "podman instead of nerdctl",
-                    "old_item": "docker"
-                  }
-                },
-                "raises": {
-                  "type": "ValueError"
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "use_item",
-                  "operands": {
-                    "item": "instead of"
-                  }
-                },
-                "raises": {
-                  "type": "ValueError"
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "use_item",
-                  "operands": {
-                    "item": "docker prohibit peanuts"
-                  }
-                },
-                "raises": {
-                  "type": "ValueError"
-                }
-              },
-              {
-                "args": [],
-                "raises": {
-                  "type": "TypeError"
-                }
-              },
-              {
-                "kwargs": {
-                  "kind": "use_item",
-                  "operands": {
-                    "item": "docker"
-                  },
-                  "unexpected": true
-                },
-                "raises": {
-                  "type": "TypeError"
-                }
-              }
-            ]
-          },
-          "InvalidDirectiveSyntax": {
-            "kind": "class",
-            "public_fields": [
-              "failure",
-              "directive_kind",
-              "missing_operand"
-            ],
-            "signature": {
-              "params": [
-                {
-                  "name": "failure",
-                  "kind": "POSITIONAL_OR_KEYWORD",
-                  "has_default": true
-                },
-                {
-                  "name": "directive_kind",
-                  "kind": "POSITIONAL_OR_KEYWORD",
-                  "has_default": true
-                },
-                {
-                  "name": "missing_operand",
-                  "kind": "POSITIONAL_OR_KEYWORD",
-                  "has_default": true
-                }
-              ]
-            },
-            "construction_probes": [
-              {
-                "return_shape": {
-                  "kind": "invalid_directive_syntax",
-                  "failure": "malformed_directive",
-                  "directive_kind": null,
-                  "missing_operand": null
-                }
-              },
-              {
-                "args": [
-                  "missing_required_operand",
-                  "use_item",
-                  "item"
-                ],
-                "return_shape": {
-                  "kind": "invalid_directive_syntax",
-                  "failure": "missing_required_operand",
-                  "directive_kind": "use_item",
-                  "missing_operand": "item"
-                }
-              },
-              {
-                "kwargs": {
-                  "unexpected": true
-                },
-                "raises": {
-                  "type": "TypeError"
-                }
-              }
-            ]
-          },
-          "get_directive_metadata": {
-            "kind": "callable",
-            "signature": {
-              "params": []
-            },
-            "shape_probes": [
-              {
-                "return_shape": {
-                  "kind": "directive_metadata_collection",
-                  "items": [
-                    {
-                      "directive_kind": "set_premise",
-                      "canonical_start": "set premise",
-                      "operand_names": [
-                        "value"
-                      ]
-                    },
-                    {
-                      "directive_kind": "change_premise",
-                      "canonical_start": "change premise to",
-                      "operand_names": [
-                        "value"
-                      ]
-                    },
-                    {
-                      "directive_kind": "use_item",
-                      "canonical_start": "use",
-                      "operand_names": [
-                        "item"
-                      ]
-                    },
-                    {
-                      "directive_kind": "prohibit_item",
-                      "canonical_start": "prohibit",
-                      "operand_names": [
-                        "item"
-                      ]
-                    },
-                    {
-                      "directive_kind": "remove_policy",
-                      "canonical_start": "remove policy",
-                      "operand_names": [
-                        "item"
-                      ]
-                    },
-                    {
-                      "directive_kind": "replace_use",
-                      "canonical_start": "use",
-                      "operand_names": [
-                        "new_item",
-                        "old_item"
-                      ]
-                    },
-                    {
-                      "directive_kind": "clear_premise",
-                      "canonical_start": "clear premise",
-                      "operand_names": []
-                    },
-                    {
-                      "directive_kind": "reset_policies",
-                      "canonical_start": "reset policies",
-                      "operand_names": []
-                    },
-                    {
-                      "directive_kind": "clear_state",
-                      "canonical_start": "clear state",
-                      "operand_names": []
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          "decompose_directive": {
-            "kind": "callable",
-            "signature": {
-              "params": [
-                {
-                  "name": "text",
-                  "kind": "POSITIONAL_OR_KEYWORD",
-                  "has_default": false
-                }
-              ]
-            },
-            "shape_probes": [
-              {
-                "kwargs": {
-                  "text": "Use Docker"
-                },
-                "return_shape": {
-                  "kind": "canonical_directive",
-                  "text": "use Docker",
-                  "directive_kind": "use_item",
-                  "operands": {
-                    "item": "Docker"
-                  }
-                }
-              },
-              {
-                "kwargs": {
-                  "text": "please use docker"
-                },
-                "return_shape": {
-                  "type": "null"
-                }
-              },
-              {
-                "kwargs": {
-                  "text": "use docker and prohibit peanuts"
-                },
-                "return_shape": {
-                  "kind": "invalid_directive_syntax",
-                  "failure": "compound_directive",
-                  "directive_kind": null,
-                  "missing_operand": null
-                }
-              }
-            ]
-          }
-        }
-      }
+      "contract": "public-grammar-v1"
     }
   }
 }

--- a/tests/fixtures/conformance/api/public-api-v2.json
+++ b/tests/fixtures/conformance/api/public-api-v2.json
@@ -336,5 +336,496 @@
         }
       }
     }
+  },
+  "namespaces": {
+    "context_compiler.grammar": {
+      "exports": {
+        "names": [
+          "DirectiveKind",
+          "DirectiveSyntaxFailure",
+          "DirectiveMetadata",
+          "CanonicalDirective",
+          "InvalidDirectiveSyntax",
+          "get_directive_metadata",
+          "decompose_directive"
+        ],
+        "members": {
+          "DirectiveKind": {
+            "kind": "class",
+            "immutable_definition": true,
+            "member_values": {
+              "SET_PREMISE": "set_premise",
+              "CHANGE_PREMISE": "change_premise",
+              "USE_ITEM": "use_item",
+              "PROHIBIT_ITEM": "prohibit_item",
+              "REMOVE_POLICY": "remove_policy",
+              "REPLACE_USE": "replace_use",
+              "CLEAR_PREMISE": "clear_premise",
+              "RESET_POLICIES": "reset_policies",
+              "CLEAR_STATE": "clear_state"
+            }
+          },
+          "DirectiveSyntaxFailure": {
+            "kind": "class",
+            "immutable_definition": true,
+            "member_values": {
+              "COMPOUND_DIRECTIVE": "compound_directive",
+              "MISSING_REQUIRED_OPERAND": "missing_required_operand",
+              "MALFORMED_DIRECTIVE": "malformed_directive"
+            }
+          },
+          "DirectiveMetadata": {
+            "kind": "class",
+            "public_fields": [
+              "kind",
+              "canonical_start",
+              "operand_names"
+            ],
+            "signature": {
+              "params": [
+                {
+                  "name": "kind",
+                  "kind": "POSITIONAL_OR_KEYWORD",
+                  "has_default": false
+                },
+                {
+                  "name": "canonical_start",
+                  "kind": "POSITIONAL_OR_KEYWORD",
+                  "has_default": false
+                },
+                {
+                  "name": "operand_names",
+                  "kind": "POSITIONAL_OR_KEYWORD",
+                  "has_default": false
+                }
+              ]
+            },
+            "construction_probes": [
+              {
+                "kwargs": {
+                  "kind": "use_item",
+                  "canonical_start": "use",
+                  "operand_names": [
+                    "item"
+                  ]
+                },
+                "return_shape": {
+                  "kind": "directive_metadata",
+                  "directive_kind": "use_item",
+                  "canonical_start": "use",
+                  "operand_names": [
+                    "item"
+                  ]
+                }
+              },
+              {
+                "args": [
+                  "use_item",
+                  "use",
+                  [
+                    "item"
+                  ]
+                ],
+                "return_shape": {
+                  "kind": "directive_metadata",
+                  "directive_kind": "use_item",
+                  "canonical_start": "use",
+                  "operand_names": [
+                    "item"
+                  ]
+                }
+              },
+              {
+                "args": [],
+                "raises": {
+                  "type": "TypeError"
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "use_item",
+                  "canonical_start": "use",
+                  "operand_names": [
+                    "item"
+                  ],
+                  "unexpected": true
+                },
+                "raises": {
+                  "type": "TypeError"
+                }
+              }
+            ]
+          },
+          "CanonicalDirective": {
+            "kind": "class",
+            "public_fields": [
+              "kind",
+              "operands",
+              "text"
+            ],
+            "signature": {
+              "params": [
+                {
+                  "name": "kind",
+                  "kind": "POSITIONAL_OR_KEYWORD",
+                  "has_default": false
+                },
+                {
+                  "name": "operands",
+                  "kind": "POSITIONAL_OR_KEYWORD",
+                  "has_default": false
+                }
+              ]
+            },
+            "construction_probes": [
+              {
+                "kwargs": {
+                  "kind": "use_item",
+                  "operands": {
+                    "item": "docker"
+                  }
+                },
+                "return_shape": {
+                  "kind": "canonical_directive",
+                  "text": "use docker",
+                  "directive_kind": "use_item",
+                  "operands": {
+                    "item": "docker"
+                  }
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "clear_state",
+                  "operands": {}
+                },
+                "return_shape": {
+                  "kind": "canonical_directive",
+                  "text": "clear state",
+                  "directive_kind": "clear_state",
+                  "operands": {}
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "set_premise",
+                  "operands": {
+                    "value": "concise replies"
+                  }
+                },
+                "return_shape": {
+                  "kind": "canonical_directive",
+                  "text": "set premise concise replies",
+                  "directive_kind": "set_premise",
+                  "operands": {
+                    "value": "concise replies"
+                  }
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "replace_use",
+                  "operands": {
+                    "new_item": "podman",
+                    "old_item": "docker"
+                  }
+                },
+                "return_shape": {
+                  "kind": "canonical_directive",
+                  "text": "use podman instead of docker",
+                  "directive_kind": "replace_use",
+                  "operands": {
+                    "new_item": "podman",
+                    "old_item": "docker"
+                  }
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "not_a_directive_kind",
+                  "operands": {
+                    "item": "docker"
+                  }
+                },
+                "raises": {
+                  "type": "ValueError"
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "use_item",
+                  "operands": {}
+                },
+                "raises": {
+                  "type": "ValueError"
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "clear_state",
+                  "operands": {
+                    "item": "docker"
+                  }
+                },
+                "raises": {
+                  "type": "ValueError"
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "set_premise",
+                  "operands": {
+                    "value": 123
+                  }
+                },
+                "raises": {
+                  "type": "ValueError"
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "set_premise",
+                  "operands": {
+                    "value": "to concise replies"
+                  }
+                },
+                "raises": {
+                  "type": "ValueError"
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "replace_use",
+                  "operands": {
+                    "new_item": "podman instead of nerdctl",
+                    "old_item": "docker"
+                  }
+                },
+                "raises": {
+                  "type": "ValueError"
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "use_item",
+                  "operands": {
+                    "item": "instead of"
+                  }
+                },
+                "raises": {
+                  "type": "ValueError"
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "use_item",
+                  "operands": {
+                    "item": "docker prohibit peanuts"
+                  }
+                },
+                "raises": {
+                  "type": "ValueError"
+                }
+              },
+              {
+                "args": [],
+                "raises": {
+                  "type": "TypeError"
+                }
+              },
+              {
+                "kwargs": {
+                  "kind": "use_item",
+                  "operands": {
+                    "item": "docker"
+                  },
+                  "unexpected": true
+                },
+                "raises": {
+                  "type": "TypeError"
+                }
+              }
+            ]
+          },
+          "InvalidDirectiveSyntax": {
+            "kind": "class",
+            "public_fields": [
+              "failure",
+              "directive_kind",
+              "missing_operand"
+            ],
+            "signature": {
+              "params": [
+                {
+                  "name": "failure",
+                  "kind": "POSITIONAL_OR_KEYWORD",
+                  "has_default": true
+                },
+                {
+                  "name": "directive_kind",
+                  "kind": "POSITIONAL_OR_KEYWORD",
+                  "has_default": true
+                },
+                {
+                  "name": "missing_operand",
+                  "kind": "POSITIONAL_OR_KEYWORD",
+                  "has_default": true
+                }
+              ]
+            },
+            "construction_probes": [
+              {
+                "return_shape": {
+                  "kind": "invalid_directive_syntax",
+                  "failure": "malformed_directive",
+                  "directive_kind": null,
+                  "missing_operand": null
+                }
+              },
+              {
+                "args": [
+                  "missing_required_operand",
+                  "use_item",
+                  "item"
+                ],
+                "return_shape": {
+                  "kind": "invalid_directive_syntax",
+                  "failure": "missing_required_operand",
+                  "directive_kind": "use_item",
+                  "missing_operand": "item"
+                }
+              },
+              {
+                "kwargs": {
+                  "unexpected": true
+                },
+                "raises": {
+                  "type": "TypeError"
+                }
+              }
+            ]
+          },
+          "get_directive_metadata": {
+            "kind": "callable",
+            "signature": {
+              "params": []
+            },
+            "shape_probes": [
+              {
+                "return_shape": {
+                  "kind": "directive_metadata_collection",
+                  "items": [
+                    {
+                      "directive_kind": "set_premise",
+                      "canonical_start": "set premise",
+                      "operand_names": [
+                        "value"
+                      ]
+                    },
+                    {
+                      "directive_kind": "change_premise",
+                      "canonical_start": "change premise to",
+                      "operand_names": [
+                        "value"
+                      ]
+                    },
+                    {
+                      "directive_kind": "use_item",
+                      "canonical_start": "use",
+                      "operand_names": [
+                        "item"
+                      ]
+                    },
+                    {
+                      "directive_kind": "prohibit_item",
+                      "canonical_start": "prohibit",
+                      "operand_names": [
+                        "item"
+                      ]
+                    },
+                    {
+                      "directive_kind": "remove_policy",
+                      "canonical_start": "remove policy",
+                      "operand_names": [
+                        "item"
+                      ]
+                    },
+                    {
+                      "directive_kind": "replace_use",
+                      "canonical_start": "use",
+                      "operand_names": [
+                        "new_item",
+                        "old_item"
+                      ]
+                    },
+                    {
+                      "directive_kind": "clear_premise",
+                      "canonical_start": "clear premise",
+                      "operand_names": []
+                    },
+                    {
+                      "directive_kind": "reset_policies",
+                      "canonical_start": "reset policies",
+                      "operand_names": []
+                    },
+                    {
+                      "directive_kind": "clear_state",
+                      "canonical_start": "clear state",
+                      "operand_names": []
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "decompose_directive": {
+            "kind": "callable",
+            "signature": {
+              "params": [
+                {
+                  "name": "text",
+                  "kind": "POSITIONAL_OR_KEYWORD",
+                  "has_default": false
+                }
+              ]
+            },
+            "shape_probes": [
+              {
+                "kwargs": {
+                  "text": "Use Docker"
+                },
+                "return_shape": {
+                  "kind": "canonical_directive",
+                  "text": "use Docker",
+                  "directive_kind": "use_item",
+                  "operands": {
+                    "item": "Docker"
+                  }
+                }
+              },
+              {
+                "kwargs": {
+                  "text": "please use docker"
+                },
+                "return_shape": {
+                  "type": "null"
+                }
+              },
+              {
+                "kwargs": {
+                  "text": "use docker and prohibit peanuts"
+                },
+                "return_shape": {
+                  "kind": "invalid_directive_syntax",
+                  "failure": "compound_directive",
+                  "directive_kind": null,
+                  "missing_operand": null
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
   }
 }

--- a/tests/fixtures/conformance/mutation-isolation/README.md
+++ b/tests/fixtures/conformance/mutation-isolation/README.md
@@ -96,8 +96,7 @@ unsynchronized TypeScript port.
 
 They intentionally do **not** include:
 
-* checkpoint APIs
-* removed continuation-state APIs
+* checkpoint and continuation-state APIs retired from the 0.9 public contract
 * obsolete TypeScript-only authority surfaces
 * implementation-mechanism requirements such as `deepcopy`, frozen objects, or
   `readonly`

--- a/tests/test_api_contract_fixture.py
+++ b/tests/test_api_contract_fixture.py
@@ -33,10 +33,19 @@ def _load_contract() -> dict[str, object]:
     )
 
 
+def _load_namespace_contracts() -> dict[str, dict[str, object]]:
+    grammar_contract = load_api_contract(
+        _CONTRACT_PATH.with_name("public-grammar-v1.json"),
+        expected_module="context_compiler.grammar",
+        allowed_export_kinds={"callable", "class"},
+    )
+    return {grammar_contract["id"]: grammar_contract}
+
+
 def test_api_contract_fixture_matches_python_public_surface() -> None:
     contract = _load_contract()
 
-    validate_declared_namespaces(contract)
+    validate_declared_namespaces(contract, _load_namespace_contracts())
 
     assert contract["kind"] == "api-contract"
     exports = contract["exports"]
@@ -145,10 +154,8 @@ def test_api_contract_fixture_has_unique_entries() -> None:
     assert len(namespaces) == len(set(namespaces))
     for namespace_name, namespace_contract in namespaces.items():
         assert namespace_name
-        namespace_exports = namespace_contract["exports"]
-        namespace_names = namespace_exports["names"]
-        assert len(namespace_names) == len(set(namespace_names))
-        assert set(namespace_exports["members"]) == set(namespace_names)
+        assert set(namespace_contract) == {"contract"}
+        assert namespace_contract["contract"] in _load_namespace_contracts()
 
     engine_members = list(contract["engine"]["public_members"]["members"].keys())
     assert len(engine_members) == len(set(engine_members))

--- a/tests/test_api_contract_fixture.py
+++ b/tests/test_api_contract_fixture.py
@@ -8,6 +8,7 @@ from _api_contract_harness import (
     load_api_contract,
     resolve_probe_value,
     validate_constructor_contract,
+    validate_declared_namespaces,
     validate_engine_member_probes,
     validate_engine_member_runtime,
     validate_export_kind,
@@ -34,6 +35,8 @@ def _load_contract() -> dict[str, object]:
 
 def test_api_contract_fixture_matches_python_public_surface() -> None:
     contract = _load_contract()
+
+    validate_declared_namespaces(contract)
 
     assert contract["kind"] == "api-contract"
     exports = contract["exports"]
@@ -137,6 +140,15 @@ def test_api_contract_fixture_has_unique_entries() -> None:
                 assert "construction_probes" in export_contract, export_name
         else:
             assert "signature" not in export_contract, export_name
+
+    namespaces = contract.get("namespaces", {})
+    assert len(namespaces) == len(set(namespaces))
+    for namespace_name, namespace_contract in namespaces.items():
+        assert namespace_name
+        namespace_exports = namespace_contract["exports"]
+        namespace_names = namespace_exports["names"]
+        assert len(namespace_names) == len(set(namespace_names))
+        assert set(namespace_exports["members"]) == set(namespace_names)
 
     engine_members = list(contract["engine"]["public_members"]["members"].keys())
     assert len(engine_members) == len(set(engine_members))

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "context-compiler"
-version = "0.9.0.dev14"
+version = "0.9.0.dev15"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- Declared and validated the public `context_compiler.grammar` namespace through the API contract harness.
- Kept `public-grammar-v1` as the grammar API source of truth.
- Clarified retired checkpoint API wording in the Python fixture documentation.
- Bumped the package version to `0.9.0dev15` and refreshed `uv.lock`.

## Why

- Make the grammar namespace an intentional consumer-facing API while preserving the package-root boundary.
- Align the Python fixture documentation and package metadata with the current 0.9 contract.

## Checklist

- [x] pre-commit run (`uv run pre-commit run --all-files`)
- [x] tests pass (`uv run pytest`)
